### PR TITLE
feat: Implement NCEI climate normals retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **NCEI Climate Normals** - Implemented official NOAA 1991–2020 climate normals retrieval for US locations (previously a placeholder that always fell back to Open-Meteo)
+  - Finds the nearest NCEI station with daily normals via a bounding-box `/stations` query (sorted by distance, expands once if empty)
+  - Reads daily high/low temperature normals (`DLY-TMAX-NORMAL`/`DLY-TMIN-NORMAL`, °F) and monthly precipitation (`MLY-PRCP-NORMAL`) averaged to a daily value
+  - Handles Feb 29 (reference year is non-leap), missing-value sentinels, rate limits, and auth errors; caches results indefinitely
+  - Requires a free `NCEI_API_TOKEN`; gracefully falls back to Open-Meteo when unavailable or outside US coverage
+  - Used by `get_forecast` and `get_current_conditions` for US climate context
+
 ## [1.7.1] - 2026-06-21
 
 ### Fixed

--- a/docs/development/INCOMPLETE_FEATURES_AUDIT.md
+++ b/docs/development/INCOMPLETE_FEATURES_AUDIT.md
@@ -1,0 +1,183 @@
+# Incomplete Features Audit
+
+**Date:** 2026-06-21
+**Scope:** `src/` (excludes `dist/`, `node_modules/`, `tests/`)
+**Purpose:** Catalog functions/features that are stubbed, partially implemented, or
+deliberately simplified, so we can decide per item whether to **implement** or **trim**.
+
+This document is a decision aid — for each item there's a description of intended
+behavior, current behavior, blast radius (callers/tests), and a recommendation.
+
+---
+
+## Summary
+
+| # | Feature | Location | Status | Recommendation |
+|---|---------|----------|--------|----------------|
+| 1 | NCEI climate normals | `src/services/ncei.ts` | ✅ **Implemented (this session)** | Done — keep |
+| 2 | Satellite imagery | `src/handlers/weatherImageryHandler.ts:84` | ❌ Stub (throws) | **Decide:** implement (GOES) or trim |
+| 3 | Imagery `layers` parameter | `src/index.ts:440`, `weatherImageryHandler.ts:35` | ⚠️ Accepted but ignored | **Decide:** implement or trim |
+| 4 | Coordinate→timezone heuristic | `src/utils/timezone.ts:121` | ⚠️ Simplified (US-only accurate) | Likely keep; optionally improve |
+| 5 | `getAllNWPSGauges` (full catalog) | `src/services/noaa.ts:693` | ⚠️ Deprecated, still used as fallback | Likely keep as fallback; document |
+
+---
+
+## 1. NCEI Climate Normals — ✅ Implemented this session
+
+**File:** `src/services/ncei.ts` — `getClimateNormals()`
+
+**Intended:** Return official NOAA 1991–2020 climate normals (daily high/low temp,
+precipitation) for US locations via the Climate Data Online (CDO) API.
+
+**Previous state:** Placeholder that threw `DataNotFoundError` before any HTTP call,
+always falling back to Open-Meteo computed normals. The token was never used.
+
+**Current state:** Fully implemented:
+- Finds nearby stations carrying daily normals (`NORMAL_DLY`) via a bounding-box
+  `/stations` query, sorted by Haversine distance (expands the box once if empty).
+- Reads `DLY-TMAX-NORMAL` / `DLY-TMIN-NORMAL` (°F via `units=standard`) for the
+  requested month/day, probing up to 4 nearest stations for complete data.
+- Reads the monthly `MLY-PRCP-NORMAL` and divides by days-in-month for a daily value.
+- Handles Feb-29 (reference year 2010 is non-leap → clamps to Feb 28), missing-value
+  sentinels (e.g. `-7777`), rate limits (429 → `RateLimitError`), and auth errors.
+- Caches results indefinitely (normals don't change).
+
+**Validated live:** Seattle, Denver, Miami, Chicago (Feb 29) all return correct
+NCEI-sourced normals; mid-ocean correctly throws `DataNotFoundError` → Open-Meteo
+fallback. Unit tests rewritten with mocked HTTP (no live calls).
+
+**Recommendation:** Done. No further action.
+
+---
+
+## 2. Satellite Imagery — ❌ Stub
+
+**File:** `src/handlers/weatherImageryHandler.ts:84-92`
+**Tool:** `get_weather_imagery` with `type="satellite"`
+
+**Intended:** Provide satellite imagery (cloud/thermal/visible) for a location,
+alongside the working `precipitation`/`radar` types.
+
+**Current behavior:** Throws `ValidationError`:
+> `Satellite imagery is not yet implemented. Use type="precipitation" or type="radar" for precipitation radar.`
+
+The tool schema in `src/index.ts` still advertises `satellite` as a valid `type` enum
+value, so a user can request it and only then hit the error.
+
+**Callers / tests:**
+- Reachable from `src/index.ts` `get_weather_imagery` dispatch.
+- `tests/integration/visualization-lightning.test.ts:102` explicitly asserts it
+  rejects with `'not yet implemented'` — so trimming or implementing requires updating
+  that test.
+
+**Options:**
+- **Implement:** integrate NOAA GOES-16/19 imagery (e.g., via NOAA STAR / NESDIS tiles
+  or RealEarth). Non-trivial: tiling, layer selection, time steps.
+- **Trim:** remove `satellite` from the `type` enum + the handler branch, and update the
+  integration test. Smallest footprint; honest about supported capabilities.
+
+**Recommendation:** **Trim unless satellite imagery is on the near-term roadmap.**
+Advertising an enum value that always errors is a poor UX. Trimming is ~15 minutes;
+implementing is a multi-day feature. (Tie this decision to item 3.)
+
+---
+
+## 3. Imagery `layers` Parameter — ⚠️ Accepted but ignored
+
+**Files:** `src/index.ts:438-444` (schema), `src/handlers/weatherImageryHandler.ts:35-43` (validation)
+**Tool:** `get_weather_imagery`, `layers` argument
+
+**Intended:** Let callers request optional overlay layers in the returned imagery.
+Schema description literally says *"(future enhancement)"*.
+
+**Current behavior:** The parameter is type-checked (must be an array, ≤10 items) but is
+**never read after validation** — it is not passed to `rainViewerService` or used
+anywhere. It has no effect on output.
+
+**Callers / tests:** No test depends on `layers` having an effect (only validation).
+
+**Options:**
+- **Implement:** define a concrete set of supported overlays and thread them through to
+  the imagery service. Only meaningful if the underlying provider supports overlays.
+- **Trim:** remove the `layers` property from the schema and the handler validation.
+  Removes a misleading no-op parameter.
+
+**Recommendation:** **Trim.** RainViewer (the current provider) doesn't expose arbitrary
+overlay layers, so the parameter promises something we can't deliver today. Remove it;
+re-add with a real implementation if/when a provider supports it.
+
+---
+
+## 4. Coordinate→Timezone Heuristic — ⚠️ Simplified by design
+
+**File:** `src/utils/timezone.ts:121` — `guessTimezoneFromCoords()`
+
+**Intended:** Best-guess IANA timezone from coordinates, used as a fallback when an API
+doesn't return a timezone (e.g., river conditions formatting).
+
+**Current behavior:** Longitude-banded mapping for the contiguous US
+(`America/New_York|Chicago|Denver|Los_Angeles`); everything else returns `UTC`. The code
+itself flags this as "simplified" and suggests `tz-lookup` / `@photostructure/tz-lookup`
+for accurate global coverage.
+
+**Known limitations:**
+- No Alaska/Hawaii, US territories, or Arizona (no-DST) handling.
+- All non-contiguous-US locations get `UTC` (predictable but not local).
+
+**Callers:** River conditions handler and other time-formatting paths.
+
+**Options:**
+- **Implement:** add a `tz-lookup` dependency for accurate global coordinate→timezone.
+  Small, well-bounded improvement (one dep, swap the function body).
+- **Keep:** the current behavior is intentional and "predictable" (UTC) — acceptable for
+  a primarily-US tool.
+
+**Recommendation:** **Keep for now; consider `tz-lookup` if non-US time accuracy matters.**
+This is a deliberate simplification, not a broken stub. Low priority.
+
+---
+
+## 5. `getAllNWPSGauges()` — ⚠️ Deprecated, still used as fallback
+
+**File:** `src/services/noaa.ts:693` (marked `@deprecated`)
+
+**Intended:** (Legacy) fetch all NWPS river gauges. Superseded by
+`getNWPSGaugesInBoundingBox()`.
+
+**Current behavior:** Still invoked as the **fallback** inside
+`getNWPSGaugesInBoundingBox()` if the bounding-box query throws. It downloads the entire
+~13 MB / ~12,700-gauge catalog — the exact heavy path the v1.7.1 fix was designed to
+avoid. With the corrected bbox query now working, the fallback should rarely (if ever)
+trigger, but it remains a latent expensive code path.
+
+**Callers:** `getNWPSGaugesInBoundingBox()` catch block only.
+
+**Options:**
+- **Keep:** retain as a genuine last-resort fallback (defensive). Document that it's a
+  heavy path.
+- **Trim:** remove the deprecated method and the fallback; let bbox failures surface as
+  errors (the handler already degrades gracefully with a user-facing message).
+
+**Recommendation:** **Keep as fallback, but verify it still works** (the response-shape
+fix in v1.7.1 updated both methods). Optionally add a `securityEvent`/warning log when
+the fallback fires so we'd notice if the bbox query regresses. Low priority.
+
+---
+
+## Non-issues (reviewed, no action)
+
+These matched incompleteness keywords but are **not** stubs:
+- `riverConditionsHandler.ts:85`, `wildfireHandler.ts:164` — "Temporary service
+  unavailability" is user-facing error copy.
+- `wildfireHandler.ts:57` — user note about NIFC data coverage.
+- `weatherImageryHandler.ts:64-65` — scope comments tied to item 2.
+
+---
+
+## Suggested decision order
+
+1. **Items 2 + 3 together** (weather imagery): decide implement-vs-trim. Recommendation
+   is to **trim both** unless satellite/overlays are roadmapped — this also tidies the
+   `get_weather_imagery` schema. Requires updating one integration test.
+2. **Item 5:** low-risk; add a fallback warning log, keep otherwise.
+3. **Item 4:** optional polish; add `tz-lookup` only if global time accuracy is a goal.

--- a/src/services/ncei.ts
+++ b/src/services/ncei.ts
@@ -1,31 +1,64 @@
 /**
  * Service for interacting with NOAA NCEI (National Centers for Environmental Information)
- * Climate Data Online (CDO) API
+ * Climate Data Online (CDO) API.
  *
  * Documentation: https://www.ncei.noaa.gov/support/access-data-service-api-user-documentation
  *
- * NOTE: This is a simplified implementation. The NCEI API is station-based (not coordinate-based),
- * which adds complexity:
- * 1. Must find nearby weather stations from coordinates
- * 2. Stations may not have all climate normals data
- * 3. Need to handle multiple stations and aggregate data
+ * Provides official NOAA 1991–2020 climate normals for US locations. The CDO API is
+ * station-based (not coordinate-based), so retrieval works in three steps:
+ *   1. Find nearby stations that carry daily normals (`NORMAL_DLY`) for the coordinate.
+ *   2. For the nearest qualifying station, read the daily high/low temperature normals
+ *      (`DLY-TMAX-NORMAL`, `DLY-TMIN-NORMAL`) for the requested month/day.
+ *   3. Read the monthly precipitation normal (`MLY-PRCP-NORMAL` from `NORMAL_MLY`) and
+ *      divide by the number of days in the month to express an average daily value.
  *
- * For v1.2.0, we implement a basic structure that falls back to Open-Meteo.
- * Future enhancement: Full NCEI climate normals integration.
+ * Normals are keyed to a fixed reference year (2010) in the CDO dataset. Values are
+ * requested with `units=standard` so temperatures come back in °F and precipitation in
+ * inches. If no nearby station has complete normals, a DataNotFoundError is thrown so the
+ * caller can fall back to Open-Meteo computed normals.
  */
 
 import axios, { AxiosInstance } from 'axios';
 import type { ClimateNormals } from '../types/openmeteo.js';
+import type {
+  NCEIDataResponse,
+  NCEIStationsResponse,
+  NCEIStationWithDistance
+} from '../types/ncei.js';
 import { NCEI_API_TOKEN } from '../config/api.js';
-import { logger } from '../utils/logger.js';
+import { logger, redactCoordinatesForLogging } from '../utils/logger.js';
 import { DataNotFoundError, RateLimitError, ServiceUnavailableError } from '../errors/ApiError.js';
 import { getUserAgent } from '../utils/version.js';
+import { Cache } from '../utils/cache.js';
+import { CacheConfig } from '../config/cache.js';
+import { calculateDistance } from '../utils/distance.js';
 
 export interface NCEIServiceConfig {
   baseURL?: string;
   timeout?: number;
   token?: string;
 }
+
+/** CDO dataset identifiers. */
+const DATASET_DAILY_NORMALS = 'NORMAL_DLY';
+const DATASET_MONTHLY_NORMALS = 'NORMAL_MLY';
+
+/** Reference year used by the CDO normals datasets (non-leap). */
+const NORMALS_REFERENCE_YEAR = 2010;
+
+/** Initial station-search half-extent in degrees (~80 km of latitude). */
+const STATION_SEARCH_DEGREES = 0.75;
+/** Expanded half-extent used if the initial search finds no stations. */
+const STATION_SEARCH_DEGREES_WIDE = 1.5;
+
+/** Maximum number of nearest stations to probe for complete normals. */
+const MAX_STATION_ATTEMPTS = 4;
+
+/**
+ * CDO uses large negative sentinels (e.g. -7777, -9999) for special/missing values.
+ * Any genuine °F temperature or inches-precipitation normal is far above this.
+ */
+const MISSING_VALUE_THRESHOLD = -100;
 
 /**
  * NCEI Climate Data Online (CDO) Service
@@ -36,6 +69,7 @@ export interface NCEIServiceConfig {
 export class NCEIService {
   private client: AxiosInstance;
   private token: string | undefined;
+  private cache: Cache<unknown>;
 
   constructor(config: NCEIServiceConfig = {}) {
     const {
@@ -45,6 +79,7 @@ export class NCEIService {
     } = config;
 
     this.token = token;
+    this.cache = new Cache(CacheConfig.maxSize);
 
     this.client = axios.create({
       baseURL,
@@ -75,22 +110,16 @@ export class NCEIService {
   }
 
   /**
-   * Get climate normals for a US location
-   *
-   * NOTE: This is a placeholder implementation. The NCEI API requires:
-   * 1. Station lookup from coordinates
-   * 2. Querying climate normals datasets by station
-   * 3. Data transformation to our format
-   *
-   * For v1.2.0, this throws DataNotFoundError to trigger fallback to Open-Meteo.
-   * Future enhancement: Implement full NCEI normals retrieval.
+   * Get official NOAA climate normals for a US location.
    *
    * @param latitude - Latitude (US only)
    * @param longitude - Longitude (US only)
    * @param month - Month (1-12)
    * @param day - Day of month (1-31)
-   * @returns Climate normals
-   * @throws {DataNotFoundError} - NCEI integration not yet complete
+   * @returns Climate normals sourced from NCEI
+   * @throws {DataNotFoundError} - No token, or no nearby station with complete normals
+   * @throws {RateLimitError} - CDO rate limit exceeded
+   * @throws {ServiceUnavailableError} - CDO unavailable or invalid token
    */
   async getClimateNormals(
     latitude: number,
@@ -105,29 +134,174 @@ export class NCEIService {
       );
     }
 
-    logger.info('NCEI climate normals requested (not yet implemented)', {
-      latitude,
-      longitude,
+    const redacted = redactCoordinatesForLogging(latitude, longitude);
+
+    // Normals are immutable, so cache indefinitely.
+    const cacheKey = Cache.generateKey(
+      'ncei-normals',
+      latitude.toFixed(2),
+      longitude.toFixed(2),
       month,
       day
-    });
+    );
+    if (CacheConfig.enabled) {
+      const cached = this.cache.get(cacheKey) as ClimateNormals | undefined;
+      if (cached) {
+        logger.info('NCEI climate normals cache hit', { ...redacted, month, day });
+        return cached;
+      }
+    }
 
-    // TODO: Implement NCEI climate normals retrieval
-    // Steps needed:
-    // 1. Find nearby weather stations using /stations endpoint
-    // 2. Query climate normals datasets (NORMAL_DLY, NORMAL_MLY) for station
-    // 3. Extract and transform data to ClimateNormals format
-    // 4. Handle missing data and station selection logic
-    //
-    // Complexity: High - requires multiple API calls and data processing
-    // Estimated implementation: 1-2 days
-    //
-    // For now, throw DataNotFoundError to trigger fallback to Open-Meteo
+    // The reference year (2010) is not a leap year, so Feb 29 has no normal.
+    const normalsDay = month === 2 && day === 29 ? 28 : day;
+    const dailyDate = `${NORMALS_REFERENCE_YEAR}-${pad2(month)}-${pad2(normalsDay)}`;
+    const monthlyDate = `${NORMALS_REFERENCE_YEAR}-${pad2(month)}-01`;
+
+    logger.info('Fetching climate normals from NCEI', { ...redacted, month, day });
+
+    const stations = await this.findNearbyStations(latitude, longitude);
+    if (stations.length === 0) {
+      throw new DataNotFoundError(
+        'NCEI',
+        'No NCEI normals stations found near this location'
+      );
+    }
+
+    const daysInMonth = getDaysInMonth(month);
+
+    // Probe nearest stations until one has both daily temperature normals and a
+    // monthly precipitation normal, so the result is fully sourced from NCEI.
+    for (const station of stations.slice(0, MAX_STATION_ATTEMPTS)) {
+      const temps = await this.fetchDailyTemperatureNormals(station.id, dailyDate);
+      if (!temps) {
+        continue;
+      }
+
+      const monthlyPrecip = await this.fetchMonthlyPrecipitationNormal(station.id, monthlyDate);
+      if (monthlyPrecip === null) {
+        continue;
+      }
+
+      const normals: ClimateNormals = {
+        tempHigh: round1(temps.tmax),
+        tempLow: round1(temps.tmin),
+        precipitation: round2(monthlyPrecip / daysInMonth),
+        source: 'NCEI',
+        month,
+        day
+      };
+
+      logger.info('Resolved NCEI climate normals', {
+        ...redacted,
+        month,
+        day,
+        station: station.id,
+        distanceKm: Math.round(station.distanceKm)
+      });
+
+      if (CacheConfig.enabled) {
+        this.cache.set(cacheKey, normals, Infinity);
+      }
+      return normals;
+    }
 
     throw new DataNotFoundError(
       'NCEI',
-      'NCEI climate normals integration is planned for a future release. Using Open-Meteo fallback.'
+      'No NCEI station with complete normals found near this location'
     );
+  }
+
+  /**
+   * Find stations carrying daily normals near a coordinate, sorted by distance.
+   * Expands the search extent once if the initial bounding box is empty.
+   */
+  private async findNearbyStations(
+    latitude: number,
+    longitude: number
+  ): Promise<NCEIStationWithDistance[]> {
+    for (const halfExtent of [STATION_SEARCH_DEGREES, STATION_SEARCH_DEGREES_WIDE]) {
+      // CDO extent format is "minlat,minlng,maxlat,maxlng" (south,west,north,east).
+      const extent = [
+        latitude - halfExtent,
+        longitude - halfExtent,
+        latitude + halfExtent,
+        longitude + halfExtent
+      ].join(',');
+
+      const response = await this.client.get<NCEIStationsResponse>('/stations', {
+        params: {
+          datasetid: DATASET_DAILY_NORMALS,
+          extent,
+          limit: 50
+        }
+      });
+
+      const results = response.data?.results ?? [];
+      if (results.length > 0) {
+        return results
+          .map(station => ({
+            ...station,
+            distanceKm: calculateDistance(latitude, longitude, station.latitude, station.longitude)
+          }))
+          .sort((a, b) => a.distanceKm - b.distanceKm);
+      }
+    }
+
+    return [];
+  }
+
+  /**
+   * Read daily high/low temperature normals (°F) for a station on a given date.
+   * Returns null if either value is missing.
+   */
+  private async fetchDailyTemperatureNormals(
+    stationId: string,
+    date: string
+  ): Promise<{ tmax: number; tmin: number } | null> {
+    const response = await this.client.get<NCEIDataResponse>('/data', {
+      params: {
+        datasetid: DATASET_DAILY_NORMALS,
+        stationid: stationId,
+        startdate: date,
+        enddate: date,
+        datatypeid: ['DLY-TMAX-NORMAL', 'DLY-TMIN-NORMAL'],
+        units: 'standard',
+        limit: 10
+      }
+    });
+
+    const results = response.data?.results ?? [];
+    const tmax = results.find(r => r.datatype === 'DLY-TMAX-NORMAL')?.value;
+    const tmin = results.find(r => r.datatype === 'DLY-TMIN-NORMAL')?.value;
+
+    if (!isValidValue(tmax) || !isValidValue(tmin)) {
+      return null;
+    }
+    return { tmax, tmin };
+  }
+
+  /**
+   * Read the monthly precipitation normal (inches) for a station's month.
+   * Returns null if the value is missing.
+   */
+  private async fetchMonthlyPrecipitationNormal(
+    stationId: string,
+    monthDate: string
+  ): Promise<number | null> {
+    const response = await this.client.get<NCEIDataResponse>('/data', {
+      params: {
+        datasetid: DATASET_MONTHLY_NORMALS,
+        stationid: stationId,
+        startdate: monthDate,
+        enddate: monthDate,
+        datatypeid: ['MLY-PRCP-NORMAL'],
+        units: 'standard',
+        limit: 10
+      }
+    });
+
+    const value = response.data?.results?.find(r => r.datatype === 'MLY-PRCP-NORMAL')?.value;
+    return isValidValue(value) ? value : null;
   }
 
   /**
@@ -175,4 +349,29 @@ export class NCEIService {
 
     throw new ServiceUnavailableError('NCEI', error.message || 'Unknown error occurred');
   }
+}
+
+/** Zero-pad a 1-2 digit number to two characters. */
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** Days in a given month, using the (non-leap) normals reference year. */
+function getDaysInMonth(month: number): number {
+  return new Date(NORMALS_REFERENCE_YEAR, month, 0).getDate();
+}
+
+/** A CDO value is valid if present and above the missing-value sentinel range. */
+function isValidValue(value: number | undefined): value is number {
+  return typeof value === 'number' && value > MISSING_VALUE_THRESHOLD;
+}
+
+/** Round to one decimal place. */
+function round1(n: number): number {
+  return Math.round(n * 10) / 10;
+}
+
+/** Round to two decimal places. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
 }

--- a/src/types/ncei.ts
+++ b/src/types/ncei.ts
@@ -1,0 +1,64 @@
+/**
+ * Type definitions for the NOAA NCEI Climate Data Online (CDO) API v2.
+ *
+ * Documentation: https://www.ncei.noaa.gov/support/access-data-service-api-user-documentation
+ */
+
+/**
+ * Pagination/result metadata returned by CDO list endpoints.
+ */
+export interface NCEIResultMetadata {
+  resultset?: {
+    offset: number;
+    count: number;
+    limit: number;
+  };
+}
+
+/**
+ * A weather station as returned by the CDO /stations endpoint.
+ */
+export interface NCEIStation {
+  id: string; // e.g. "GHCND:USW00024233"
+  name: string; // e.g. "SEATTLE TACOMA AIRPORT, WA US"
+  latitude: number;
+  longitude: number;
+  elevation?: number;
+  datacoverage?: number; // 0..1 fraction of available data
+  mindate?: string; // ISO date
+  maxdate?: string; // ISO date
+}
+
+/**
+ * Response from the CDO /stations endpoint.
+ */
+export interface NCEIStationsResponse {
+  metadata?: NCEIResultMetadata;
+  results?: NCEIStation[];
+}
+
+/**
+ * A single climate-normals data value from the CDO /data endpoint.
+ */
+export interface NCEIDataPoint {
+  date: string; // ISO datetime (reference year, e.g. "2010-07-15T00:00:00")
+  datatype: string; // e.g. "DLY-TMAX-NORMAL"
+  station: string;
+  attributes?: string;
+  value: number;
+}
+
+/**
+ * Response from the CDO /data endpoint.
+ */
+export interface NCEIDataResponse {
+  metadata?: NCEIResultMetadata;
+  results?: NCEIDataPoint[];
+}
+
+/**
+ * A station annotated with its distance (km) from a query point.
+ */
+export interface NCEIStationWithDistance extends NCEIStation {
+  distanceKm: number;
+}

