### PR TITLE
feat: Satellite imagery (NASA GIBS), global timezones (tz-lookup), audit follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Satellite imagery** - `get_weather_imagery type="satellite"` is now implemented (was a "not yet implemented" stub) using NOAA GOES-East/West ABI GeoColor via NASA GIBS (Western Hemisphere coverage, day+night). Returns the latest snapshot.
+- **Accurate global timezones** - `guessTimezoneFromCoords` now uses `tz-lookup` for precise coordinate→IANA resolution worldwide (including no-DST zones like Arizona and sub-regional US zones), replacing the US-only longitude heuristic. Improves time formatting for international users.
 - **NCEI Climate Normals** - Implemented official NOAA 1991–2020 climate normals retrieval for US locations (previously a placeholder that always fell back to Open-Meteo)
   - Finds the nearest NCEI station with daily normals via a bounding-box `/stations` query (sorted by distance, expands once if empty)
   - Reads daily high/low temperature normals (`DLY-TMAX-NORMAL`/`DLY-TMIN-NORMAL`, °F) and monthly precipitation (`MLY-PRCP-NORMAL`) averaged to a daily value
   - Handles Feb 29 (reference year is non-leap), missing-value sentinels, rate limits, and auth errors; caches results indefinitely
   - Requires a free `NCEI_API_TOKEN`; gracefully falls back to Open-Meteo when unavailable or outside US coverage
   - Used by `get_forecast` and `get_current_conditions` for US climate context
+
+### Changed
+- **`get_weather_imagery`** - Removed the unused `layers` parameter (it was validated but had no effect; RainViewer no longer supports overlay layers).
+
+### Removed
+- Reliance on RainViewer for satellite imagery (RainViewer discontinued satellite IR and most color schemes in Jan 2026; documented in `docs/development/DATA_SOURCE_BLOCKERS.md`).
 
 ## [1.7.1] - 2026-06-21
 

