### PR TITLE
chore(release): v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-22
+
 ### Added
 - **Satellite imagery** - `get_weather_imagery type="satellite"` is now implemented (was a "not yet implemented" stub) using NOAA GOES-East/West ABI GeoColor via NASA GIBS (Western Hemisphere coverage, day+night). Returns the latest snapshot.
 - **Accurate global timezones** - `guessTimezoneFromCoords` now uses `tz-lookup` for precise coordinate→IANA resolution worldwide (including no-DST zones like Arizona and sub-regional US zones), replacing the US-only longitude heuristic. Improves time formatting for international users.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dangahagan/weather-mcp",
-      "version": "1.7.1",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "MCP (Model Context Protocol) server providing weather data from NOAA and Open-Meteo APIs. Supports forecasts, current conditions, and historical weather data (1940-present) with no API keys required.",
   "mcpName": "io.github.dgahagan/weather-mcp",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Cuts the **v1.8.0** release. Bumps version `1.7.1` → `1.8.0` and finalizes the CHANGELOG.

## Highlights since 1.7.1
- **Satellite imagery** — `get_weather_imagery type="satellite"` now returns NOAA GOES-East/West GeoColor via NASA GIBS (was a stub)
- **NCEI climate normals** — real NOAA CDO integration for US locations (was a placeholder)
- **Accurate global timezones** — `guessTimezoneFromCoords` now uses `tz-lookup` worldwide
- **Removed** the unused `get_weather_imagery` `layers` parameter (minor breaking schema change → minor version bump)
- Added `securityEvent` warning on the heavy NWPS gauge-catalog fallback
- New `docs/development/DATA_SOURCE_BLOCKERS.md`

## After merge
Tag `v1.8.0` on main and `npm publish --access public` (2FA via YubiKey).

- [x] `npm run build` clean
- [x] `npm test` — 1084/1084 passing
- [x] `npm pack --dry-run` — v1.8.0, 243 files