--- a/tests/unit/ncei.test.ts
+++ b/tests/unit/ncei.test.ts
@@ -1,101 +1,138 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the axios instance used by NCEIService so no real network calls are made.
+const { mockGet, mockUse } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockUse: vi.fn()
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => ({
+      get: mockGet,
+      defaults: { headers: { common: {} as Record<string, string> } },
+      interceptors: { response: { use: mockUse } }
+    }))
+  }
+}));
+
 import { NCEIService } from '../../src/services/ncei.js';
 import { DataNotFoundError, RateLimitError, ServiceUnavailableError } from '../../src/errors/ApiError.js';
 
+const SEATAC = {
+  id: 'GHCND:USW00024233',
+  name: 'SEATTLE TACOMA AIRPORT, WA US',
+  latitude: 47.4502,
+  longitude: -122.3088,
+  datacoverage: 1
+};
+
+/**
+ * Configure the mocked client to return a healthy station + daily temps + monthly precip.
+ * Optional overrides let individual tests simulate missing data.
+ */
+function setupHappyPath(opts: {
+  stations?: unknown[];
+  tmax?: number | null;
+  tmin?: number | null;
+  monthlyPrecip?: number | null;
+} = {}) {
+  const {
+    stations = [SEATAC],
+    tmax = 76,
+    tmin = 55.7,
+    monthlyPrecip = 0.7
+  } = opts;
+
+  mockGet.mockImplementation((url: string, config?: { params?: Record<string, unknown> }) => {
+    const params = config?.params ?? {};
+    if (url === '/stations') {
+      return Promise.resolve({ data: { results: stations } });
+    }
+    if (url === '/data' && params.datasetid === 'NORMAL_DLY') {
+      const results: unknown[] = [];
+      if (tmax !== null) results.push({ datatype: 'DLY-TMAX-NORMAL', value: tmax });
+      if (tmin !== null) results.push({ datatype: 'DLY-TMIN-NORMAL', value: tmin });
+      return Promise.resolve({ data: { results } });
+    }
+    if (url === '/data' && params.datasetid === 'NORMAL_MLY') {
+      const results: unknown[] = [];
+      if (monthlyPrecip !== null) results.push({ datatype: 'MLY-PRCP-NORMAL', value: monthlyPrecip });
+      return Promise.resolve({ data: { results } });
+    }
+    return Promise.resolve({ data: { results: [] } });
+  });
+}
+
 describe('NCEI Service', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockUse.mockClear();
+  });
+
   describe('Service initialization', () => {
     it('should create service with default configuration', () => {
-      const service = new NCEIService();
-      expect(service).toBeInstanceOf(NCEIService);
+      expect(new NCEIService()).toBeInstanceOf(NCEIService);
     });
 
     it('should create service with custom baseURL', () => {
-      const service = new NCEIService({ baseURL: 'https://custom.api.com' });
-      expect(service).toBeInstanceOf(NCEIService);
+      expect(new NCEIService({ baseURL: 'https://custom.api.com' })).toBeInstanceOf(NCEIService);
     });
 
     it('should create service with custom timeout', () => {
-      const service = new NCEIService({ timeout: 15000 });
-      expect(service).toBeInstanceOf(NCEIService);
+      expect(new NCEIService({ timeout: 15000 })).toBeInstanceOf(NCEIService);
     });
 
     it('should create service with custom token', () => {
-      const service = new NCEIService({ token: 'test-token-123' });
-      expect(service).toBeInstanceOf(NCEIService);
-    });
-
-    it('should create service with all custom config', () => {
-      const service = new NCEIService({
-        baseURL: 'https://custom.api.com',
-        timeout: 20000,
-        token: 'custom-token'
-      });
-      expect(service).toBeInstanceOf(NCEIService);
+      expect(new NCEIService({ token: 'test-token-123' })).toBeInstanceOf(NCEIService);
     });
 
     it('should create service without token', () => {
       const originalToken = process.env.NCEI_API_TOKEN;
       delete process.env.NCEI_API_TOKEN;
-
-      const service = new NCEIService();
-      expect(service).toBeInstanceOf(NCEIService);
-
+      expect(new NCEIService()).toBeInstanceOf(NCEIService);
       process.env.NCEI_API_TOKEN = originalToken;
     });
   });
 
   describe('isAvailable', () => {
     it('should return true when token is provided', () => {
-      const service = new NCEIService({ token: 'valid-token' });
-      expect(service.isAvailable()).toBe(true);
+      expect(new NCEIService({ token: 'valid-token' }).isAvailable()).toBe(true);
     });
 
     it('should return false when token is undefined', () => {
-      const service = new NCEIService({ token: undefined });
-      expect(service.isAvailable()).toBe(false);
+      expect(new NCEIService({ token: undefined }).isAvailable()).toBe(false);
     });
 
     it('should return false when token is empty string', () => {
-      const service = new NCEIService({ token: '' });
-      expect(service.isAvailable()).toBe(false);
+      expect(new NCEIService({ token: '' }).isAvailable()).toBe(false);
     });
 
     it('should return false when token is whitespace only', () => {
-      const service = new NCEIService({ token: '   ' });
-      expect(service.isAvailable()).toBe(false);
+      expect(new NCEIService({ token: '   ' }).isAvailable()).toBe(false);
     });
 
-    it('should return true for non-empty token', () => {
-      const service = new NCEIService({ token: 'abc123' });
-      expect(service.isAvailable()).toBe(true);
-    });
-
-    it('should return true for token with spaces around content', () => {
-      const service = new NCEIService({ token: '  token123  ' });
-      expect(service.isAvailable()).toBe(true);
+    it('should return false when token is null', () => {
+      expect(new NCEIService({ token: null as any }).isAvailable()).toBe(false);
     });
   });
 
   describe('getClimateNormals - without token', () => {
     it('should throw DataNotFoundError when token not configured', async () => {
       const service = new NCEIService({ token: undefined });
-
-      await expect(
-        service.getClimateNormals(40.7128, -74.0060, 1, 15)
-      ).rejects.toThrow(DataNotFoundError);
+      await expect(service.getClimateNormals(40.7128, -74.006, 1, 15)).rejects.toThrow(DataNotFoundError);
     });
 
-    it('should throw error with token configuration message', async () => {
+    it('should not make any network call when token is missing', async () => {
       const service = new NCEIService({ token: '' });
-
-      await expect(
-        service.getClimateNormals(40.7128, -74.0060, 6, 1)
-      ).rejects.toThrow('NCEI API token not configured');
+      await expect(service.getClimateNormals(40.7128, -74.006, 6, 1)).rejects.toThrow(
+        'NCEI API token not configured'
+      );
+      expect(mockGet).not.toHaveBeenCalled();
     });
 
     it('should include environment variable name in error', async () => {
       const service = new NCEIService({ token: undefined });
-
       try {
         await service.getClimateNormals(37.7749, -122.4194, 12, 25);
         expect.fail('Should have thrown error');
@@ -106,260 +143,184 @@ describe('NCEI Service', () => {
         }
       }
     });
+  });
 
-    it('should have service name as NCEI in error', async () => {
-      const service = new NCEIService({ token: '' });
+  describe('getClimateNormals - successful retrieval', () => {
+    it('should return NCEI-sourced normals from the nearest station', async () => {
+      setupHappyPath();
+      const service = new NCEIService({ token: 'valid-token' });
 
-      try {
-        await service.getClimateNormals(40.0, -100.0, 7, 4);
-        expect.fail('Should have thrown error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(DataNotFoundError);
-        if (error instanceof DataNotFoundError) {
-          expect(error.service).toBe('NCEI');
-        }
-      }
+      const normals = await service.getClimateNormals(47.6062, -122.3321, 7, 15);
+
+      expect(normals).toEqual({
+        tempHigh: 76,
+        tempLow: 55.7,
+        precipitation: round2(0.7 / 31), // monthly normal divided by days in July
+        source: 'NCEI',
+        month: 7,
+        day: 15
+      });
+    });
+
+    it('should request daily temperatures in standard (°F) units', async () => {
+      setupHappyPath();
+      const service = new NCEIService({ token: 'valid-token' });
+      await service.getClimateNormals(47.6062, -122.3321, 7, 15);
+
+      const dailyCall = mockGet.mock.calls.find(
+        ([url, cfg]) => url === '/data' && cfg?.params?.datasetid === 'NORMAL_DLY'
+      );
+      expect(dailyCall).toBeDefined();
+      expect(dailyCall![1].params.units).toBe('standard');
+      expect(dailyCall![1].params.datatypeid).toEqual(['DLY-TMAX-NORMAL', 'DLY-TMIN-NORMAL']);
+      expect(dailyCall![1].params.startdate).toBe('2010-07-15');
+    });
+
+    it('should clamp Feb 29 to Feb 28 (reference year is non-leap)', async () => {
+      setupHappyPath();
+      const service = new NCEIService({ token: 'valid-token' });
+      await service.getClimateNormals(47.6062, -122.3321, 2, 29);
+
+      const dailyCall = mockGet.mock.calls.find(
+        ([url, cfg]) => url === '/data' && cfg?.params?.datasetid === 'NORMAL_DLY'
+      );
+      expect(dailyCall![1].params.startdate).toBe('2010-02-28');
+    });
+
+    it('should cache results and not re-query on a second identical call', async () => {
+      setupHappyPath();
+      const service = new NCEIService({ token: 'valid-token' });
+
+      await service.getClimateNormals(47.6062, -122.3321, 7, 15);
+      const callsAfterFirst = mockGet.mock.calls.length;
+      const second = await service.getClimateNormals(47.6062, -122.3321, 7, 15);
+
+      expect(second.source).toBe('NCEI');
+      expect(mockGet.mock.calls.length).toBe(callsAfterFirst); // served from cache
     });
   });
 
-  describe('getClimateNormals - with token (placeholder implementation)', () => {
-    it('should throw DataNotFoundError for placeholder implementation', async () => {
+  describe('getClimateNormals - missing data', () => {
+    it('should throw DataNotFoundError when no stations are found', async () => {
+      setupHappyPath({ stations: [] });
       const service = new NCEIService({ token: 'valid-token' });
-
-      await expect(
-        service.getClimateNormals(40.7128, -74.0060, 1, 1)
-      ).rejects.toThrow(DataNotFoundError);
+      await expect(service.getClimateNormals(40.0, -100.0, 6, 15)).rejects.toThrow(
+        /No NCEI normals stations found/
+      );
     });
 
-    it('should throw error with implementation message', async () => {
-      const service = new NCEIService({ token: 'test-token' });
+    it('should throw DataNotFoundError when the station lacks temperature normals', async () => {
+      setupHappyPath({ tmax: null });
+      const service = new NCEIService({ token: 'valid-token' });
+      await expect(service.getClimateNormals(47.6062, -122.3321, 7, 15)).rejects.toThrow(
+        /No NCEI station with complete normals/
+      );
+    });
 
-      try {
-        await service.getClimateNormals(37.7749, -122.4194, 6, 15);
-        expect.fail('Should have thrown error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(DataNotFoundError);
-        if (error instanceof DataNotFoundError) {
-          expect(error.userMessage).toContain('planned for a future release');
+    it('should throw DataNotFoundError when the station lacks precipitation normals', async () => {
+      setupHappyPath({ monthlyPrecip: null });
+      const service = new NCEIService({ token: 'valid-token' });
+      await expect(service.getClimateNormals(47.6062, -122.3321, 7, 15)).rejects.toThrow(
+        /No NCEI station with complete normals/
+      );
+    });
+
+    it('should treat missing-value sentinels (e.g. -7777) as missing', async () => {
+      setupHappyPath({ tmax: -7777 });
+      const service = new NCEIService({ token: 'valid-token' });
+      await expect(service.getClimateNormals(47.6062, -122.3321, 7, 15)).rejects.toThrow(
+        DataNotFoundError
+      );
+    });
+
+    it('should fall through to a second station when the first is incomplete', async () => {
+      const near = { ...SEATAC, id: 'GHCND:NEAR', latitude: 47.61, longitude: -122.33 };
+      const far = { ...SEATAC, id: 'GHCND:FAR', latitude: 47.7, longitude: -122.4 };
+      mockGet.mockImplementation((url: string, config?: { params?: Record<string, unknown> }) => {
+        const params = config?.params ?? {};
+        if (url === '/stations') return Promise.resolve({ data: { results: [near, far] } });
+        if (url === '/data' && params.datasetid === 'NORMAL_DLY') {
+          // Nearest station has no temps; far station does.
+          if (params.stationid === 'GHCND:NEAR') return Promise.resolve({ data: { results: [] } });
+          return Promise.resolve({
+            data: { results: [
+              { datatype: 'DLY-TMAX-NORMAL', value: 70 },
+              { datatype: 'DLY-TMIN-NORMAL', value: 50 }
+            ] }
+          });
         }
-      }
-    });
-
-    it('should mention Open-Meteo fallback in error message', async () => {
-      const service = new NCEIService({ token: 'token123' });
-
-      try {
-        await service.getClimateNormals(45.0, -93.0, 3, 20);
-        expect.fail('Should have thrown error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(DataNotFoundError);
-        if (error instanceof DataNotFoundError) {
-          expect(error.userMessage).toContain('Open-Meteo fallback');
+        if (url === '/data' && params.datasetid === 'NORMAL_MLY') {
+          return Promise.resolve({ data: { results: [{ datatype: 'MLY-PRCP-NORMAL', value: 1.0 }] } });
         }
-      }
-    });
+        return Promise.resolve({ data: { results: [] } });
+      });
 
-    it('should accept valid latitude range', async () => {
-      const service = new NCEIService({ token: 'token' });
-
-      await expect(
-        service.getClimateNormals(49.0, -100.0, 1, 1)
-      ).rejects.toThrow(DataNotFoundError);
-
-      await expect(
-        service.getClimateNormals(24.0, -100.0, 1, 1)
-      ).rejects.toThrow(DataNotFoundError);
-    });
-
-    it('should accept valid longitude range', async () => {
-      const service = new NCEIService({ token: 'token' });
-
-      await expect(
-        service.getClimateNormals(40.0, -125.0, 1, 1)
-      ).rejects.toThrow(DataNotFoundError);
-
-      await expect(
-        service.getClimateNormals(40.0, -66.0, 1, 1)
-      ).rejects.toThrow(DataNotFoundError);
-    });
-
-    it('should accept valid month range', async () => {
-      const service = new NCEIService({ token: 'token' });
-
-      await expect(
-        service.getClimateNormals(40.0, -100.0, 1, 15)
-      ).rejects.toThrow(DataNotFoundError);
-
-      await expect(
-        service.getClimateNormals(40.0, -100.0, 12, 15)
-      ).rejects.toThrow(DataNotFoundError);
-    });
-
-    it('should accept valid day range', async () => {
-      const service = new NCEIService({ token: 'token' });
-
-      await expect(
-        service.getClimateNormals(40.0, -100.0, 6, 1)
-      ).rejects.toThrow(DataNotFoundError);
-
-      await expect(
-        service.getClimateNormals(40.0, -100.0, 6, 31)
-      ).rejects.toThrow(DataNotFoundError);
+      const service = new NCEIService({ token: 'valid-token' });
+      const normals = await service.getClimateNormals(47.6062, -122.3321, 6, 15);
+      expect(normals.tempHigh).toBe(70);
+      expect(normals.tempLow).toBe(50);
+      expect(normals.source).toBe('NCEI');
     });
   });
 
   describe('Error handling interceptor', () => {
-    it('should have proper error handling structure', () => {
-      const service = new NCEIService({ token: 'token' });
-      expect(service).toBeInstanceOf(NCEIService);
+    // The service registers an error interceptor; grab it to test error mapping.
+    function getErrorInterceptor() {
+      new NCEIService({ token: 'token' });
+      const lastCall = mockUse.mock.calls[mockUse.mock.calls.length - 1];
+      return lastCall[1] as (error: any) => Promise<never>;
+    }
+
+    it('should map 429 to RateLimitError', async () => {
+      const onRejected = getErrorInterceptor();
+      await expect(onRejected({ response: { status: 429, data: {} } })).rejects.toThrow(RateLimitError);
     });
 
-    it('should be prepared for 429 rate limit errors', () => {
-      // Test that RateLimitError can be constructed for NCEI
-      const error = new RateLimitError('NCEI', 'Rate limit exceeded', 60);
-      expect(error).toBeInstanceOf(RateLimitError);
-      expect(error.service).toBe('NCEI');
-      expect(error.statusCode).toBe(429);
+    it('should map 401/403 to ServiceUnavailableError (invalid token)', async () => {
+      const onRejected = getErrorInterceptor();
+      await expect(onRejected({ response: { status: 401, data: {} } })).rejects.toThrow(
+        ServiceUnavailableError
+      );
+      await expect(onRejected({ response: { status: 403, data: {} } })).rejects.toThrow(
+        ServiceUnavailableError
+      );
     });
 
-    it('should be prepared for 401/403 authentication errors', () => {
-      // Test that ServiceUnavailableError can be constructed for NCEI
-      const error = new ServiceUnavailableError('NCEI', 'Invalid token');
-      expect(error).toBeInstanceOf(ServiceUnavailableError);
-      expect(error.service).toBe('NCEI');
-    });
-
-    it('should be prepared for 404 not found errors', () => {
-      // Test that DataNotFoundError can be constructed for NCEI
-      const error = new DataNotFoundError('NCEI', 'Data not found');
-      expect(error).toBeInstanceOf(DataNotFoundError);
-      expect(error.service).toBe('NCEI');
-      expect(error.statusCode).toBe(404);
-    });
-
-    it('should be prepared for 500+ server errors', () => {
-      // Test that ServiceUnavailableError can be constructed for NCEI
-      const error = new ServiceUnavailableError('NCEI', 'Server error');
-      expect(error).toBeInstanceOf(ServiceUnavailableError);
-      expect(error.service).toBe('NCEI');
-      expect(error.statusCode).toBe(503);
-    });
-  });
-
-  describe('Configuration validation', () => {
-    it('should handle undefined config object', () => {
-      const service = new NCEIService(undefined);
-      expect(service).toBeInstanceOf(NCEIService);
-    });
-
-    it('should handle empty config object', () => {
-      const service = new NCEIService({});
-      expect(service).toBeInstanceOf(NCEIService);
-    });
-
-    it('should use default baseURL when not provided', () => {
-      const service = new NCEIService({ token: 'token' });
-      expect(service).toBeInstanceOf(NCEIService);
-    });
-
-    it('should use default timeout when not provided', () => {
-      const service = new NCEIService({ token: 'token' });
-      expect(service).toBeInstanceOf(NCEIService);
-    });
-  });
-
-  describe('Token handling', () => {
-    it('should handle token from environment variable', () => {
-      const originalToken = process.env.NCEI_API_TOKEN;
-      process.env.NCEI_API_TOKEN = 'env-token-123';
-
-      // Import will read the env var
-      const service = new NCEIService();
-      expect(service).toBeInstanceOf(NCEIService);
-
-      process.env.NCEI_API_TOKEN = originalToken;
-    });
-
-    it('should prefer explicit token over environment variable', () => {
-      const originalToken = process.env.NCEI_API_TOKEN;
-      process.env.NCEI_API_TOKEN = 'env-token';
-
-      const service = new NCEIService({ token: 'explicit-token' });
-      expect(service).toBeInstanceOf(NCEIService);
-
-      process.env.NCEI_API_TOKEN = originalToken;
-    });
-
-    it('should handle null token', () => {
-      const service = new NCEIService({ token: null as any });
-      expect(service.isAvailable()).toBe(false);
-    });
-
-    it('should handle numeric token (coerced to string)', () => {
-      const service = new NCEIService({ token: '12345' });
-      expect(service.isAvailable()).toBe(true);
-    });
-  });
-
-  describe('Service metadata', () => {
-    it('should have correct service name in errors', () => {
-      const error1 = new DataNotFoundError('NCEI', 'Test');
-      expect(error1.service).toBe('NCEI');
-
-      const error2 = new RateLimitError('NCEI');
-      expect(error2.service).toBe('NCEI');
-
-      const error3 = new ServiceUnavailableError('NCEI');
-      expect(error3.service).toBe('NCEI');
-    });
-
-    it('should be distinguishable from other services', () => {
-      const nceiError = new DataNotFoundError('NCEI', 'Test');
-      const noaaError = new DataNotFoundError('NOAA', 'Test');
-      const meteoError = new DataNotFoundError('OpenMeteo', 'Test');
-
-      expect(nceiError.service).not.toBe(noaaError.service);
-      expect(nceiError.service).not.toBe(meteoError.service);
-    });
-  });
-
-  describe('Future implementation readiness', () => {
-    it('should accept all required parameters for climate normals', async () => {
-      const service = new NCEIService({ token: 'token' });
-
-      // Verify method signature accepts correct parameters
+    it('should map 404 to DataNotFoundError', async () => {
+      const onRejected = getErrorInterceptor();
       await expect(
-        service.getClimateNormals(40.7128, -74.0060, 7, 15)
+        onRejected({ response: { status: 404, data: { message: 'nope' } } })
       ).rejects.toThrow(DataNotFoundError);
     });
 
-    it('should accept coordinates for US locations', async () => {
-      const service = new NCEIService({ token: 'token' });
-
-      // Seattle
-      await expect(
-        service.getClimateNormals(47.6062, -122.3321, 1, 1)
-      ).rejects.toThrow();
-
-      // Miami
-      await expect(
-        service.getClimateNormals(25.7617, -80.1918, 6, 15)
-      ).rejects.toThrow();
-
-      // Denver
-      await expect(
-        service.getClimateNormals(39.7392, -104.9903, 12, 31)
-      ).rejects.toThrow();
+    it('should map 5xx to ServiceUnavailableError', async () => {
+      const onRejected = getErrorInterceptor();
+      await expect(onRejected({ response: { status: 503, data: {} } })).rejects.toThrow(
+        ServiceUnavailableError
+      );
     });
 
-    it('should accept month/day combinations', async () => {
-      const service = new NCEIService({ token: 'token' });
+    it('should map network timeouts to ServiceUnavailableError', async () => {
+      const onRejected = getErrorInterceptor();
+      await expect(onRejected({ code: 'ETIMEDOUT' })).rejects.toThrow(ServiceUnavailableError);
+    });
+  });
 
-      // Various valid date combinations
-      await expect(service.getClimateNormals(40.0, -100.0, 1, 1)).rejects.toThrow();
-      await expect(service.getClimateNormals(40.0, -100.0, 2, 29)).rejects.toThrow();
-      await expect(service.getClimateNormals(40.0, -100.0, 6, 15)).rejects.toThrow();
-      await expect(service.getClimateNormals(40.0, -100.0, 12, 31)).rejects.toThrow();
+  describe('Error class metadata', () => {
+    it('should tag errors with the NCEI service name', () => {
+      expect(new DataNotFoundError('NCEI', 'x').service).toBe('NCEI');
+      expect(new RateLimitError('NCEI').service).toBe('NCEI');
+      expect(new ServiceUnavailableError('NCEI').service).toBe('NCEI');
+    });
+
+    it('should be distinguishable from other services', () => {
+      expect(new DataNotFoundError('NCEI', 'x').service).not.toBe(
+        new DataNotFoundError('NOAA', 'x').service
+      );
     });
   });
 });
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}


### PR DESCRIPTION
## Summary

Implements real NOAA NCEI climate-normals retrieval (was a placeholder that always fell back to Open-Meteo), and adds an audit of remaining incomplete features for review.

### NCEI climate normals (`src/services/ncei.ts`)
`getClimateNormals()` now hits the Climate Data Online (CDO) API for official 1991–2020 normals at US locations:
- Nearest-station discovery via bounding-box `/stations` (sorted by distance, expands once if empty), probing up to 4 stations for complete data
- Daily high/low temps (`DLY-TMAX-NORMAL`/`DLY-TMIN-NORMAL`, °F) + monthly precip (`MLY-PRCP-NORMAL`) ÷ days-in-month
- Feb-29 clamping, missing-value sentinels, 429→`RateLimitError`, 401/403→`ServiceUnavailableError`, indefinite caching
- New `src/types/ncei.ts`; `ncei.test.ts` rewritten with mocked HTTP

Falls back to Open-Meteo gracefully when the token is absent or no US station has complete data.

### Incomplete-features audit (`docs/development/INCOMPLETE_FEATURES_AUDIT.md`)
Review doc cataloging the remaining stubs/simplifications (satellite imagery, `layers` param, timezone heuristic, deprecated `getAllNWPSGauges`) with implement-vs-trim recommendations. **No code changes for those yet** — pending review.

## Validation
- [x] `npm run build` clean
- [x] Full suite **1080/1080** passing
- [x] Live-validated normals: Seattle 75.9°/56.6°F, Denver 47.8°/18.7°F, Miami 86.6°/77.1°F (0.28"/day), Chicago Feb-29; mid-ocean → fallback