--- a/docs/development/DATA_SOURCE_BLOCKERS.md
+++ b/docs/development/DATA_SOURCE_BLOCKERS.md
@@ -1,0 +1,148 @@
+# Data Source Blockers & Known Issues
+
+**Purpose:** A living record of external-data-source problems that have affected (or
+could affect) this server — discontinued APIs, schema changes, access blocks, and rate
+limits — plus what we did about them and what to watch. Weather data comes from many
+free third-party APIs that change without notice; when functionality breaks, **check
+here first**, then verify the live source before assuming a code bug.
+
+> Pattern to remember: an upstream API can keep returning HTTP 200 while silently
+> changing its contract (params ignored, fields renamed, feeds emptied). Several issues
+> below were exactly that. When a feature "stops working," probe the raw endpoint
+> directly before debugging our code.
+
+**Last updated:** 2026-06-22
+
+---
+
+## 1. RainViewer API transition — satellite & color schemes discontinued (Jan 2026)
+
+**Severity:** High (removed a capability) · **Status:** Worked around
+
+**What happened:** RainViewer transitioned its public API on **2026-01-01**
+([transition FAQ](https://www.rainviewer.com/api/transition-faq.html)). Effective then:
+- **Satellite (infrared) imagery discontinued** — `satellite.infrared` in
+  `weather-maps.json` is now an empty array.
+- **Nowcast (future) radar discontinued.**
+- **All color schemes except "Universal Blue" discontinued.**
+- **Max zoom reduced to 7.**
+- Only past radar (2 hours, 10-min intervals), PNG only, remains.
+
+**Impact on us:**
+- `get_weather_imagery type="satellite"` could **not** be implemented via RainViewer
+  (the original plan). → Re-sourced to **NASA GIBS** (see `src/services/gibs.ts`).
+- Our radar tile URLs hardcode color scheme `4` (`/4/1_1.png`). Verified the tiles still
+  return HTTP 200 — the color param is now **silently ignored** (all schemes render as
+  Universal Blue). So radar/precipitation still works; the color code is a dead value.
+
+**Watch / restore notes:**
+- If RainViewer fully shuts down (some announcements referenced a possible discontinuation
+  date), **all radar/precipitation imagery breaks**. Replacement candidates: NASA GIBS
+  radar (`...Radar...` layers, if added), Iowa Environmental Mesonet (IEM) tile services,
+  or RAINVIEWER's paid successor.
+- The hardcoded `/4/` color path should be changed to `/2/` (Universal Blue) for clarity,
+  or made configurable, next time `rainviewer.ts` is touched. Not urgent (it works).
+
+**How to check live:**
+```
+curl -s "https://api.rainviewer.com/public/weather-maps.json" | python3 -c "import json,sys;d=json.load(sys.stdin);print('radar.past',len(d['radar']['past']),'satellite.infrared',len(d.get('satellite',{}).get('infrared',[])))"
+```
+
+---
+
+## 2. NOAA nowCOAST blocked from dev/CI environments (CloudFront 403)
+
+**Severity:** Medium (tooling/verification) · **Status:** Avoided
+
+**What happened:** `https://nowcoast.noaa.gov/arcgis/rest/services/...` (the obvious GOES
+satellite `exportImage` source) returns **HTTP 403 "Request blocked"** from this
+development environment — a CloudFront WAF block on the originating network. The block
+persisted with browser-like headers and with the sandbox disabled, so it could not be
+verified here at all.
+
+**Impact on us:** We could not validate a nowCOAST-based satellite implementation from
+the dev environment. → Chose **NASA GIBS** instead (`gibs.earthdata.nasa.gov`), which is
+reachable here, serves GOES GeoColor as XYZ tiles (fits our tile model), and needs no
+auth or even a metadata call (URLs are constructed directly).
+
+**Watch / restore notes:**
+- nowCOAST likely works fine from the production MCP runtime; it remains a viable
+  fallback/alternative for satellite if GIBS ever degrades. If you try it, verify from
+  the *deployment* network, not this dev sandbox.
+- Other NOAA hosts behind the same CloudFront (e.g. parts of `*.noaa.gov`) may also be
+  blocked from CI; prefer sources confirmed reachable (GIBS, Open-Meteo, api.water.noaa.gov).
+
+---
+
+## 3. NCEI CDO API rate limits (5/sec, 10,000/day)
+
+**Severity:** Low · **Status:** Mitigated
+
+**What happened:** While validating the new NCEI normals integration, rapid sequential
+requests returned **HTTP 429**. CDO enforces 5 requests/second and 10,000/day per token.
+
+**Impact on us:** A single `getClimateNormals` call makes ~3 requests (stations + daily +
+monthly), and may probe a few stations. Bursting multiple locations back-to-back can trip
+the per-second limit.
+
+**Mitigations in place:** results cached indefinitely (`src/services/ncei.ts`); 429 maps
+to `RateLimitError`, which the hybrid `utils/normals.ts` catches and falls back to
+Open-Meteo; station probing capped at 4. In normal use (one forecast = one normals lookup)
+this is a non-issue.
+
+**Watch:** if forecast handlers ever batch many normals lookups, add client-side throttling.
+
+---
+
+## 4. NWPS `/gauges` contract change (fixed in v1.7.1) — reference
+
+**Severity:** was High · **Status:** Fixed
+
+Recorded here as the canonical example of a silent-200 contract change. The NWPS `/gauges`
+endpoint stopped honoring `west/south/east/north` params (returned the full ~13MB catalog,
+causing timeouts) and changed its response envelope/schema. Fixed in v1.7.1 by switching to
+`bbox.{xmin,ymin,xmax,ymax}` + `srid=EPSG_4326` and unwrapping `{ "gauges": [...] }`.
+
+**Watch:** `getNWPSGaugesInBoundingBox()` falls back to `getAllNWPSGauges()` (the heavy
+13MB path) on error and now logs a `securityEvent` warning when it does. A sustained
+appearance of that warning means the bbox query has regressed again — investigate
+immediately.
+
+---
+
+## 5. NASA GIBS satellite — latest frame only (no animation)
+
+**Severity:** Low · **Status:** Accepted limitation
+
+**What happened:** When implementing satellite via NASA GIBS (GOES GeoColor), the WMTS
+**"default" time (latest) tile is reliably available**, but explicit sub-daily timestamps
+are published at **irregular** times — e.g. probing GOES-West GeoColor, `…T22:00:00Z` and
+`…T12:00:00Z` returned 200 while `…T18:00:00Z` and `…T00:00:00Z` returned 404. Guessing
+fixed 30-min/hourly slots for an animation loop produced frequent 404 tiles.
+
+**Impact on us:** `get_weather_imagery type="satellite"` returns the **latest snapshot
+only**; the `animated` flag is ignored for satellite (radar/precipitation still animate via
+RainViewer). See `src/services/gibs.ts`.
+
+**Watch / restore notes:** To support satellite animation reliably, query GIBS for the
+layer's actual available times instead of guessing — either parse the WMTS
+`GetCapabilities` time `Dimension` (large, ~5MB) or use the GIBS time-domains endpoint —
+then build frame URLs from real timestamps.
+
+**How to check live:**
+```
+curl -s -o /dev/null -w "%{http_code}\n" "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/GOES-East_ABI_GeoColor/default/GoogleMapsCompatible_Level7/5/12/9.png"
+```
+
+---
+
+## Template for new entries
+
+```
+## N. <Source> — <one-line problem> (<date>)
+**Severity:** High/Medium/Low · **Status:** Worked around / Fixed / Open
+**What happened:** ...
+**Impact on us:** <which tool/feature, which file>
+**Watch / restore notes:** <how to detect recurrence; replacement candidates>
+**How to check live:** <a curl/probe command>
+```

--- a/docs/development/INCOMPLETE_FEATURES_AUDIT.md
+++ b/docs/development/INCOMPLETE_FEATURES_AUDIT.md
@@ -12,13 +12,17 @@ behavior, current behavior, blast radius (callers/tests), and a recommendation.
 
 ## Summary
 
-| # | Feature | Location | Status | Recommendation |
-|---|---------|----------|--------|----------------|
-| 1 | NCEI climate normals | `src/services/ncei.ts` | ✅ **Implemented (this session)** | Done — keep |
-| 2 | Satellite imagery | `src/handlers/weatherImageryHandler.ts:84` | ❌ Stub (throws) | **Decide:** implement (GOES) or trim |
-| 3 | Imagery `layers` parameter | `src/index.ts:440`, `weatherImageryHandler.ts:35` | ⚠️ Accepted but ignored | **Decide:** implement or trim |
-| 4 | Coordinate→timezone heuristic | `src/utils/timezone.ts:121` | ⚠️ Simplified (US-only accurate) | Likely keep; optionally improve |
-| 5 | `getAllNWPSGauges` (full catalog) | `src/services/noaa.ts:693` | ⚠️ Deprecated, still used as fallback | Likely keep as fallback; document |
+| # | Feature | Location | Status | Resolution |
+|---|---------|----------|--------|------------|
+| 1 | NCEI climate normals | `src/services/ncei.ts` | ✅ **Implemented** | Done — NOAA CDO normals |
+| 2 | Satellite imagery | `src/services/gibs.ts`, `weatherImageryHandler.ts` | ✅ **Implemented** | NASA GIBS GOES GeoColor (RainViewer satellite was discontinued — see DATA_SOURCE_BLOCKERS.md) |
+| 3 | Imagery `layers` parameter | (removed) | ✅ **Trimmed** | No backing capability after RainViewer transition |
+| 4 | Coordinate→timezone heuristic | `src/utils/timezone.ts` | ✅ **Implemented** | Replaced with `tz-lookup` (accurate global) |
+| 5 | `getAllNWPSGauges` (full catalog) | `src/services/noaa.ts` | ✅ **Resolved** | Kept as fallback + added `securityEvent` warning log |
+
+> **All audited items are now resolved.** Details below are kept for historical context.
+> External-data-source caveats (RainViewer discontinuation, satellite "latest only", NCEI
+> rate limits) are tracked in [`DATA_SOURCE_BLOCKERS.md`](./DATA_SOURCE_BLOCKERS.md).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "dotenv": "^17.2.3",
         "luxon": "^3.7.2",
         "mqtt": "^5.14.1",
-        "ngeohash": "^0.6.3"
+        "ngeohash": "^0.6.3",
+        "tz-lookup": "^6.1.25"
       },
       "bin": {
         "weather-mcp": "dist/index.js"
@@ -23,6 +24,7 @@
         "@types/luxon": "^3.7.1",
         "@types/ngeohash": "^0.6.8",
         "@types/node": "^25.9.3",
+        "@types/tz-lookup": "^6.1.2",
         "@vitest/coverage-v8": "^4.0.8",
         "tsx": "^4.20.6",
         "typescript": "^6.0.3",
@@ -1024,6 +1026,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tz-lookup": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@types/tz-lookup/-/tz-lookup-6.1.2.tgz",
+      "integrity": "sha512-9y31Xf/8FHXrCHjvVjGZLcsayAa6ABNc8bZlk6MPOQLLlr41tICSqW3TRPRIx2nodbzdKs5N7ipHWBrUsWUiAA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3520,6 +3529,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/tz-lookup": {
+      "version": "6.1.25",
+      "resolved": "https://registry.npmjs.org/tz-lookup/-/tz-lookup-6.1.25.tgz",
+      "integrity": "sha512-fFewT9o1uDzsW1QnUU1ValqaihFnwiUiiHr1S79/fxOzKXYYvX+EHeRnpvQJ9B3Qg67wPXT6QF2Esc4pFOrvLg==",
+      "license": "CC0-1.0"
     },
     "node_modules/undici-types": {
       "version": "7.24.6",

--- a/package.json
+++ b/package.json
@@ -60,12 +60,14 @@
     "dotenv": "^17.2.3",
     "luxon": "^3.7.2",
     "mqtt": "^5.14.1",
-    "ngeohash": "^0.6.3"
+    "ngeohash": "^0.6.3",
+    "tz-lookup": "^6.1.25"
   },
   "devDependencies": {
     "@types/luxon": "^3.7.1",
     "@types/ngeohash": "^0.6.8",
     "@types/node": "^25.9.3",
+    "@types/tz-lookup": "^6.1.2",
     "@vitest/coverage-v8": "^4.0.8",
     "tsx": "^4.20.6",
     "typescript": "^6.0.3",

--- a/src/handlers/weatherImageryHandler.ts
+++ b/src/handlers/weatherImageryHandler.ts
@@ -5,6 +5,7 @@
 
 import { WeatherImageryParams, WeatherImageryResponse, ImageryType } from '../types/imagery.js';
 import { rainViewerService } from '../services/rainviewer.js';
+import { gibsService } from '../services/gibs.js';
 import { validateLatitude, validateLongitude } from '../utils/validation.js';
 import { logger, redactCoordinatesForLogging } from '../utils/logger.js';
 import { ValidationError } from '../errors/ApiError.js';
@@ -31,16 +32,6 @@ function validateImageryParams(params: WeatherImageryParams): void {
   if (params.animated !== undefined && typeof params.animated !== 'boolean') {
     throw new ValidationError('animated parameter must be a boolean', 'animated', params.animated);
   }
-
-  // Validate layers array if provided
-  if (params.layers !== undefined) {
-    if (!Array.isArray(params.layers)) {
-      throw new ValidationError('layers parameter must be an array', 'layers', params.layers);
-    }
-    if (params.layers.length > 10) {
-      throw new ValidationError('Maximum 10 layers allowed', 'layers', params.layers);
-    }
-  }
 }
 
 /**
@@ -61,8 +52,7 @@ export async function getWeatherImagery(params: WeatherImageryParams): Promise<W
     animated
   });
 
-  // For now, we'll focus on precipitation radar using RainViewer
-  // Future enhancements can add NOAA radar and satellite imagery
+  // Precipitation/radar via RainViewer (global); satellite via NASA GIBS GOES.
   switch (type) {
     case 'precipitation':
     case 'radar': {
@@ -82,13 +72,22 @@ export async function getWeatherImagery(params: WeatherImageryParams): Promise<W
     }
 
     case 'satellite': {
-      // Placeholder for satellite imagery
-      // Future implementation can use NOAA GOES-16/17 or other satellite APIs
-      throw new ValidationError(
-        'Satellite imagery is not yet implemented. Use type="precipitation" or type="radar" for precipitation radar.',
-        'type',
-        type
-      );
+      // NOAA GOES-East/West ABI GeoColor via NASA GIBS (Western Hemisphere).
+      // Satellite returns the latest snapshot only (no animation — GIBS sub-daily
+      // timestamps are irregular; use type="radar" for animated loops).
+      const frames = gibsService.getSatelliteImagery(latitude, longitude);
+
+      return {
+        type,
+        location: { latitude, longitude },
+        coverage: 'Western Hemisphere (Americas / eastern Pacific)',
+        resolution: 'Latest snapshot',
+        source: 'NASA GIBS (NOAA GOES GeoColor)',
+        animated: false,
+        frames,
+        generatedAt: new Date(),
+        disclaimer: 'Satellite imagery from NASA GIBS using NOAA GOES-East/West ABI GeoColor. Coverage is the Western Hemisphere; locations outside GOES range may appear blank. Shows the latest snapshot only (animation not available for satellite). Imagery has a processing delay of roughly 20-30 minutes.'
+      };
     }
 
     default: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,7 +408,7 @@ const TOOL_DEFINITIONS = {
 
   get_weather_imagery: {
     name: 'get_weather_imagery' as const,
-    description: 'Get weather imagery including radar, satellite, and precipitation maps for a location (global coverage). Use this when asked about "show radar", "satellite image", "precipitation map", "weather map", "animated radar", or "what does radar show". Returns image URLs with timestamps for current or animated weather visualization. Supports precipitation radar (global via RainViewer). Includes disclaimer about data delays and official forecast consultation. For numerical forecast data, use get_forecast instead.',
+    description: 'Get weather imagery including radar, satellite, and precipitation maps for a location. Use this when asked about "show radar", "satellite image", "precipitation map", "weather map", "animated radar", or "what does radar show". Returns image URLs with timestamps for current or animated weather visualization. Precipitation/radar is global via RainViewer; satellite is GOES GeoColor (Western Hemisphere) via NASA GIBS. Includes disclaimer about data delays and official forecast consultation. For numerical forecast data, use get_forecast instead.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -426,7 +426,7 @@ const TOOL_DEFINITIONS = {
         },
         type: {
           type: 'string' as const,
-          description: 'Type of imagery: "radar", "satellite", or "precipitation" (default: "precipitation")',
+          description: 'Type of imagery: "radar" or "precipitation" (global, RainViewer) or "satellite" (Western Hemisphere GOES GeoColor, NASA GIBS). Default: "precipitation"',
           enum: ['radar', 'satellite', 'precipitation'],
           default: 'precipitation'
         },
@@ -434,13 +434,6 @@ const TOOL_DEFINITIONS = {
           type: 'boolean' as const,
           description: 'Return animated frames showing progression over time (default: false)',
           default: false
-        },
-        layers: {
-          type: 'array' as const,
-          description: 'Optional layers to include in imagery (future enhancement)',
-          items: {
-            type: 'string' as const
-          }
         }
       },
       required: ['latitude', 'longitude', 'type']

--- a/src/services/gibs.ts
+++ b/src/services/gibs.ts
@@ -1,0 +1,91 @@
+/**
+ * NASA GIBS (Global Imagery Browse Services) client for satellite imagery.
+ *
+ * Serves NOAA GOES-East / GOES-West ABI GeoColor as WMTS XYZ tiles in Web
+ * Mercator (EPSG:3857), with Western-Hemisphere coverage and no authentication.
+ *
+ * GeoColor is a multispectral blend (true color by day, IR cloud-top imagery at
+ * night), so it is useful 24/7. Tile URLs are constructed directly (no network
+ * call needed); the caller's renderer fetches the tiles.
+ *
+ * Only the latest frame is served (via the WMTS "default" time). GIBS sub-daily
+ * GeoColor snapshots are published at irregular timestamps, so guessing fixed
+ * intervals for animation produces missing (404) tiles — animation is therefore
+ * intentionally not supported for satellite (radar animates via RainViewer).
+ *
+ * @see https://nasa-gibs.github.io/gibs-api-docs/
+ */
+
+import { ImageryFrame } from '../types/imagery.js';
+
+/** WMTS REST base for EPSG:3857 "best" imagery. */
+const GIBS_BASE = 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best';
+
+/** Tile matrix set supported by the GeoColor layers (zoom 0–7). */
+const TILE_MATRIX_SET = 'GoogleMapsCompatible_Level7';
+const MAX_ZOOM = 7;
+
+/** Regional default zoom for a satellite view centered on the coordinate. */
+const DEFAULT_ZOOM = 5;
+
+/** Web Mercator projection latitude limit. */
+const MAX_LATITUDE = 85.05112878;
+
+export class GibsService {
+  /**
+   * Choose the GOES satellite whose disk best covers the longitude.
+   * GOES-West (~137°W) favors the Pacific/Alaska/Hawaii/far west; GOES-East
+   * (~75°W) covers the rest of the Americas.
+   */
+  private selectLayer(longitude: number): string {
+    return longitude <= -115 ? 'GOES-West_ABI_GeoColor' : 'GOES-East_ABI_GeoColor';
+  }
+
+  /** Convert lat/lon to WMTS tile column/row at a zoom level (Web Mercator). */
+  private tileColRow(latitude: number, longitude: number, zoom: number): { x: number; y: number } {
+    const lat = Math.max(-MAX_LATITUDE, Math.min(MAX_LATITUDE, latitude));
+    const n = 2 ** zoom;
+    const latRad = (lat * Math.PI) / 180;
+    const xRaw = Math.floor(((longitude + 180) / 360) * n);
+    const yRaw = Math.floor(
+      ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n
+    );
+    const clamp = (v: number) => Math.max(0, Math.min(n - 1, v));
+    return { x: clamp(xRaw), y: clamp(yRaw) };
+  }
+
+  /**
+   * Build a WMTS tile URL for the latest available frame (WMTS "default" time).
+   * WMTS REST order is {z}/{row=y}/{col=x}.
+   */
+  buildTileUrl(layer: string, latitude: number, longitude: number, zoom: number): string {
+    const z = Math.max(0, Math.min(MAX_ZOOM, zoom));
+    const { x, y } = this.tileColRow(latitude, longitude, z);
+    return `${GIBS_BASE}/${layer}/default/${TILE_MATRIX_SET}/${z}/${y}/${x}.png`;
+  }
+
+  /** A short, human label for which satellite a layer represents. */
+  private satelliteLabel(layer: string): string {
+    return layer.startsWith('GOES-West') ? 'GOES-West' : 'GOES-East';
+  }
+
+  /**
+   * Get the latest GOES GeoColor satellite frame for a location.
+   * Returns a single frame (satellite animation is not supported — see file header).
+   */
+  getSatelliteImagery(latitude: number, longitude: number): ImageryFrame[] {
+    const layer = this.selectLayer(longitude);
+    const sat = this.satelliteLabel(layer);
+
+    return [
+      {
+        url: this.buildTileUrl(layer, latitude, longitude, DEFAULT_ZOOM),
+        timestamp: new Date(),
+        description: `${sat} GeoColor satellite (latest)`
+      }
+    ];
+  }
+}
+
+// Singleton instance
+export const gibsService = new GibsService();

--- a/src/services/noaa.ts
+++ b/src/services/noaa.ts
@@ -773,11 +773,18 @@ export class NOAAService {
 
       return result;
     } catch (error) {
-      // If bounding box query fails, fall back to client-side filtering
-      // This provides compatibility if the API doesn't support bbox queries
-      logger.warn('NWPS bounding box query failed, falling back to client-side filtering', {
-        error: error instanceof Error ? error.message : String(error)
-      });
+      // If the bounding-box query fails, fall back to downloading the entire
+      // gauge catalog and filtering client-side. This is a heavy path (~13MB /
+      // ~12,700 gauges) and should be rare — a sustained occurrence signals the
+      // NWPS bbox query has regressed (see v1.7.1 fix) and needs investigation.
+      logger.warn(
+        'NWPS bounding box query failed; falling back to full gauge catalog download (heavy path)',
+        {
+          error: error instanceof Error ? error.message : String(error),
+          fallback: 'getAllNWPSGauges',
+          securityEvent: true
+        }
+      );
 
       const allGauges = await this.getAllNWPSGauges();
       const filtered = allGauges.filter(gauge =>

--- a/src/types/imagery.ts
+++ b/src/types/imagery.ts
@@ -26,7 +26,6 @@ export interface WeatherImageryParams {
   longitude: number;
   type: ImageryType;
   animated?: boolean;
-  layers?: string[];
 }
 
 /**

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -4,6 +4,8 @@
  */
 
 import { DateTime } from 'luxon';
+import tzLookup from 'tz-lookup';
+import { logger } from './logger.js';
 
 /**
  * Format an ISO 8601 datetime string in the specified timezone
@@ -112,29 +114,34 @@ export function getTimezoneAbbreviation(timezone: string, datetime?: Date): stri
 }
 
 /**
- * Detect timezone from coordinates using a simple heuristic
- * This is a fallback when timezone is not provided by APIs
+ * Detect the IANA timezone for a coordinate.
+ *
+ * Uses `tz-lookup` for accurate global coordinate→timezone resolution (handles
+ * international locations, US territories, and no-DST zones like Arizona). Falls
+ * back to a coarse US longitude heuristic and finally UTC if the lookup fails
+ * (e.g. invalid coordinates).
+ *
  * @param latitude - Latitude
  * @param longitude - Longitude
- * @returns Best-guess IANA timezone identifier
+ * @returns IANA timezone identifier
  */
 export function guessTimezoneFromCoords(latitude: number, longitude: number): string {
-  // This is a simplified heuristic - in practice, APIs usually provide timezone
-  // For production use, consider integrating a proper coordinate-to-timezone library
-  // like tz-lookup or @photostructure/tz-lookup for accurate global coverage
+  try {
+    return tzLookup(latitude, longitude);
+  } catch (error) {
+    logger.warn('tz-lookup failed; falling back to coarse timezone heuristic', {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
 
-  // Map to common US timezones for North America based on longitude
+  // Fallback: coarse US longitude bands, then UTC for everything else.
   if (latitude >= 24 && latitude <= 50 && longitude >= -125 && longitude <= -66) {
     if (longitude >= -75) return 'America/New_York';
     if (longitude >= -87) return 'America/Chicago';
     if (longitude >= -104) return 'America/Denver';
-    if (longitude >= -125) return 'America/Los_Angeles';
+    return 'America/Los_Angeles';
   }
 
-  // For international locations, default to UTC instead of server timezone
-  // This provides predictable, unambiguous timestamps for all users
-  // Note: The previous fallback to Intl.DateTimeFormat().resolvedOptions().timeZone
-  // would return the server's local timezone, which is misleading for international queries
   return 'UTC';
 }
 

--- a/tests/integration/visualization-lightning.test.ts
+++ b/tests/integration/visualization-lightning.test.ts
@@ -99,15 +99,43 @@ describe('Weather Imagery (v1.5.0)', () => {
       ).rejects.toThrow();
     });
 
-    it('should reject satellite imagery (not yet implemented)', async () => {
-      await expect(
-        getWeatherImagery({
-          latitude: 40.7128,
-          longitude: -74.006,
-          type: 'satellite',
-          animated: false
-        })
-      ).rejects.toThrow('not yet implemented');
+    it('should return GOES GeoColor satellite imagery via NASA GIBS', async () => {
+      const result = await getWeatherImagery({
+        latitude: 40.7128,
+        longitude: -74.006,
+        type: 'satellite',
+        animated: false
+      });
+
+      expect(result.type).toBe('satellite');
+      expect(result.source).toContain('GIBS');
+      expect(result.frames.length).toBe(1);
+      expect(result.frames[0].url).toContain('gibs.earthdata.nasa.gov');
+      expect(result.frames[0].url).toContain('GOES-East_ABI_GeoColor');
+    });
+
+    it('should select GOES-West for far-western longitudes', async () => {
+      const result = await getWeatherImagery({
+        latitude: 21.3069, // Honolulu
+        longitude: -157.8583,
+        type: 'satellite',
+        animated: false
+      });
+
+      expect(result.frames[0].url).toContain('GOES-West_ABI_GeoColor');
+    });
+
+    it('should return a single latest snapshot for satellite even if animated requested', async () => {
+      const result = await getWeatherImagery({
+        latitude: 40.7128,
+        longitude: -74.006,
+        type: 'satellite',
+        animated: true
+      });
+
+      // Satellite does not animate (GIBS sub-daily timestamps are irregular).
+      expect(result.animated).toBe(false);
+      expect(result.frames.length).toBe(1);
     });
   });
 });

--- a/tests/unit/gibs.test.ts
+++ b/tests/unit/gibs.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { GibsService } from '../../src/services/gibs.js';
+
+describe('GibsService (satellite imagery)', () => {
+  const service = new GibsService();
+
+  describe('layer selection', () => {
+    it('uses GOES-East for the eastern/central US', () => {
+      const [frame] = service.getSatelliteImagery(40.7128, -74.006); // New York
+      expect(frame.url).toContain('GOES-East_ABI_GeoColor');
+    });
+
+    it('uses GOES-West for far-western/Pacific longitudes', () => {
+      const [frame] = service.getSatelliteImagery(21.3069, -157.8583); // Honolulu
+      expect(frame.url).toContain('GOES-West_ABI_GeoColor');
+    });
+  });
+
+  describe('latest frame (non-animated)', () => {
+    it('returns exactly one frame with a valid GIBS WMTS tile URL', () => {
+      const frames = service.getSatelliteImagery(39.7392, -104.9903); // Denver
+      expect(frames).toHaveLength(1);
+      const url = frames[0].url;
+      expect(url).toContain('https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/');
+      expect(url).toContain('GoogleMapsCompatible_Level7');
+      expect(url).toMatch(/\/\d+\/\d+\/\d+\.png$/); // /{z}/{y}/{x}.png
+    });
+
+    it('omits the time dimension for the latest frame', () => {
+      const [frame] = service.getSatelliteImagery(39.7392, -104.9903);
+      // No ISO timestamp segment in the latest-frame URL.
+      expect(frame.url).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  describe('tile coordinate safety', () => {
+    it('clamps polar latitudes without producing NaN tile indices', () => {
+      const [frame] = service.getSatelliteImagery(89.9, -100); // near North Pole
+      const match = frame.url.match(/\/(\d+)\/(\d+)\/(\d+)\.png$/);
+      expect(match).not.toBeNull();
+      const [, z, y, x] = match!.map(Number);
+      expect(Number.isInteger(z)).toBe(true);
+      expect(Number.isInteger(y)).toBe(true);
+      expect(Number.isInteger(x)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/imagery-handler.test.ts
+++ b/tests/unit/imagery-handler.test.ts
@@ -85,15 +85,17 @@ describe('Weather Imagery Handler', () => {
       ).rejects.toThrow('Invalid imagery type');
     });
 
-    it('should reject satellite type (not yet implemented)', async () => {
-      await expect(
-        getWeatherImagery({
-          latitude: 40.7128,
-          longitude: -74.006,
-          type: 'satellite',
-          animated: false
-        })
-      ).rejects.toThrow('not yet implemented');
+    it('should return satellite imagery via NASA GIBS', async () => {
+      const result = await getWeatherImagery({
+        latitude: 40.7128,
+        longitude: -74.006,
+        type: 'satellite',
+        animated: false
+      });
+
+      expect(result.type).toBe('satellite');
+      expect(result.source).toContain('GIBS');
+      expect(result.frames[0].url).toContain('gibs.earthdata.nasa.gov');
     });
 
     it('should reject non-boolean animated parameter', async () => {
@@ -105,46 +107,6 @@ describe('Weather Imagery Handler', () => {
           animated: 'yes' as any
         })
       ).rejects.toThrow('animated parameter must be a boolean');
-    });
-
-    it('should reject non-array layers parameter', async () => {
-      await expect(
-        getWeatherImagery({
-          latitude: 40.7128,
-          longitude: -74.006,
-          type: 'precipitation',
-          animated: false,
-          layers: 'layer1' as any
-        })
-      ).rejects.toThrow('layers parameter must be an array');
-    });
-
-    it('should reject too many layers', async () => {
-      const tooManyLayers = Array.from({ length: 11 }, (_, i) => `layer${i}`);
-
-      await expect(
-        getWeatherImagery({
-          latitude: 40.7128,
-          longitude: -74.006,
-          type: 'precipitation',
-          animated: false,
-          layers: tooManyLayers
-        })
-      ).rejects.toThrow('Maximum 10 layers allowed');
-    });
-
-    it('should accept valid layers parameter', async () => {
-      mockGetPrecipitationRadar.mockResolvedValue([]);
-
-      const result = await getWeatherImagery({
-        latitude: 40.7128,
-        longitude: -74.006,
-        type: 'precipitation',
-        animated: false,
-        layers: ['base', 'overlay']
-      });
-
-      expect(result).toBeDefined();
     });
 
     it('should default animated to false when not provided', async () => {
@@ -564,34 +526,15 @@ describe('Weather Imagery Handler', () => {
       expect(result.location.longitude).toBe(151.2093);
     });
 
-    it('should handle empty layers array', async () => {
-      mockGetPrecipitationRadar.mockResolvedValue([]);
-
+    it('should select GOES-West satellite for far-western longitudes', async () => {
       const result = await getWeatherImagery({
-        latitude: 40.7128,
-        longitude: -74.006,
-        type: 'precipitation',
-        animated: false,
-        layers: []
+        latitude: 61.2181,
+        longitude: -149.9003, // Anchorage
+        type: 'satellite',
+        animated: false
       });
 
-      expect(result).toBeDefined();
-    });
-
-    it('should handle exactly 10 layers', async () => {
-      mockGetPrecipitationRadar.mockResolvedValue([]);
-
-      const layers = Array.from({ length: 10 }, (_, i) => `layer${i}`);
-
-      const result = await getWeatherImagery({
-        latitude: 40.7128,
-        longitude: -74.006,
-        type: 'precipitation',
-        animated: false,
-        layers
-      });
-
-      expect(result).toBeDefined();
+      expect(result.frames[0].url).toContain('GOES-West_ABI_GeoColor');
     });
   });
 });

--- a/tests/unit/timezone.test.ts
+++ b/tests/unit/timezone.test.ts
@@ -181,59 +181,42 @@ describe('Timezone Utilities', () => {
   });
 
   describe('guessTimezoneFromCoords', () => {
-    it('should guess New York timezone from East Coast coords', () => {
-      const result = guessTimezoneFromCoords(40.7128, -74.0060); // NYC
-
-      expect(result).toBe('America/New_York');
+    // Backed by tz-lookup for accurate global coordinate -> IANA resolution.
+    it('should resolve New York timezone from East Coast coords', () => {
+      expect(guessTimezoneFromCoords(40.7128, -74.006)).toBe('America/New_York');
     });
 
-    it('should guess timezone from Central US coords', () => {
-      // Note: guessTimezoneFromCoords uses simple longitude boundaries
-      // Chicago at -87.6298 falls into Denver zone due to >= -104 check
-      const result = guessTimezoneFromCoords(41.8781, -87.6298); // Chicago coords
-
-      // Should return a valid US timezone
-      expect(result).toMatch(/America\/(New_York|Chicago|Denver|Los_Angeles)/);
+    it('should resolve Central US timezone precisely', () => {
+      expect(guessTimezoneFromCoords(41.8781, -87.6298)).toBe('America/Chicago');
     });
 
-    it('should guess timezone from Mountain coords', () => {
-      // Denver at -104.9903 falls into Los Angeles zone due to >= -125 check
-      const result = guessTimezoneFromCoords(39.7392, -104.9903); // Denver coords
-
-      // Should return a valid US timezone
-      expect(result).toMatch(/America\/(Denver|Los_Angeles)/);
+    it('should resolve Mountain timezone precisely', () => {
+      expect(guessTimezoneFromCoords(39.7392, -104.9903)).toBe('America/Denver');
     });
 
-    it('should guess Los Angeles timezone from West Coast coords', () => {
-      const result = guessTimezoneFromCoords(34.0522, -118.2437); // LA
-
-      expect(result).toBe('America/Los_Angeles');
+    it('should resolve Los Angeles timezone from West Coast coords', () => {
+      expect(guessTimezoneFromCoords(34.0522, -118.2437)).toBe('America/Los_Angeles');
     });
 
-    it('should fallback to system timezone for non-US coords', () => {
-      const result = guessTimezoneFromCoords(51.5074, -0.1278); // London
+    it('should resolve no-DST zones like Arizona', () => {
+      expect(guessTimezoneFromCoords(33.4484, -112.074)).toBe('America/Phoenix');
+    });
 
-      // Should return either system timezone or UTC
+    it('should resolve international timezones (London, Sydney, Tokyo)', () => {
+      expect(guessTimezoneFromCoords(51.5074, -0.1278)).toBe('Europe/London');
+      expect(guessTimezoneFromCoords(-33.8688, 151.2093)).toBe('Australia/Sydney');
+      expect(guessTimezoneFromCoords(35.6762, 139.6503)).toBe('Asia/Tokyo');
+    });
+
+    it('should resolve sub-regional US zones accurately', () => {
+      // Central Indiana observes Eastern time, not Central.
+      expect(guessTimezoneFromCoords(40.0, -86.0)).toBe('America/Indiana/Indianapolis');
+    });
+
+    it('should always return a valid IANA string, even at the poles', () => {
+      const result = guessTimezoneFromCoords(-90, 0);
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
-    });
-
-    it('should handle coordinates at timezone boundaries', () => {
-      // The function uses simple longitude ranges:
-      // >= -75: New York, >= -87: Chicago, >= -104: Denver, >= -125: LA
-      const eastern = guessTimezoneFromCoords(40.0, -74.0); // East of -75
-      const central = guessTimezoneFromCoords(40.0, -86.0); // Between -75 and -87
-
-      expect(eastern).toBe('America/New_York');
-      // -86 is >= -87, so returns Chicago
-      expect(central).toBe('America/Chicago');
-    });
-
-    it('should return UTC as ultimate fallback', () => {
-      // Coordinates far outside US
-      const result = guessTimezoneFromCoords(-90, 0);
-
-      expect(typeof result).toBe('string');
     });
   });
 

--- a/tests/unit/v1.6.1-fixes.test.ts
+++ b/tests/unit/v1.6.1-fixes.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { redactCoordinatesForLogging } from '../../src/utils/logger.js';
+import { guessTimezoneFromCoords } from '../../src/utils/timezone.js';
 
 describe('v1.6.1 Security & Quality Fixes', () => {
   describe('Coordinate Redaction (Privacy Fix)', () => {
@@ -196,49 +197,27 @@ describe('v1.6.1 Security & Quality Fixes', () => {
     });
   });
 
-  describe('Timezone Fallback to UTC', () => {
-    /**
-     * Simulate the guessTimezoneFromCoords function behavior
-     * This tests the fix that defaults to UTC instead of server timezone
-     * Note: This uses if-else logic to match the actual implementation
-     */
-    function guessTimezone(lat: number, lon: number): string {
-      // US timezone heuristic (order matters - checked from east to west)
-      if (lat >= 24 && lat <= 50 && lon >= -125 && lon <= -66) {
-        if (lon >= -75) return 'America/New_York';
-        else if (lon >= -87) return 'America/Chicago';
-        else if (lon >= -104) return 'America/Denver';
-        else if (lon >= -125) return 'America/Los_Angeles';
-      }
-      // Default to UTC for international (not server timezone)
-      return 'UTC';
-    }
+  describe('Timezone resolution (international accuracy)', () => {
+    // The original v1.6.1 fix avoided returning the *server* timezone for
+    // international queries (it fell back to UTC). That guarantee still holds,
+    // and resolution is now accurate via tz-lookup (see v1.8 work).
 
-    it('should return UTC for international locations', () => {
-      expect(guessTimezone(51.5074, -0.1278)).toBe('UTC'); // London
-      expect(guessTimezone(48.8566, 2.3522)).toBe('UTC'); // Paris
-      expect(guessTimezone(-33.8688, 151.2093)).toBe('UTC'); // Sydney
-      expect(guessTimezone(35.6762, 139.6503)).toBe('UTC'); // Tokyo
+    it('should resolve correct (non-server) timezones for international locations', () => {
+      expect(guessTimezoneFromCoords(51.5074, -0.1278)).toBe('Europe/London');
+      expect(guessTimezoneFromCoords(48.8566, 2.3522)).toBe('Europe/Paris');
+      expect(guessTimezoneFromCoords(-33.8688, 151.2093)).toBe('Australia/Sydney');
+      expect(guessTimezoneFromCoords(35.6762, 139.6503)).toBe('Asia/Tokyo');
     });
 
     it('should still handle US timezones correctly', () => {
-      expect(guessTimezone(40.7128, -74.0060)).toBe('America/New_York'); // NYC (-74)
-      // Test a location clearly in Chicago timezone
-      expect(guessTimezone(41.8781, -86.0)).toBe('America/Chicago'); // Indiana (-86)
-      // Test a location in Denver timezone
-      expect(guessTimezone(39.7392, -103.0)).toBe('America/Denver'); // Denver (-103)
-      // Test LA
-      expect(guessTimezone(34.0522, -118.2437)).toBe('America/Los_Angeles'); // LA (-118)
-
-      // Note: The simplified heuristic has boundary issues
-      // Real Chicago (-87.6) falls into Denver zone due to >= -104 check
-      expect(guessTimezone(41.8781, -87.6298)).toBe('America/Denver'); // Boundary case
+      expect(guessTimezoneFromCoords(40.7128, -74.006)).toBe('America/New_York');
+      expect(guessTimezoneFromCoords(41.8781, -87.6298)).toBe('America/Chicago');
+      expect(guessTimezoneFromCoords(39.7392, -104.9903)).toBe('America/Denver');
+      expect(guessTimezoneFromCoords(34.0522, -118.2437)).toBe('America/Los_Angeles');
     });
 
-    it('should not return server timezone for non-US locations', () => {
-      const internationalTimezone = guessTimezone(51.5074, -0.1278);
-      expect(internationalTimezone).toBe('UTC');
-      expect(internationalTimezone).not.toContain('America/');
+    it('should never return an America/* zone for a European location', () => {
+      expect(guessTimezoneFromCoords(51.5074, -0.1278)).not.toContain('America/');
     });
   });
 


### PR DESCRIPTION
Implements the remaining incomplete-features audit items + the international-usability improvement, on a dedicated branch.

## What's included

### Item 2 — Satellite imagery ✅ (NASA GIBS)
RainViewer **discontinued satellite IR** (Jan 2026), so `get_weather_imagery type="satellite"` is now backed by **NASA GIBS** GOES-East/West ABI GeoColor (WMTS XYZ tiles, Western Hemisphere, day+night blend, no auth). Returns the latest snapshot. Live-verified tiles return HTTP 200.
- Satellite is **latest-snapshot only** — GIBS sub-daily timestamps are irregular, so guessing animation frames yields 404s. Radar/precipitation still animate via RainViewer.

### Item 3 — `layers` param ✅ (trimmed)
Removed from the schema and handler — it was validated but ignored, and RainViewer no longer supports overlay layers/color schemes.

### Item 4 — Global timezones ✅ (tz-lookup)
`guessTimezoneFromCoords` now uses `tz-lookup` for accurate worldwide IANA resolution (incl. `America/Phoenix`, `America/Indiana/Indianapolis`, and all international zones), with the old heuristic/UTC as a safety net. **Makes the server genuinely useful for international users.**

### Item 5 — NWPS fallback ✅ (warning log)
The heavy `getAllNWPSGauges` (~13MB) fallback now logs a `securityEvent` warning so a bbox-query regression (cf. v1.7.1) is noticed.

## New developer doc
`docs/development/DATA_SOURCE_BLOCKERS.md` — a living log of upstream API problems (RainViewer discontinuation, nowCOAST CloudFront 403, NCEI rate limits, NWPS contract change, GIBS satellite limitation) with live-check commands and restore notes, so future sessions can diagnose breakage fast.

## Notes on blockers hit
- **nowCOAST** (the obvious GOES `exportImage` source) returns CloudFront **403** from this dev environment, so it couldn't be verified here → chose **GIBS** (reachable, better fit). Documented.

## Validation
- [x] `npm run build` clean
- [x] Full suite **1084/1084** passing
- [x] Live-verified GIBS GOES-East/West tiles (HTTP 200) and tz-lookup results