### PR TITLE
fix: Repair NWPS river gauge integration + update tool-config test counts

### DIFF
--- a/src/handlers/riverConditionsHandler.ts
+++ b/src/handlers/riverConditionsHandler.ts
@@ -108,10 +108,12 @@ export async function handleGetRiverConditions(
 function formatGaugeDetails(gauge: NWPSGauge, distance: number, timezone: string): string {
   let output = `## ${gauge.name}\n\n`;
   output += `**Distance:** ${distance.toFixed(1)} km (${(distance * 0.621371).toFixed(1)} mi)\n`;
-  output += `**Location:** ${gauge.state}${gauge.county ? `, ${gauge.county} County` : ''}\n`;
+  output += `**Location:** ${gauge.state?.abbreviation ?? 'Unknown'}${gauge.county ? `, ${gauge.county} County` : ''}\n`;
   output += `**Coordinates:** ${gauge.latitude.toFixed(4)}, ${gauge.longitude.toFixed(4)}\n`;
   output += `**Gauge ID:** ${gauge.lid}${gauge.usgsId ? ` (USGS: ${gauge.usgsId})` : ''}\n`;
-  output += `**Status:** ${gauge.inService ? '✅ Active' : '❌ Out of Service'}\n\n`;
+  // inService is only present on the per-gauge detail endpoint; gauges returned
+  // by the bounding-box query are active by definition, so default to Active.
+  output += `**Status:** ${gauge.inService === false ? '❌ Out of Service' : '✅ Active'}\n\n`;
 
   // Current conditions
   if (gauge.status.observed) {
@@ -129,7 +131,7 @@ function formatGaugeDetails(gauge: NWPSGauge, distance: number, timezone: string
 
     // Flood category with emoji
     const floodEmoji = getFloodEmoji(obs.floodCategory);
-    const floodText = obs.floodCategory ? obs.floodCategory.toUpperCase() : 'NO FLOODING';
+    const floodText = obs.floodCategory ? obs.floodCategory.replace(/_/g, ' ').toUpperCase() : 'NO FLOODING';
     output += `**Flood Category:** ${floodEmoji} ${floodText}\n\n`;
   } else {
     output += `### Current Conditions\n`;
@@ -168,7 +170,7 @@ function formatGaugeDetails(gauge: NWPSGauge, distance: number, timezone: string
     }
 
     const forecastFloodEmoji = getFloodEmoji(forecast.floodCategory);
-    const forecastFloodText = forecast.floodCategory ? forecast.floodCategory.toUpperCase() : 'NO FLOODING';
+    const forecastFloodText = forecast.floodCategory ? forecast.floodCategory.replace(/_/g, ' ').toUpperCase() : 'NO FLOODING';
     output += `**Forecasted Category:** ${forecastFloodEmoji} ${forecastFloodText}\n\n`;
   }
 
@@ -198,10 +200,12 @@ function formatGaugeDetails(gauge: NWPSGauge, distance: number, timezone: string
  * Get emoji for flood category
  */
 function getFloodEmoji(category: string | null | undefined): string {
-  if (!category || category === 'no flooding') return '✅';
-  if (category === 'action') return '🟡';
-  if (category === 'minor') return '🟠';
-  if (category === 'moderate') return '🔴';
-  if (category === 'major') return '🔴🔴';
+  // NWPS uses underscore-delimited categories (e.g. "no_flooding", "not_defined")
+  const normalized = category?.replace(/_/g, ' ');
+  if (!normalized || normalized === 'no flooding' || normalized === 'not defined') return '✅';
+  if (normalized === 'action') return '🟡';
+  if (normalized === 'minor') return '🟠';
+  if (normalized === 'moderate') return '🔴';
+  if (normalized === 'major') return '🔴🔴';
   return '⚪';
 }

--- a/src/services/noaa.ts
+++ b/src/services/noaa.ts
@@ -12,6 +12,7 @@ import type {
   AlertCollectionResponse,
   NOAAErrorResponse,
   NWPSGauge,
+  NWPSGaugesResponse,
   NWPSStageFlowResponse,
   USGSIVResponse
 } from '../types/noaa.js';
@@ -699,16 +700,16 @@ export class NOAAService {
         return cached as NWPSGauge[];
       }
 
-      const response = await this.nwpsClient.get<NWPSGauge[]>('/gauges');
-      const result = response.data;
+      const response = await this.nwpsClient.get<NWPSGaugesResponse>('/gauges');
+      const result = response.data.gauges ?? [];
 
       // Cache for 24 hours (gauge locations don't change often)
       this.cache.set(cacheKey, result, 86400000);
       return result;
     }
 
-    const response = await this.nwpsClient.get<NWPSGauge[]>('/gauges');
-    return response.data;
+    const response = await this.nwpsClient.get<NWPSGaugesResponse>('/gauges');
+    return response.data.gauges ?? [];
   }
 
   /**
@@ -749,17 +750,20 @@ export class NOAAService {
       }
     }
 
-    // NWPS API supports bounding box queries via query parameters
+    // NWPS API supports bounding box queries via query parameters.
+    // The endpoint requires bbox.{xmin,ymin,xmax,ymax} plus an srid; without
+    // them it ignores the filter and returns the entire ~13MB gauge catalog.
     const params = {
-      west: west.toString(),
-      south: south.toString(),
-      east: east.toString(),
-      north: north.toString()
+      'bbox.xmin': west.toString(),
+      'bbox.ymin': south.toString(),
+      'bbox.xmax': east.toString(),
+      'bbox.ymax': north.toString(),
+      srid: 'EPSG_4326'
     };
 
     try {
-      const response = await this.nwpsClient.get<NWPSGauge[]>('/gauges', { params });
-      const result = response.data;
+      const response = await this.nwpsClient.get<NWPSGaugesResponse>('/gauges', { params });
+      const result = response.data.gauges ?? [];
 
       // Cache for 24 hours
       if (CacheConfig.enabled) {

--- a/src/types/noaa.ts
+++ b/src/types/noaa.ts
@@ -420,38 +420,65 @@ export interface HistoricCrest {
 export interface GaugeStatus {
   primary: number | null; // Stage in feet
   secondary: number | null; // Flow in kcfs (thousand cubic feet per second)
-  floodCategory: 'major' | 'moderate' | 'minor' | 'action' | 'no flooding' | null;
+  // NWPS returns underscore-delimited categories (e.g. "no_flooding", "not_defined")
+  floodCategory:
+    | 'major'
+    | 'moderate'
+    | 'minor'
+    | 'action'
+    | 'no_flooding'
+    | 'not_defined'
+    | null;
   validTime: string; // ISO 8601 datetime
+  primaryUnit?: string; // e.g. "ft"
+  secondaryUnit?: string; // e.g. "kcfs"
 }
 
 /**
  * River gauge metadata and current status from NWPS API
  */
+/**
+ * Office reference returned by the NWPS API (state, WFO, RFC).
+ */
+export interface NWPSOfficeRef {
+  abbreviation: string;
+  name: string;
+}
+
 export interface NWPSGauge {
   lid: string; // NWSLI (5-character identifier)
-  usgsId?: string; // USGS site number (optional)
+  usgsId?: string; // USGS site number (only on the per-gauge detail endpoint)
   name: string; // Gauge name (e.g., "Mississippi River at St. Louis")
   latitude: number;
   longitude: number;
-  state: string;
+  state: NWPSOfficeRef;
   county?: string;
-  timeZone: string; // IANA timezone (e.g., "America/Chicago")
-  wfo: string; // Weather Forecast Office
-  rfc: string; // River Forecast Center
+  timeZone?: string; // IANA timezone (e.g., "America/Chicago")
+  wfo?: NWPSOfficeRef; // Weather Forecast Office
+  rfc?: NWPSOfficeRef; // River Forecast Center
   status: {
     observed?: GaugeStatus;
     forecast?: GaugeStatus;
   };
-  flood: {
+  // Detailed flood/crest data is only present on the per-gauge detail endpoint,
+  // not on the bounding-box list response.
+  flood?: {
     categories: FloodCategories;
     crests?: {
       historic?: HistoricCrest[];
       recent?: HistoricCrest[];
     };
   };
-  inService: boolean;
+  inService?: boolean;
   upstreamLid?: string;
   downstreamLid?: string;
+}
+
+/**
+ * Response wrapper for the NWPS /gauges endpoint.
+ */
+export interface NWPSGaugesResponse {
+  gauges: NWPSGauge[];
 }
 
 /**

--- a/tests/unit/tool-config.test.ts
+++ b/tests/unit/tool-config.test.ts
@@ -79,7 +79,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('basic');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(5);
+      expect(enabled).toHaveLength(9); // Updated for v1.7.0: added 4 saved-location tools
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
@@ -91,7 +91,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('standard');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(6);
+      expect(enabled).toHaveLength(10); // Updated for v1.7.0: added 4 saved-location tools
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
@@ -104,7 +104,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('full');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(7);
+      expect(enabled).toHaveLength(11); // Updated for v1.7.0: added 4 saved-location tools
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
@@ -118,7 +118,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('all');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(12); // Updated for v1.6.0: added get_river_conditions and get_wildfire_info
+      expect(enabled).toHaveLength(16); // Updated for v1.7.0: added 4 saved-location tools
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
@@ -207,7 +207,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('all,-get_marine_conditions');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(11); // Updated for v1.6.0: 12 total tools - 1 removed = 11
+      expect(enabled).toHaveLength(15); // Updated for v1.7.0: 16 total tools - 1 removed = 15
       expect(enabled).not.toContain('get_marine_conditions');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_air_quality');


### PR DESCRIPTION
## Summary

Brings the test suite back to 100% green (was **10 failing**) and fixes a real production bug in `get_river_conditions`.

### 1. NWPS river gauge integration broken by upstream API changes
The NWPS `/gauges` endpoint changed its bounding-box contract and response shape:
- Old `west/south/east/north` query params are now **ignored**, so every call downloaded the **entire ~13MB / 12,745-gauge catalog** (~30s) → request timeouts + retries → 60s+ test timeouts.
- Response is now `{ "gauges": [...] }`, not a bare array.
- `state`/`wfo`/`rfc` are now `{ abbreviation, name }` objects; `flood`/`inService`/`county`/`timeZone`/`usgsId` only appear on the per-gauge detail endpoint.
- Flood categories use underscores (`no_flooding`, `not_defined`).

**Fix:** query with `bbox.{xmin,ymin,xmax,ymax}` + `srid=EPSG_4326`, unwrap `.gauges`, update the `NWPSGauge` type, and render the new schema correctly.

### 2. Stale tool-config preset counts
v1.7.0 added 4 saved-location tools to every preset but the size assertions still expected v1.6.0 counts (basic 5→9, standard 6→10, full 7→11, all 12→16, removal 11→15).

## Results
- **1092/1092 tests pass** (was 1082/1092)
- River gauge queries now return in **<1s** instead of timing out; full suite runtime dropped from **311s → 9s**
- `npm run build` clean

## Test plan
- [x] `npm run build`
- [x] `npm test` (full suite, 1092 passing)
- [x] Verified live NWPS bbox query returns correct gauges for St. Louis/Houston/NYC