### PR TITLE
feat: Universal location resolution, weather summary, and detail controls (v1.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-13
+
+### Added
+- **Universal location resolution across all weather tools** - Every location-based tool (`get_current_conditions`, `get_alerts`, `get_historical_weather`, `get_air_quality`, `get_marine_conditions`, `get_weather_imagery`, `get_lightning_activity`, `get_river_conditions`, `get_wildfire_info`) now accepts the same three location forms that `get_forecast` did: `latitude`+`longitude`, a saved `location_name`, or a free-text `city_name` (geocoded on demand). A shared `LOCATION_SCHEMA_PROPERTIES` fragment keeps the tool schemas consistent, and name-based lookups echo the resolved place and coordinates in a `**Location:**` header. This resolves the previous mismatch where saved-location guidance advertised calls the tool schemas rejected.
+- **`get_weather_summary` composite tool** - Answers broad "what's the weather like?" questions in a single call by aggregating current conditions, forecast, and alerts (optionally air quality and lightning) for one location. Accepts an `include` array, `detail`, and `days`. Location is resolved once and passed to each section so there is no repeated geocoding; a section that is unavailable (e.g. US-only alerts abroad) is noted rather than failing the whole summary.
+- **`detail` output control** - `get_forecast`, `get_alerts`, and `get_weather_imagery` accept `detail: "summary" | "standard" | "full"` (default `standard`) to trade completeness for token cost. Hourly forecasts are capped (24h summary / 48h standard) unless `full`; alerts include the full NWS description only at `full`; imagery returns direct URLs by default and embeds Markdown images only at `full`.
+
+### Changed
+- **Preset tiers reworked around a "summary-first" default.** The default `basic` preset (used when `ENABLED_TOOLS` is unset — what most users get) is now 6 tools led by `get_weather_summary`: `get_weather_summary`, `get_forecast`, `get_current_conditions`, `get_alerts`, `search_location`, `check_service_status`. `standard` adds history, air quality, and the four saved-location management tools (12 total). `full` adds the specialized environmental/safety tools (marine, imagery, lightning, river, wildfire) and is now the complete 17-tool set, identical to `all`. Because every tool accepts `city_name`/`location_name`, the default set answers most weather questions on its own.
+- The NOAA forecast path fetches point data once and reuses `gridId`/`gridX`/`gridY` for the forecast and gridpoint calls, avoiding duplicate upstream point lookups on a cold cache.
+
+### Fixed
+- `search_location` now escapes provider-returned strings (`name`, `display_name`) before embedding them in Markdown, matching the existing escaping of the user query.
+
 ## [1.10.0] - 2026-07-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This document provides context and guidelines for AI assistants (Claude, etc.) w
 **Weather MCP Server** is a Model Context Protocol (MCP) server providing weather data from NOAA and Open-Meteo APIs. It enables AI assistants to fetch real-time weather forecasts, current conditions, historical data, air quality, marine conditions, and severe weather alerts.
 
 - **Language:** TypeScript (Node.js)
-- **Version:** 1.10.0 (Production Ready)
+- **Version:** 1.11.0 (Production Ready)
 - **License:** MIT
 - **MCP SDK:** @modelcontextprotocol/sdk v1.21.0
 
@@ -68,24 +68,28 @@ src/
 4. **Caching Strategy:** LRU cache with TTL based on data volatility (see `src/config/cache.ts`)
 5. **Error Hierarchy:** Custom error classes for different failure scenarios
 
-## Key Features (16 MCP Tools)
+## Key Features (17 MCP Tools)
 
-1. **get_forecast** - 7-day forecasts (NOAA/Open-Meteo, auto-select by location) - Supports saved locations via `location_name` and free-text place names via `city_name` (geocoded)
+All location-based tools accept coordinates, a saved `location_name`, or a
+free-text `city_name` (geocoded on demand) — see [Currently Supported Tools](#currently-supported-tools).
+
+1. **get_forecast** - 7-day forecasts (NOAA/Open-Meteo, auto-select by location); `detail` output control
 2. **get_current_conditions** - Current weather + fire weather indices (NOAA, US only)
-3. **get_alerts** - Weather alerts/warnings (NOAA, US only)
+3. **get_alerts** - Weather alerts/warnings (NOAA, US only); `detail` output control
 4. **get_historical_weather** - Historical data 1940-present (Open-Meteo, global)
-5. **check_service_status** - API health check (all services)
-6. **search_location** - Location search/geocoding (Nominatim/OSM, better small town coverage)
-7. **get_air_quality** - Air quality index + pollutants (Open-Meteo, global)
-8. **get_marine_conditions** - Wave height, swell, currents (Open-Meteo, global)
-9. **get_weather_imagery** - Weather radar/precipitation imagery (RainViewer, global)
-10. **get_lightning_activity** - Real-time lightning detection (Blitzortung.org, global)
-11. **get_river_conditions** - River levels and flood monitoring (NOAA/USGS, US only)
-12. **get_wildfire_info** - Active wildfire tracking (NIFC, US only)
-13. **save_location** - Save frequently used locations with aliases (NEW in v1.7.0)
-14. **list_saved_locations** - View all saved locations (NEW in v1.7.0)
-15. **get_saved_location** - Get details for a saved location (NEW in v1.7.0)
-16. **remove_saved_location** - Delete a saved location (NEW in v1.7.0)
+5. **get_weather_summary** - One-call overview: current + forecast + alerts (+ optional air quality, lightning) (NEW in v1.11.0)
+6. **check_service_status** - API health check (all services)
+7. **search_location** - Location search/geocoding (Nominatim/OSM, better small town coverage)
+8. **get_air_quality** - Air quality index + pollutants (Open-Meteo, global)
+9. **get_marine_conditions** - Wave height, swell, currents (Open-Meteo, global)
+10. **get_weather_imagery** - Weather radar/precipitation imagery (RainViewer, global); `detail` controls URL vs embedded images
+11. **get_lightning_activity** - Real-time lightning detection (Blitzortung.org, global)
+12. **get_river_conditions** - River levels and flood monitoring (NOAA/USGS, US only)
+13. **get_wildfire_info** - Active wildfire tracking (NIFC, US only)
+14. **save_location** - Save frequently used locations with aliases (NEW in v1.7.0)
+15. **list_saved_locations** - View all saved locations (NEW in v1.7.0)
+16. **get_saved_location** - Get details for a saved location (NEW in v1.7.0)
+17. **remove_saved_location** - Delete a saved location (NEW in v1.7.0)
 
 ## Development Guidelines
 
@@ -468,14 +472,17 @@ your_tool: {
 
 ### Currently Supported Tools
 
-- ✅ `get_forecast` - Full support for `location_name` (saved) and `city_name` (geocoded on demand)
+As of v1.11.0, **every location-based weather tool** accepts `location_name`
+(saved) and `city_name` (geocoded on demand) in addition to `latitude`/`longitude`,
+via the shared `resolveLocationAsync` helper and the `LOCATION_SCHEMA_PROPERTIES`
+schema fragment in `src/index.ts`. Name-based lookups echo the resolved place in a
+`**Location:**` header (see `formatLocationLine`/`prependLocationLine` in
+`src/utils/locationResolver.ts`):
 
-**Coming Soon:**
-- `get_current_conditions`
-- `get_alerts`
-- `get_air_quality`
-- `get_marine_conditions`
-- All other weather tools
+- ✅ `get_forecast`, `get_current_conditions`, `get_alerts`, `get_historical_weather`
+- ✅ `get_air_quality`, `get_marine_conditions`, `get_weather_imagery`
+- ✅ `get_lightning_activity`, `get_river_conditions`, `get_wildfire_info`
+- ✅ `get_weather_summary` (composite; resolves once, fans out to the above)
 
 ## Common Tasks
 
@@ -538,12 +545,13 @@ npm audit             # No critical vulnerabilities
 
 ## Project Status
 
-- **Version:** 1.10.0
+- **Version:** 1.11.0
 - **Status:** Production Ready ✅
+- **New in v1.11.0:** Universal location resolution (`location_name`/`city_name` on every location-based tool), `get_weather_summary` composite tool, `detail` output control (forecast/alerts/imagery), and a "summary-first" 6-tool default `basic` preset led by `get_weather_summary` (history, air quality, saved-location CRUD, and specialized tools live in `standard`/`full`)
 - **New in v1.10.0:** Unit localization — imperial/metric (plus per-unit overrides and 12h/24h) via `WEATHER_UNITS` env or a per-call `units` parameter on forecast/current/historical tools
 - **New in v1.9.0:** `city_name` parameter for `get_forecast` — request a forecast by free-text place name (geocoded on demand, with caching)
 - **Security Rating:** A- (Excellent, 93/100)
-- **Test Coverage:** 1,129 tests, 100% pass rate
+- **Test Coverage:** 1,149 tests, 100% pass rate
 - **Code Quality:** A+ (Excellent, 97.5/100)
 
 ## Useful References
@@ -566,6 +574,6 @@ npm audit             # No critical vulnerabilities
 
 ---
 
-**Last Updated:** 2026-07-13 (v1.10.0)
+**Last Updated:** 2026-07-13 (v1.11.0)
 
 This document should be updated whenever major architectural changes are made or new patterns are introduced.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Tests](https://img.shields.io/badge/tests-1%2C129%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 
-**Give your AI assistant real weather data — 16 tools, zero API keys, zero signup, zero cost.**
+**Give your AI assistant real weather data — 17 tools, zero API keys, zero signup, zero cost.**
 
 Weather MCP is a [Model Context Protocol](https://modelcontextprotocol.io) server that connects AI assistants (Claude, Cursor, Cline, Zed, and any other MCP client) to live weather data: forecasts, current conditions, alerts, air quality, marine conditions, lightning, radar, rivers, wildfires, and 85+ years of historical weather. It's built entirely on free public data sources — NOAA, Open-Meteo, USGS, NIFC, RainViewer, and Blitzortung.org — so there is nothing to sign up for and no key to paste in.
 
@@ -47,13 +47,13 @@ Choose this one if you want:
 - **No API keys** — install to first forecast in under a minute. Nothing to configure, nothing to leak into a repo.
 - **Fully open source** — MIT licensed, readable TypeScript, 1,129 tests. Audit it, fork it, fix it.
 - **Privacy-respecting** — your queries go directly from your machine to public weather APIs. No middleman server, no telemetry.
-- **Breadth** — 16 tools covering weather, safety hazards (lightning, floods, wildfires), marine conditions, air quality, and historical data back to 1940. Most weather MCPs stop at forecasts.
+- **Breadth** — 17 tools covering weather, safety hazards (lightning, floods, wildfires), marine conditions, air quality, and historical data back to 1940. Most weather MCPs stop at forecasts.
 
 The tradeoff is honest: US data (NOAA) is richer than international data (Open-Meteo), some tools are US-only, and free APIs come with fair-use rate limits. See [Coverage & Limitations](#coverage--limitations).
 
 ## Tools
 
-All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
+All 17 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 
 | Tool | What it does | Coverage |
 |------|-------------|----------|
@@ -61,6 +61,7 @@ All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 | `get_current_conditions` | Real-time observations: temperature, wind, heat index/wind chill, snow depth, optional fire-weather indices | 🇺🇸 US |
 | `get_alerts` | Active watches, warnings, and advisories sorted by severity | 🇺🇸 US |
 | `get_historical_weather` | Hourly/daily observations from 1940 to present | 🌍 Global |
+| `get_weather_summary` | One-call overview combining current conditions, forecast, and alerts (optionally air quality and lightning) | 🌍 Global |
 | `search_location` | Geocode place names to coordinates ("Paris" → 48.85, 2.35) | 🌍 Global |
 | `get_air_quality` | AQI (US/European scales), pollutants, UV index, health guidance | 🌍 Global |
 | `get_marine_conditions` | Wave height, swell, ocean currents, Douglas Sea Scale — includes Great Lakes and major US bays | 🌍 Global |
@@ -74,7 +75,11 @@ All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 | `get_saved_location` | Details for one saved location | — |
 | `remove_saved_location` | Delete a saved location | — |
 
-> **Default preset:** to keep your AI's context lean, the server exposes 5 essential tools by default (`forecast`, `current_conditions`, `alerts`, `search_location`, `check_service_status`). Enable everything with one environment variable — see [Tool Selection](#tool-selection).
+> **Default preset:** with no configuration, the server exposes 6 tools led by `get_weather_summary` (one call covers most "what's the weather?" questions), plus `forecast`, `current_conditions`, `alerts`, `search_location`, and `check_service_status`. Enable everything with one environment variable — see [Tool Selection](#tool-selection).
+
+> **Consistent location input:** every location-based tool accepts the same three forms — `latitude`+`longitude`, a saved `location_name` (e.g. `"home"`), or a free-text `city_name` (e.g. `"Bend, Oregon"`, geocoded automatically). When a name is used, the response echoes the resolved place and coordinates.
+
+> **Output verbosity:** high-volume tools (`get_forecast`, `get_alerts`, `get_weather_imagery`) accept `detail: "summary" | "standard" | "full"` (default `standard`) to trade completeness for token cost — e.g. `full` returns the complete alert text and uncapped hourly forecast.
 
 ## Feature highlights
 
@@ -185,10 +190,10 @@ Control which tools are exposed to reduce context overhead:
 
 | Preset | Tools |
 |--------|-------|
-| `basic` (default) | forecast, current_conditions, alerts, search_location, check_service_status |
-| `standard` | basic + historical_weather |
-| `full` | standard + air_quality |
-| `all` | everything — all 16 tools including marine, imagery, lightning, rivers, wildfire, and saved locations |
+| `basic` (default) | weather_summary, forecast, current_conditions, alerts, search_location, check_service_status |
+| `standard` | basic + historical_weather, air_quality, and saved-location tools |
+| `full` | everything — standard + marine, imagery, lightning, rivers, wildfire (same as `all`) |
+| `all` | all 17 tools |
 
 ```bash
 ENABLED_TOOLS=all                               # Use a preset
@@ -280,7 +285,7 @@ To report a vulnerability, see [SECURITY.md](./SECURITY.md).
 
 ## Documentation
 
-- **[Tool Reference](./docs/TOOLS.md)** — all 16 tools: parameters, examples, sample output
+- **[Tool Reference](./docs/TOOLS.md)** — all 17 tools: parameters, examples, sample output
 - **[Client Setup](./docs/CLIENT_SETUP.md)** — step-by-step for 8 MCP clients
 - **[Error Handling](./docs/ERROR_HANDLING.md)** — how failures are reported
 - **[Testing Guide](./docs/testing/TESTING_GUIDE.md)** — manual testing procedures

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,8 +1,10 @@
 # Tool Reference
 
-Complete reference for all 16 MCP tools provided by the Weather MCP Server.
+Complete reference for all 17 MCP tools provided by the Weather MCP Server.
 
-> **Note on tool presets:** By default the server exposes the `basic` preset (5 tools). Set `ENABLED_TOOLS=all` to enable everything. See [Tool Selection](../README.md#tool-selection) in the README.
+> **Note on tool presets:** By default the server exposes the `basic` preset (6 tools, led by `get_weather_summary`). Set `ENABLED_TOOLS=all` to enable everything. See [Tool Selection](../README.md#tool-selection) in the README.
+
+> **Common parameters (all location-based tools):** Every weather tool accepts the location in one of three ways — `latitude`+`longitude`, a saved `location_name` (e.g. `"home"`), or a free-text `city_name` (e.g. `"Bend, Oregon"`, geocoded on demand). Precedence: coordinates > `location_name` > `city_name`. When a name is used, the response echoes the resolved place in a `**Location:**` header. The high-volume tools (`get_forecast`, `get_alerts`, `get_weather_imagery`) also accept `detail`: `summary` | `standard` (default) | `full`.
 
 ## Contents
 
@@ -11,24 +13,25 @@ Complete reference for all 16 MCP tools provided by the Weather MCP Server.
 2. [get_current_conditions](#2-get_current_conditions) — Real-time observations, US
 3. [get_alerts](#3-get_alerts) — Watches/warnings/advisories, US
 4. [get_historical_weather](#4-get_historical_weather) — 1940–present, global
-5. [search_location](#5-search_location) — Geocoding, global
-6. [check_service_status](#6-check_service_status) — API health checks
+5. [get_weather_summary](#5-get_weather_summary) — One-call combined overview, global
+6. [search_location](#6-search_location) — Geocoding, global
+7. [check_service_status](#7-check_service_status) — API health checks
 
 **Environment & Safety**
 
-7. [get_air_quality](#7-get_air_quality) — AQI + pollutants, global
-8. [get_marine_conditions](#8-get_marine_conditions) — Waves/swell/currents, global
-9. [get_weather_imagery](#9-get_weather_imagery) — Radar, precipitation, and satellite imagery
-10. [get_lightning_activity](#10-get_lightning_activity) — Strike detection, global
-11. [get_river_conditions](#11-get_river_conditions) — River levels/flooding, US
-12. [get_wildfire_info](#12-get_wildfire_info) — Active fires, US
+8. [get_air_quality](#8-get_air_quality) — AQI + pollutants, global
+9. [get_marine_conditions](#9-get_marine_conditions) — Waves/swell/currents, global
+10. [get_weather_imagery](#10-get_weather_imagery) — Radar, precipitation, and satellite imagery
+11. [get_lightning_activity](#11-get_lightning_activity) — Strike detection, global
+12. [get_river_conditions](#12-get_river_conditions) — River levels/flooding, US
+13. [get_wildfire_info](#13-get_wildfire_info) — Active fires, US
 
 **Saved Locations**
 
-13. [save_location](#13-save_location)
-14. [list_saved_locations](#14-list_saved_locations)
-15. [get_saved_location](#15-get_saved_location)
-16. [remove_saved_location](#16-remove_saved_location)
+14. [save_location](#14-save_location)
+15. [list_saved_locations](#15-list_saved_locations)
+16. [get_saved_location](#16-get_saved_location)
+17. [remove_saved_location](#17-remove_saved_location)
 
 Also in this document:
 - [Finding Coordinates](#finding-coordinates)
@@ -83,11 +86,15 @@ Automatically selects the best data source: NOAA for US locations (more detailed
 Get current weather conditions for a location (US only).
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `include_fire_weather` (optional): Include fire weather indices (default: false)
 - `include_normals` (optional): Include climate normals for comparison (default: false)
 - `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Example:**
 ```
@@ -109,9 +116,14 @@ What are the current weather conditions in New York? (latitude: 40.7128, longitu
 Get active weather alerts, watches, warnings, and advisories for US locations.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `active_only` (optional): Show only active alerts (default: true)
+- `detail` (optional): `summary` (headline + timing), `standard` (default; adds instructions), or `full` (adds the complete NWS description)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Retrieves current weather alerts from the NOAA API for safety-critical weather information. Returns severity levels (Extreme, Severe, Moderate, Minor), urgency indicators, effective/expiration times, and affected areas. Alerts are automatically sorted by severity with the most critical first.
@@ -135,12 +147,16 @@ Retrieves current weather alerts from the NOAA API for safety-critical weather i
 Get historical weather observations for a location.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `start_date` (required): Start date in ISO format (YYYY-MM-DD)
 - `end_date` (required): End date in ISO format (YYYY-MM-DD)
 - `limit` (optional): Max observations to return (1-500, default: 168)
 - `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Data Source Selection:**
 The server automatically chooses the best data source based on your date range:
@@ -191,7 +207,34 @@ If you get "No historical data available":
 - Note: Most recent data has a 5-day delay
 - Very recent dates (last 5 days) may not be available in archival data yet
 
-### 5. search_location
+### 5. get_weather_summary
+Get a combined weather overview for a location in a single call.
+
+**Parameters:**
+- `latitude` / `longitude` (required*): Coordinates (-90 to 90 / -180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
+- `include` (optional): Array of sections to include — any of `current`, `forecast`, `alerts`, `air_quality`, `lightning` (default: `["current", "forecast", "alerts"]`)
+- `days` (optional): Forecast days when the forecast section is included (1-16, default: 7)
+- `detail` (optional): `summary` (default here), `standard`, or `full`
+- `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
+
+*Coordinates not required when `location_name` or `city_name` is provided. Precedence: coordinates > `location_name` > `city_name`.
+
+**Description:**
+Best for broad questions like "What's the weather like in Seattle?" or "Is it safe to hike today?". Aggregates several specialized tools for one location in a single response, resolving the location once so there is no repeated geocoding. Sections that are unavailable for a location (e.g. US-only alerts abroad) are noted rather than failing the whole summary. For a single specific data product, call that specialized tool directly.
+
+**Examples:**
+```
+"Give me a weather rundown for Bend, Oregon"
+"What's the weather like at home, and is there any lightning?"  (include=["current","forecast","lightning"])
+```
+
+**Returns:**
+- A `# Weather Summary` header with the resolved location and the included sections
+- Each requested section's full output (current conditions, forecast, alerts, air quality, lightning), separated by rules
+
+### 6. search_location
 Find coordinates for any location worldwide by name.
 
 **Parameters:**
@@ -216,7 +259,7 @@ Converts location names to coordinates. Returns multiple matches with detailed m
 - Country and region information
 - Feature type (capital, city, airport, etc.)
 
-### 6. check_service_status
+### 7. check_service_status
 Check the operational status of weather APIs and cache performance.
 
 **Parameters:** None
@@ -236,13 +279,17 @@ Check if the weather services are operational
 - Status page links and recommended actions if issues are detected
 - Overall service availability summary
 
-### 7. get_air_quality
+### 8. get_air_quality
 Get comprehensive air quality data for any location worldwide.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `forecast` (optional): Include hourly forecast for next 5 days (default: false)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides current air quality conditions using the Open-Meteo Air Quality API with automatic AQI scale selection (US AQI for US locations, European EAQI elsewhere). Includes health recommendations, pollutant concentrations, and UV index.
@@ -262,13 +309,17 @@ Provides current air quality conditions using the Open-Meteo Air Quality API wit
 - Activity recommendations for sensitive groups
 - Optional 5-day hourly forecast
 
-### 8. get_marine_conditions
+### 9. get_marine_conditions
 Get marine weather conditions including wave height, swell, ocean currents, and sea state with automatic source selection for Great Lakes and coastal bays.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `forecast` (optional): Include 5-day marine forecast (default: false)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides comprehensive marine weather data with intelligent dual-source support:
@@ -295,14 +346,19 @@ Provides comprehensive marine weather data with intelligent dual-source support:
 - Wave period for planning and safety
 - Optional 5-day forecast with daily summaries
 
-### 9. get_weather_imagery
+### 10. get_weather_imagery
 Get weather radar, precipitation, and satellite imagery for visual weather analysis.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `type` (optional): Imagery type - "precipitation" (default), "radar", or "satellite"
 - `animated` (optional): Return animated loop vs static image (default: false)
+- `detail` (optional): `summary`/`standard` (default) surface direct image URLs; `full` embeds Markdown images
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 - `layers` (optional): Additional map layers (reserved for future use)
 
 **Description:**
@@ -327,14 +383,18 @@ Provides access to weather imagery from two sources: precipitation/radar tiles f
 
 **Note:** Precipitation/radar coverage is global (RainViewer). Satellite coverage is Western Hemisphere only (GOES GeoColor via NASA GIBS).
 
-### 10. get_lightning_activity
+### 11. get_lightning_activity
 Get real-time lightning strike detection and safety assessment for outdoor activity planning.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `radius` (optional): Search radius in kilometers (1-500, default: 100)
 - `timeWindow` (optional): Historical time window in minutes (1-180, default: 60)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides real-time lightning strike detection from the Blitzortung.org global lightning detection network. Includes comprehensive safety assessment with 4 risk levels based on strike proximity. Critical for outdoor safety planning including boating, hiking, golfing, and other outdoor activities.
@@ -368,13 +428,17 @@ Provides real-time lightning strike detection from the Blitzortung.org global li
 
 **Note:** Data provided by Blitzortung.org, a free community-operated lightning detection network. May have regional coverage variations.
 
-### 11. get_river_conditions
+### 12. get_river_conditions
 Monitor river levels and flood status using NOAA and USGS data sources.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `radius` (optional): Search radius in kilometers (1-500, default: 50)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides comprehensive river and streamflow monitoring for flood safety and recreation planning. Automatically finds the nearest river gauges within the specified radius and reports current water levels, flood stages, and flow rates. Uses NOAA National Water Prediction Service (NWPS) for gauge locations and USGS Water Services for real-time streamflow data.
@@ -399,13 +463,17 @@ Provides comprehensive river and streamflow monitoring for flood safety and recr
 
 **Note:** US coverage only. Data provided by NOAA National Water Prediction Service and USGS Water Services.
 
-### 12. get_wildfire_info
+### 13. get_wildfire_info
 Monitor active wildfires and fire perimeters for safety and evacuation planning.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `radius` (optional): Search radius in kilometers (1-500, default: 100)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides critical wildfire monitoring and safety information using NIFC (National Interagency Fire Center) data. Reports active wildfires and prescribed burns within the specified radius, including fire size, containment status, and proximity-based safety assessments. Essential for residents in fire-prone regions and outdoor activity planning.
@@ -435,7 +503,7 @@ Provides critical wildfire monitoring and safety information using NIFC (Nationa
 
 **Note:** Data from NIFC WFIGS (Wildland Fire Interagency Geospatial Services). Always consult official sources for evacuation orders at https://inciweb.nwcg.gov/
 
-### 13. save_location
+### 14. save_location
 Save a location with an alias for easy reuse in weather queries.
 
 **Parameters:**
@@ -480,7 +548,7 @@ Saves a location to persistent storage (`~/.weather-mcp/locations.json`) for eas
 - Coordinates, timezone, and administrative region
 - Usage examples showing how to use with weather tools
 
-### 14. list_saved_locations
+### 15. list_saved_locations
 View all saved locations.
 
 **Parameters:** None
@@ -500,7 +568,7 @@ Lists all locations saved in your persistent storage with their aliases, names, 
 - Usage examples for each location
 - Total count of saved locations
 
-### 15. get_saved_location
+### 16. get_saved_location
 Get details for a specific saved location.
 
 **Parameters:**
@@ -522,7 +590,7 @@ Retrieves detailed information about a specific saved location, including coordi
 - Save and update timestamps
 - Usage examples
 
-### 16. remove_saved_location
+### 17. remove_saved_location
 Remove a saved location.
 
 **Parameters:**

--- a/docs/development/CODE_REVIEW_2026-07-13.md
+++ b/docs/development/CODE_REVIEW_2026-07-13.md
@@ -1,0 +1,317 @@
+# Code Review - 2026-07-13
+
+## Scope
+
+Reviewed the Weather MCP TypeScript server with emphasis on:
+
+- MCP tool count and whether the tool set is easy for AI assistants to use.
+- Opportunities to preserve the feature set while reducing tool-choice friction.
+- Output quality, token efficiency, and user-facing consistency.
+- Local build/type/test signal available from this workspace.
+
+## Summary
+
+The project exposes 16 MCP tools in code. The domain split is mostly sensible: forecasts, current conditions, alerts, historical weather, environmental/safety tools, imagery, and saved-location management each have distinct user intents and data sources. I would not remove the core weather/environmental tools.
+
+The biggest usability problem is not the total number of tools. It is that the location model is inconsistent. `get_forecast` accepts coordinates, saved `location_name`, or `city_name`, but most other weather tools only accept raw coordinates. Saved-location responses and docs imply broader support than the handlers actually provide. This will cause assistants to make invalid calls and forces unnecessary `search_location` hops.
+
+The second major issue is preset/documentation drift. The code's default `basic` preset contains 9 tools, while README/docs describe it as 5 tools. That matters because tool count is part of the user-facing product promise.
+
+## Findings
+
+### High: Saved-location guidance advertises calls that the tool schemas reject
+
+References:
+
+- `src/handlers/savedLocationsHandler.ts:241`
+- `src/handlers/savedLocationsHandler.ts:243`
+- `src/handlers/savedLocationsHandler.ts:244`
+- `src/handlers/savedLocationsHandler.ts:429`
+- `src/handlers/savedLocationsHandler.ts:430`
+- `src/handlers/savedLocationsHandler.ts:431`
+- `src/handlers/savedLocationsHandler.ts:432`
+- `src/index.ts:300`
+- `src/index.ts:328`
+- `src/index.ts:427`
+
+The save/get saved-location responses tell users and assistants that saved locations can be used with "any weather tool", including examples like:
+
+- `get_current_conditions(location_name="home")`
+- `get_alerts(location_name="home")`
+- `get_air_quality(location_name="home")`
+
+However, `get_current_conditions`, `get_alerts`, and `get_air_quality` schemas require `latitude` and `longitude`, and their handlers call `validateCoordinates(args)` directly. The same coordinate-only pattern exists for marine, imagery, lightning, river, and wildfire tools.
+
+Impact:
+
+- Assistants will follow the tool's own output and make calls that fail validation.
+- Saved locations feel unreliable even though the underlying location store works.
+- The server spends tool calls explaining invalid usage instead of answering weather questions.
+
+Recommendation:
+
+Extend the existing `resolveLocationAsync` pattern to all coordinate-based weather tools. Each tool should accept the same location alternatives:
+
+- `latitude` + `longitude`
+- `location_name`
+- `city_name`
+
+Then add a shared schema fragment so tool definitions stay consistent. If that is too large for one release, immediately correct the saved-location output to list only supported calls, then add universal location resolution as the next usability release.
+
+### Medium: Default tool preset documentation is wrong
+
+References:
+
+- `src/config/tools.ts:38`
+- `src/config/tools.ts:40`
+- `src/config/tools.ts:49`
+- `README.md:186`
+- `README.md:188`
+- `docs/TOOLS.md:5`
+
+The actual default `basic` preset includes 9 tools:
+
+- `get_forecast`
+- `get_current_conditions`
+- `get_alerts`
+- `search_location`
+- `check_service_status`
+- `save_location`
+- `list_saved_locations`
+- `get_saved_location`
+- `remove_saved_location`
+
+The README says default basic is 5 tools, and `docs/TOOLS.md` explicitly says "basic preset (5 tools)".
+
+Impact:
+
+- Users trying to reduce context overhead get a larger tool surface than documented.
+- Evaluating MCP usability becomes confusing because the advertised and actual default are different.
+
+Recommendation:
+
+Decide whether saved-location CRUD belongs in the default preset.
+
+Best usability options:
+
+1. Keep `basic` at 5 tools as documented: forecast, current, alerts, search, status. Move saved-location tools to `standard` or a new `locations` add-on.
+2. Keep code as-is and update README/docs to say default is 9 tools.
+
+I lean toward option 1 if "easier for AI assistants" is the priority. Saved locations are valuable, but they are management tools and add four choices to every default install.
+
+### Medium: Location lookup is not consistently available across weather tools
+
+References:
+
+- `src/index.ts:206`
+- `src/index.ts:222`
+- `src/index.ts:226`
+- `src/index.ts:300`
+- `src/index.ts:328`
+- `src/index.ts:455`
+- `src/index.ts:489`
+- `src/index.ts:526`
+- `src/index.ts:556`
+- `src/index.ts:586`
+- `src/utils/locationResolver.ts:153`
+
+`get_forecast` has the right assistant-friendly interface: the model can pass a city name directly, and the server handles geocoding/caching. Other location-based tools still force coordinates. This means a natural user question like "Is there lightning near Bend?" requires the assistant to call `search_location`, parse output text, then call `get_lightning_activity`.
+
+Impact:
+
+- More tool calls.
+- More chances for parsing mistakes.
+- `search_location` becomes a workaround instead of a deliberate disambiguation tool.
+
+Recommendation:
+
+Make direct geocoding and saved-location resolution a platform capability, not a forecast-only feature. Add a shared `LOCATION_SCHEMA_PROPERTIES` fragment and a helper like:
+
+```ts
+resolveWeatherLocation(args, locationStore, geocodingService)
+```
+
+Return the resolved display name in every weather output when the input was `location_name` or `city_name`, matching the forecast handler's existing behavior.
+
+### Medium: Output defaults are often too verbose for assistant workflows
+
+References:
+
+- `src/handlers/forecastHandler.ts:300`
+- `src/handlers/forecastHandler.ts:309`
+- `src/handlers/forecastHandler.ts:324`
+- `src/handlers/alertsHandler.ts:91`
+- `src/handlers/alertsHandler.ts:110`
+- `src/handlers/weatherImageryHandler.ts:120`
+
+The tools return rich Markdown, which is good for users, but some defaults can be expensive:
+
+- Hourly forecast can emit up to `days * 24`, with schema allowing 16 days. That can be 384 hourly sections.
+- Alerts include full descriptions and instructions for every alert.
+- Imagery embeds Markdown image tags directly, which may be useful in some clients but noisy in text-only agents.
+
+Impact:
+
+- Larger context usage.
+- Harder assistant summarization.
+- Slower responses for common "quick answer" questions.
+
+Recommendation:
+
+Add a common output-control parameter to high-volume tools:
+
+- `detail`: `summary | standard | full`
+- default `standard`
+
+Suggested behavior:
+
+- Forecast hourly default should cap to 24-48 hours unless the user explicitly requests more.
+- Alerts default should include headline/severity/timing/instruction summary, with `full` for full descriptions.
+- Imagery should include direct URLs and metadata first, with Markdown image embedding behind `render_markdown_images: true` or `detail: full`.
+
+This preserves the feature set while making the tools more predictable for AI assistants.
+
+### Low: NOAA forecast path can avoid repeated point/grid lookups
+
+References:
+
+- `src/handlers/forecastHandler.ts:292`
+- `src/handlers/forecastHandler.ts:301`
+- `src/handlers/forecastHandler.ts:367`
+- `src/handlers/forecastHandler.ts:381`
+- `src/services/noaa.ts:360`
+- `src/services/noaa.ts:405`
+
+`formatNOAAForecast` calls `getPointData` for timezone, then calls `getForecastByCoordinates`, which calls `getPointData` again. It may also call `getGridpointDataByCoordinates` for severe weather and again for winter data, although caching reduces the network impact.
+
+Impact:
+
+- With cache enabled, this is mostly extra cache lookups and code complexity.
+- With cache disabled or cold cache, it can become extra upstream calls.
+
+Recommendation:
+
+Fetch point data once and pass `gridId`, `gridX`, and `gridY` to lower-level NOAA service methods. A helper returning `{ pointData, forecast, gridpointData? }` would make this path clearer and reduce accidental duplicate upstream requests.
+
+### Low: `search_location` escapes the query but not provider-returned strings
+
+References:
+
+- `src/handlers/locationHandler.ts:60`
+- `src/handlers/locationHandler.ts:66`
+- `src/handlers/locationHandler.ts:74`
+
+The user query is Markdown-escaped, but returned fields such as `location.name` and `location.display_name` are inserted raw. These fields come from external providers and can contain characters that alter Markdown rendering.
+
+Impact:
+
+- Low security risk, but malformed provider text could produce confusing output.
+
+Recommendation:
+
+Apply the same `escapeMarkdown` helper to all provider-returned text fields used in Markdown output.
+
+## Tool Surface Assessment
+
+Current total: 16 tools.
+
+Actual default: 9 tools from the `basic` preset.
+
+Advertised default: 5 tools in README/docs.
+
+### Keep As Separate Tools
+
+These tool boundaries make sense and should stay separate because they represent distinct user intents or data products:
+
+- `get_forecast`
+- `get_current_conditions`
+- `get_alerts`
+- `get_historical_weather`
+- `search_location`
+- `check_service_status`
+- `get_air_quality`
+- `get_marine_conditions`
+- `get_weather_imagery`
+- `get_lightning_activity`
+- `get_river_conditions`
+- `get_wildfire_info`
+
+The environmental and safety tools overlap geographically but not semantically. Combining them into one large "environment" tool would likely make parameters and output less clear.
+
+### Best Candidates To Combine
+
+The four saved-location management tools are the only strong consolidation candidate:
+
+- `save_location`
+- `list_saved_locations`
+- `get_saved_location`
+- `remove_saved_location`
+
+They could become one `manage_saved_locations` tool with an `action` enum: `save`, `list`, `get`, `remove`.
+
+Tradeoff:
+
+- Fewer MCP tools and less default context.
+- More conditional input schema complexity.
+
+If compatibility matters, keep the existing four tools but remove them from `basic` and expose them in `standard`, `all`, or a new `locations` preset.
+
+### Consider Adding A Composite Tool
+
+Rather than eliminating domain tools, consider adding one high-level tool:
+
+`get_weather_summary`
+
+Purpose:
+
+- Answer common user questions with one call.
+- Inputs: same shared location fields, `include` array (`current`, `forecast`, `alerts`, `air_quality`, `lightning`, etc.), `detail`, `days`.
+- Defaults: current + forecast + alerts when available.
+
+This would be easier for assistants than deciding among 16 specialized tools for broad prompts like "What's the weather like in Seattle today, and is it safe to hike?"
+
+Keep specialized tools for precise follow-up questions.
+
+## Output Improvements
+
+Recommended cross-tool output pattern:
+
+1. Start with a short summary line.
+2. Include location resolution when a name was used.
+3. Put safety-critical issues before routine details.
+4. Include data source and timestamp.
+5. Make verbose details opt-in.
+
+Example shape:
+
+```md
+# Weather Summary
+
+**Location:** Bend, Oregon (44.0582, -121.3153)
+**Updated:** 2026-07-13 09:15 PDT
+
+**Bottom line:** Warm and dry today. No active NOAA alerts. Air quality is moderate.
+
+## Key Details
+...
+
+---
+*Data sources: NOAA, Open-Meteo*
+```
+
+## Verification
+
+Commands run:
+
+- `npx tsc --noEmit` - passed.
+- `npm run build` - not verified in this sandbox. It failed because TypeScript attempted to write compiled files under `/home/dgahagan/.../dist`, which is read-only in this environment; the writable workspace path is `/var/home/dgahagan/...`.
+- `npm test` - not verified in this sandbox. Vitest attempted to write a bundled config under `/home/dgahagan/.../node_modules/.vite-temp`, which is read-only here.
+
+## Recommended Priority Order
+
+1. Fix the saved-location mismatch, preferably by adding shared location resolution to every coordinate-based weather tool.
+2. Align the default preset docs and implementation.
+3. Add output `detail` controls for high-volume tools.
+4. Decide whether saved-location CRUD should remain four separate tools or move out of the default preset.
+5. Optimize NOAA forecast point/grid lookup reuse.
+6. Escape provider-returned strings in `search_location`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "MCP server giving AI assistants 16 weather tools with zero API keys: global forecasts, current conditions, alerts, air quality, marine conditions, lightning detection, radar imagery, river levels, wildfire tracking, and historical weather back to 1940. Built entirely on free public APIs (NOAA, Open-Meteo, USGS, NIFC).",
   "mcpName": "io.github.dgahagan/weather-mcp",
   "main": "dist/index.js",

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -19,6 +19,7 @@ export type ToolName =
   | 'get_current_conditions'
   | 'get_alerts'
   | 'get_historical_weather'
+  | 'get_weather_summary'
   | 'check_service_status'
   | 'search_location'
   | 'get_air_quality'
@@ -36,50 +37,60 @@ export type ToolName =
  * Tool presets for easy configuration
  */
 const TOOL_PRESETS: Record<string, ToolName[]> = {
-  // Essential weather tools - minimal overhead
+  // The DEFAULT preset (used when ENABLED_TOOLS is unset), so this is what most
+  // users actually see. Led by get_weather_summary (one call answers the common
+  // "what's the weather?" question), with the atomic follow-up tools and
+  // geocoding/health-check helpers. Every tool accepts city_name/location_name,
+  // so this 6-tool set covers the bulk of real usage on its own.
   basic: [
+    'get_weather_summary',
     'get_forecast',
     'get_current_conditions',
     'get_alerts',
     'search_location',
-    'check_service_status',
-    'save_location',
-    'list_saved_locations',
-    'get_saved_location',
-    'remove_saved_location'
+    'check_service_status'
   ],
 
-  // Basic + historical data
+  // Basic + history, air quality, and saved-location personalization
   standard: [
+    'get_weather_summary',
     'get_forecast',
     'get_current_conditions',
     'get_alerts',
     'get_historical_weather',
-    'search_location',
-    'check_service_status',
-    'save_location',
-    'list_saved_locations',
-    'get_saved_location',
-    'remove_saved_location'
-  ],
-
-  // Standard + environmental data
-  full: [
-    'get_forecast',
-    'get_current_conditions',
-    'get_alerts',
-    'get_historical_weather',
-    'search_location',
-    'check_service_status',
     'get_air_quality',
+    'search_location',
+    'check_service_status',
     'save_location',
     'list_saved_locations',
     'get_saved_location',
     'remove_saved_location'
   ],
 
-  // All available tools
+  // Standard + the specialized environmental & safety tools (everything)
+  full: [
+    'get_weather_summary',
+    'get_forecast',
+    'get_current_conditions',
+    'get_alerts',
+    'get_historical_weather',
+    'get_air_quality',
+    'get_marine_conditions',
+    'get_weather_imagery',
+    'get_lightning_activity',
+    'get_river_conditions',
+    'get_wildfire_info',
+    'search_location',
+    'check_service_status',
+    'save_location',
+    'list_saved_locations',
+    'get_saved_location',
+    'remove_saved_location'
+  ],
+
+  // All available tools (identical set to `full`)
   all: [
+    'get_weather_summary',
     'get_forecast',
     'get_current_conditions',
     'get_alerts',
@@ -110,6 +121,9 @@ const TOOL_ALIASES: Record<string, ToolName> = {
   'warnings': 'get_alerts',
   'historical': 'get_historical_weather',
   'history': 'get_historical_weather',
+  'summary': 'get_weather_summary',
+  'weather_summary': 'get_weather_summary',
+  'overview': 'get_weather_summary',
   'status': 'check_service_status',
   'location': 'search_location',
   'search': 'search_location',
@@ -246,6 +260,7 @@ function isToolName(name: string): name is ToolName {
     'get_current_conditions',
     'get_alerts',
     'get_historical_weather',
+    'get_weather_summary',
     'check_service_status',
     'search_location',
     'get_air_quality',

--- a/src/handlers/airQualityHandler.ts
+++ b/src/handlers/airQualityHandler.ts
@@ -3,7 +3,10 @@
  */
 
 import { OpenMeteoService } from '../services/openmeteo.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean } from '../utils/validation.js';
 import {
   getUSAQICategory,
   getEuropeanAQICategory,
@@ -17,15 +20,20 @@ import type { OpenMeteoAirQualityResponse } from '../types/openmeteo.js';
 interface AirQualityArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   forecast?: boolean;
 }
 
 export async function handleGetAirQuality(
   args: unknown,
-  openMeteoService: OpenMeteoService
+  openMeteoService: OpenMeteoService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as AirQualityArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const forecast = validateOptionalBoolean(
     (args as AirQualityArgs)?.forecast,
     'forecast',
@@ -43,14 +51,14 @@ export async function handleGetAirQuality(
   // Format the air quality data for display
   const output = formatAirQuality(airQualityData, latitude, longitude, forecast);
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/handlers/alertsHandler.ts
+++ b/src/handlers/alertsHandler.ts
@@ -3,26 +3,37 @@
  */
 
 import { NOAAService } from '../services/noaa.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean, validateDetail } from '../utils/validation.js';
 import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js';
 
 interface AlertsArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   active_only?: boolean;
+  detail?: 'summary' | 'standard' | 'full';
 }
 
 export async function handleGetAlerts(
   args: unknown,
-  noaaService: NOAAService
+  noaaService: NOAAService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as AlertsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const active_only = validateOptionalBoolean(
     (args as AlertsArgs)?.active_only,
     'active_only',
     true
   );
+  // Output verbosity: 'full' includes the complete NWS description text.
+  const detail = validateDetail((args as AlertsArgs)?.detail);
 
   // Get timezone for proper time formatting
   let timezone = guessTimezoneFromCoords(latitude, longitude); // fallback
@@ -107,26 +118,35 @@ export async function handleGetAlerts(
         output += `**Ends:** ${formatInTimezone(props.ends, timezone)}\n`;
       }
 
-      output += `\n**Description:**\n${props.description}\n`;
+      // Full NWS description text is verbose; include it only at detail=full.
+      if (detail === 'full' && props.description) {
+        output += `\n**Description:**\n${props.description}\n`;
+      }
 
-      if (props.instruction) {
+      // Actionable instructions are surfaced at standard and full (not summary).
+      if (detail !== 'summary' && props.instruction) {
         output += `\n**Instructions:**\n${props.instruction}\n`;
       }
 
       output += `\n**Recommended Response:** ${props.response}\n`;
       output += `**Sender:** ${props.senderName}\n\n`;
     }
+
+    if (detail !== 'full') {
+      output += `*Showing ${detail === 'summary' ? 'a condensed summary' : 'standard detail'}. `;
+      output += `Use detail="full" for complete alert descriptions.*\n\n`;
+    }
   }
 
   output += `---\n`;
   output += `*Data source: NOAA National Weather Service*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }

--- a/src/handlers/currentConditionsHandler.ts
+++ b/src/handlers/currentConditionsHandler.ts
@@ -5,7 +5,10 @@
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
 import { NCEIService } from '../services/ncei.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean } from '../utils/validation.js';
 import { convertToFahrenheit } from '../utils/temperatureConversion.js';
 import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
 import {
@@ -33,6 +36,8 @@ import { getClimateNormals, formatNormals, getDateComponents } from '../utils/no
 interface CurrentConditionsArgs extends UnitArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   include_fire_weather?: boolean;
   include_normals?: boolean;
 }
@@ -41,10 +46,13 @@ export async function handleGetCurrentConditions(
   args: unknown,
   noaaService: NOAAService,
   openMeteoService: OpenMeteoService,
-  nceiService: NCEIService
+  nceiService: NCEIService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as CurrentConditionsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const includeFireWeather = validateOptionalBoolean(
     (args as CurrentConditionsArgs)?.include_fire_weather,
     'include_fire_weather',
@@ -372,12 +380,12 @@ export async function handleGetCurrentConditions(
   output += `\n---\n`;
   output += `*Data source: NOAA National Weather Service*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }

--- a/src/handlers/forecastHandler.ts
+++ b/src/handlers/forecastHandler.ts
@@ -14,8 +14,10 @@ import {
   validateForecastDays,
   validateGranularity,
   validateOptionalBoolean,
+  validateDetail,
+  DetailLevel,
 } from '../utils/validation.js';
-import { resolveLocationAsync, ResolvedLocation } from '../utils/locationResolver.js';
+import { resolveLocationAsync, formatLocationLine } from '../utils/locationResolver.js';
 import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
 import { UnitPreferences } from '../config/units.js';
 import {
@@ -47,6 +49,24 @@ interface ForecastArgs extends UnitArgs {
   include_severe_weather?: boolean;
   include_normals?: boolean;
   source?: 'auto' | 'noaa' | 'openmeteo';
+  detail?: DetailLevel;
+}
+
+/**
+ * Cap the number of hourly forecast entries by verbosity level.
+ * Hourly forecasts can emit up to days*24 entries (384 at 16 days), which is
+ * expensive for assistant contexts. Unless the user asks for detail="full",
+ * cap to a short horizon; the daily view still covers the full requested range.
+ *
+ * @param detail - Requested verbosity
+ * @param days - Number of forecast days requested
+ * @returns Maximum hourly entries to emit
+ */
+function hourlyEntryCap(detail: DetailLevel, days: number): number {
+  const maxHours = days * 24;
+  if (detail === 'full') return maxHours;
+  if (detail === 'summary') return Math.min(24, maxHours);
+  return Math.min(48, maxHours); // standard default
 }
 
 /**
@@ -201,6 +221,8 @@ export async function handleGetForecast(
     'include_normals',
     false
   );
+  // Output verbosity: caps hourly output unless detail="full" (see hourlyEntryCap)
+  const detail = validateDetail((args as ForecastArgs)?.detail);
 
   // Resolve unit preferences (per-call params over the server default)
   const prefs = resolveUnitPreferences(args as ForecastArgs);
@@ -230,7 +252,8 @@ export async function handleGetForecast(
       include_precipitation_probability,
       include_severe_weather,
       include_normals,
-      prefs
+      prefs,
+      detail
     );
   } else {
     // Use Open-Meteo for international locations
@@ -243,7 +266,8 @@ export async function handleGetForecast(
       granularity,
       include_precipitation_probability,
       include_normals,
-      prefs
+      prefs,
+      detail
     );
   }
 
@@ -255,19 +279,6 @@ export async function handleGetForecast(
   }
 
   return result;
-}
-
-/**
- * Build a header line describing how a location name was resolved.
- * Returns an empty string for direct-coordinate requests (nothing to disclose).
- */
-function formatLocationLine(resolved: ResolvedLocation): string {
-  if (resolved.source === 'coordinates' || !resolved.location_name) {
-    return '';
-  }
-
-  const coords = `${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}`;
-  return `**Location:** ${resolved.location_name} (${coords})\n\n`;
 }
 
 /**
@@ -284,29 +295,29 @@ async function formatNOAAForecast(
   include_precipitation_probability: boolean,
   include_severe_weather: boolean,
   include_normals: boolean,
-  prefs: UnitPreferences
+  prefs: UnitPreferences,
+  detail: DetailLevel
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const noaaUnits = noaaUnitsParam(prefs);
-  // Get timezone for proper time formatting
-  let timezone = guessTimezoneFromCoords(latitude, longitude);
-  try {
-    const points = await noaaService.getPointData(latitude, longitude);
-    if (points.properties.timeZone) {
-      timezone = points.properties.timeZone;
-    }
-  } catch (error) {
-    // Use fallback timezone
-  }
+  // Fetch point data once. It yields both the timezone AND the grid coordinates,
+  // so downstream forecast/gridpoint calls use the grid-based methods directly
+  // instead of re-resolving the point (avoids duplicate upstream lookups on a
+  // cold cache). A point-data failure here propagates — the forecast can't be
+  // built without it anyway.
+  const points = await noaaService.getPointData(latitude, longitude);
+  const { gridId, gridX, gridY } = points.properties;
+  const timezone = points.properties.timeZone || guessTimezoneFromCoords(latitude, longitude);
+
   // Get forecast data based on granularity (units=us|si controls NWS output units)
   const forecast = granularity === 'hourly'
-    ? await noaaService.getHourlyForecastByCoordinates(latitude, longitude, noaaUnits)
-    : await noaaService.getForecastByCoordinates(latitude, longitude, noaaUnits);
+    ? await noaaService.getHourlyForecast(gridId, gridX, gridY, noaaUnits)
+    : await noaaService.getForecast(gridId, gridX, gridY, noaaUnits);
 
   // Determine how many periods to show
   let periods;
   if (granularity === 'hourly') {
-    // For hourly, show up to days * 24 hours
-    periods = forecast.properties.periods.slice(0, days * 24);
+    // Hourly output is capped by verbosity (see hourlyEntryCap) unless full
+    periods = forecast.properties.periods.slice(0, hourlyEntryCap(detail, days));
   } else {
     // For daily, show up to days * 2 (day/night periods)
     periods = forecast.properties.periods.slice(0, days * 2);
@@ -320,6 +331,9 @@ async function formatNOAAForecast(
     output += `**Updated:** ${formatInTimezone(forecast.properties.updated, timezone, 'medium', prefs.timeFormat)}\n`;
   }
   output += `**Showing:** ${periods.length} ${granularity === 'hourly' ? 'hours' : 'periods'}\n\n`;
+  if (granularity === 'hourly' && detail !== 'full' && forecast.properties.periods.length > periods.length) {
+    output += `*Hourly output capped at ${periods.length} hours (detail="${detail}"). Use detail="full" for the full ${days}-day hourly forecast.*\n\n`;
+  }
 
   for (const period of periods) {
     // For hourly forecasts, use the start time as the header since period names are empty
@@ -349,8 +363,8 @@ async function formatNOAAForecast(
 
     output += `**Forecast:** ${period.shortForecast}\n\n`;
 
-    // For daily forecasts, include detailed forecast
-    if (granularity === 'daily' && period.detailedForecast) {
+    // For daily forecasts, include the long detailed forecast (omitted at summary)
+    if (granularity === 'daily' && detail !== 'summary' && period.detailedForecast) {
       output += `${period.detailedForecast}\n\n`;
     }
   }
@@ -364,7 +378,7 @@ async function formatNOAAForecast(
   // Add severe weather probabilities if requested
   if (include_severe_weather) {
     try {
-      gridpointData = await noaaService.getGridpointDataByCoordinates(latitude, longitude);
+      gridpointData = await noaaService.getGridpointData(gridId, gridX, gridY);
       const severeWeatherSection = formatSevereWeather(gridpointData.properties);
       if (severeWeatherSection) {
         output += `\n${severeWeatherSection}`;
@@ -379,7 +393,7 @@ async function formatNOAAForecast(
   try {
     // Fetch gridpoint data if we haven't already
     if (!gridpointData) {
-      gridpointData = await noaaService.getGridpointDataByCoordinates(latitude, longitude);
+      gridpointData = await noaaService.getGridpointData(gridId, gridX, gridY);
     }
 
     // Calculate time range for forecast period
@@ -469,7 +483,8 @@ async function formatOpenMeteoForecast(
   granularity: 'daily' | 'hourly',
   include_precipitation_probability: boolean,
   include_normals: boolean,
-  prefs: UnitPreferences
+  prefs: UnitPreferences,
+  detail: DetailLevel
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   // Unit labels for output (Open-Meteo returns values already in requested units)
   const tempU = temperatureLabel(prefs);
@@ -492,9 +507,12 @@ async function formatOpenMeteoForecast(
   output += `**Forecast Days:** ${days}\n\n`;
 
   if (granularity === 'hourly' && forecast.hourly) {
-    // Format hourly data
+    // Format hourly data (capped by verbosity unless detail="full")
     const hourly = forecast.hourly;
-    const numHours = Math.min(hourly.time.length, days * 24);
+    const numHours = Math.min(hourly.time.length, hourlyEntryCap(detail, days));
+    if (detail !== 'full' && hourly.time.length > numHours) {
+      output += `*Hourly output capped at ${numHours} hours (detail="${detail}"). Use detail="full" for the full ${days}-day hourly forecast.*\n\n`;
+    }
 
     for (let i = 0; i < numHours; i++) {
       output += `## ${formatInTimezone(hourly.time[i], forecast.timezone, 'short', prefs.timeFormat)}\n`;

--- a/src/handlers/historicalWeatherHandler.ts
+++ b/src/handlers/historicalWeatherHandler.ts
@@ -4,6 +4,9 @@
 
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { validateHistoricalWeatherParams } from '../utils/validation.js';
 import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
 import {
@@ -20,10 +23,19 @@ import { ApiConstants, FormatConstants } from '../config/displayThresholds.js';
 export async function handleGetHistoricalWeather(
   args: unknown,
   noaaService: NOAAService,
-  openMeteoService: OpenMeteoService
+  openMeteoService: OpenMeteoService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude, start_date, end_date, limit = FormatConstants.defaultHistoricalLimit } = validateHistoricalWeatherParams(args);
+  // Resolve location first (coordinates, saved name, or geocoded city), then
+  // validate the date range. Coordinates from resolution are re-validated by
+  // validateHistoricalWeatherParams alongside the dates.
+  const resolved = await resolveLocationAsync(args as { latitude?: number; longitude?: number; location_name?: string; city_name?: string }, locationStore, geocodingService);
+  const { latitude, longitude, start_date, end_date, limit = FormatConstants.defaultHistoricalLimit } = validateHistoricalWeatherParams({
+    ...(args as Record<string, unknown>),
+    latitude: resolved.latitude,
+    longitude: resolved.longitude
+  });
   const prefs = resolveUnitPreferences(args as UnitArgs);
   const tempU = temperatureLabel(prefs);
   const windU = windSpeedLabel(prefs);
@@ -123,14 +135,14 @@ export async function handleGetHistoricalWeather(
           output += `\n`;
         }
 
-        return {
+        return prependLocationLine({
           content: [
             {
               type: 'text',
               text: output
             }
           ]
-        };
+        }, resolved);
       } else if (weatherData.daily) {
         // Format daily summaries
         let output = `# Historical Weather Data (Daily Summaries)\n\n`;
@@ -174,14 +186,14 @@ export async function handleGetHistoricalWeather(
           output += `\n`;
         }
 
-        return {
+        return prependLocationLine({
           content: [
             {
               type: 'text',
               text: output
             }
           ]
-        };
+        }, resolved);
       } else {
         throw new Error('No weather data available in response');
       }
@@ -201,14 +213,14 @@ export async function handleGetHistoricalWeather(
     );
 
     if (!observations.features || observations.features.length === 0) {
-      return {
+      return prependLocationLine({
         content: [
           {
             type: 'text',
             text: `No historical observations found for the specified date range (${start_date} to ${end_date}).\n\nThis may occur because:\n- The dates are outside the station's available data range\n- There are gaps in the observation records for this location\n- The weather station near this location may not have archived data for these dates\n\nNote: Historical weather data availability varies by location and weather station. Some stations have limited historical records.`
           }
         ]
-      };
+      }, resolved);
     }
 
     // Format the observations
@@ -236,13 +248,13 @@ export async function handleGetHistoricalWeather(
       output += `\n`;
     }
 
-    return {
+    return prependLocationLine({
       content: [
         {
           type: 'text',
           text: output
         }
       ]
-    };
+    }, resolved);
   }
 }

--- a/src/handlers/lightningHandler.ts
+++ b/src/handlers/lightningHandler.ts
@@ -13,9 +13,52 @@ import {
   LightningSafetyLevel
 } from '../types/lightning.js';
 import { blitzortungService } from '../services/blitzortung.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { validateLatitude, validateLongitude } from '../utils/validation.js';
 import { logger, redactCoordinatesForLogging } from '../utils/logger.js';
 import { ValidationError } from '../errors/ApiError.js';
+
+interface LightningActivityArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  city_name?: string;
+  radius?: number;
+  timeWindow?: number;
+}
+
+/**
+ * Tool entry point: resolve the location (coordinates, saved name, or geocoded
+ * city), fetch lightning activity, and format it with a resolved-location header.
+ */
+export async function handleGetLightningActivity(
+  args: unknown,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const typedArgs = (args ?? {}) as LightningActivityArgs;
+  const resolved = await resolveLocationAsync(typedArgs, locationStore, geocodingService);
+
+  const result = await getLightningActivity({
+    latitude: resolved.latitude,
+    longitude: resolved.longitude,
+    radius: typedArgs.radius,
+    timeWindow: typedArgs.timeWindow
+  });
+
+  const formatted = formatLightningActivityResponse(result);
+
+  return prependLocationLine({
+    content: [
+      {
+        type: 'text',
+        text: formatted
+      }
+    ]
+  }, resolved);
+}
 
 /**
  * Validate lightning activity request parameters

--- a/src/handlers/locationHandler.ts
+++ b/src/handlers/locationHandler.ts
@@ -63,7 +63,9 @@ export async function handleSearchLocation(
 
   for (let i = 0; i < results.length; i++) {
     const location = results[i];
-    output += `## ${i + 1}. ${location.name}\n\n`;
+    // Provider-returned strings (name, display_name, admin fields) are escaped
+    // before embedding — external text can otherwise alter Markdown rendering.
+    output += `## ${i + 1}. ${escapeMarkdown(location.name)}\n\n`;
 
     // Build location description
     const parts: string[] = [location.name];
@@ -71,7 +73,7 @@ export async function handleSearchLocation(
     if (location.admin2 && location.admin2 !== location.admin1) parts.push(location.admin2);
     if (location.country) parts.push(location.country);
 
-    output += `**Full Name:** ${location.display_name}\n`;
+    output += `**Full Name:** ${escapeMarkdown(location.display_name)}\n`;
     output += `**Coordinates:** ${location.latitude.toFixed(4)}°, ${location.longitude.toFixed(4)}°\n`;
 
     if (location.country_code) {

--- a/src/handlers/marineConditionsHandler.ts
+++ b/src/handlers/marineConditionsHandler.ts
@@ -6,7 +6,10 @@
 import { DateTime } from 'luxon';
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean } from '../utils/validation.js';
 import {
   formatWaveHeight,
   formatWavePeriod,
@@ -26,16 +29,21 @@ import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js'
 interface MarineConditionsArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   forecast?: boolean;
 }
 
 export async function handleGetMarineConditions(
   args: unknown,
   noaaService: NOAAService,
-  openMeteoService: OpenMeteoService
+  openMeteoService: OpenMeteoService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as MarineConditionsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const forecast = validateOptionalBoolean(
     (args as MarineConditionsArgs)?.forecast,
     'forecast',
@@ -86,14 +94,14 @@ export async function handleGetMarineConditions(
           forecast
         );
 
-        return {
+        return prependLocationLine({
           content: [
             {
               type: 'text',
               text: output
             }
           ]
-        };
+        }, resolved);
       } else {
         const redacted2 = redactCoordinatesForLogging(latitude, longitude);
         logger.info('NOAA gridpoint has no marine data, falling back to Open-Meteo', {
@@ -123,14 +131,14 @@ export async function handleGetMarineConditions(
   // Format the marine data for display
   const output = formatOpenMeteoMarineConditions(marineData, latitude, longitude, forecast);
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/handlers/riverConditionsHandler.ts
+++ b/src/handlers/riverConditionsHandler.ts
@@ -3,7 +3,9 @@
  */
 
 import { NOAAService } from '../services/noaa.js';
-import { validateCoordinates } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js';
 import { calculateDistance } from '../utils/distance.js';
 import type { NWPSGauge } from '../types/noaa.js';
@@ -11,15 +13,20 @@ import type { NWPSGauge } from '../types/noaa.js';
 interface RiverConditionsArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   radius?: number; // search radius in km (default: 50)
 }
 
 export async function handleGetRiverConditions(
   args: unknown,
-  noaaService: NOAAService
+  noaaService: NOAAService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as RiverConditionsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
 
   // Validate radius parameter
   let radius = (args as RiverConditionsArgs)?.radius ?? 50; // default 50 km
@@ -92,14 +99,14 @@ export async function handleGetRiverConditions(
   output += `*Data sources: NOAA National Water Prediction Service (NWPS), USGS Water Services*\n`;
   output += `*River conditions are updated hourly. Always consult official sources for critical decisions.*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/handlers/weatherImageryHandler.ts
+++ b/src/handlers/weatherImageryHandler.ts
@@ -6,9 +6,56 @@
 import { WeatherImageryParams, WeatherImageryResponse, ImageryType } from '../types/imagery.js';
 import { rainViewerService } from '../services/rainviewer.js';
 import { gibsService } from '../services/gibs.js';
-import { validateLatitude, validateLongitude } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateLatitude, validateLongitude, validateDetail, DetailLevel } from '../utils/validation.js';
 import { logger, redactCoordinatesForLogging } from '../utils/logger.js';
 import { ValidationError } from '../errors/ApiError.js';
+
+interface WeatherImageryArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  city_name?: string;
+  type?: ImageryType;
+  animated?: boolean;
+  detail?: DetailLevel;
+}
+
+/**
+ * Tool entry point: resolve the location (coordinates, saved name, or geocoded
+ * city), fetch imagery, and format it. Markdown image embeds are opt-in via
+ * detail="full"; the default surfaces direct URLs and metadata (lighter for
+ * text-only agents).
+ */
+export async function handleGetWeatherImagery(
+  args: unknown,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const typedArgs = (args ?? {}) as WeatherImageryArgs;
+  const resolved = await resolveLocationAsync(typedArgs, locationStore, geocodingService);
+  const detail = validateDetail(typedArgs.detail);
+
+  const result = await getWeatherImagery({
+    latitude: resolved.latitude,
+    longitude: resolved.longitude,
+    type: (typedArgs.type ?? 'precipitation') as ImageryType,
+    animated: typedArgs.animated
+  });
+
+  const formatted = formatWeatherImageryResponse(result, detail);
+
+  return prependLocationLine({
+    content: [
+      {
+        type: 'text',
+        text: formatted
+      }
+    ]
+  }, resolved);
+}
 
 /**
  * Validate imagery request parameters
@@ -97,9 +144,30 @@ export async function getWeatherImagery(params: WeatherImageryParams): Promise<W
 }
 
 /**
- * Format weather imagery response for display
+ * Render a single imagery frame line.
+ * At detail="full" the image is embedded as Markdown so rich clients render it;
+ * otherwise the direct URL is shown as text (cheaper, and usable by text-only
+ * agents that would otherwise carry an un-renderable image tag).
  */
-export function formatWeatherImageryResponse(response: WeatherImageryResponse): string {
+function formatFrameLine(
+  frame: { url: string; description?: string },
+  detail: DetailLevel
+): string {
+  if (detail === 'full') {
+    return `![${frame.description || 'Weather imagery'}](${frame.url})`;
+  }
+  return `**Image URL:** ${frame.url}`;
+}
+
+/**
+ * Format weather imagery response for display
+ * @param response - Imagery result to render
+ * @param detail - Verbosity; "full" embeds Markdown images, otherwise URLs are text
+ */
+export function formatWeatherImageryResponse(
+  response: WeatherImageryResponse,
+  detail: DetailLevel = 'standard'
+): string {
   const lines: string[] = [];
 
   lines.push('# Weather Imagery');
@@ -133,7 +201,7 @@ export function formatWeatherImageryResponse(response: WeatherImageryResponse): 
     framesToShow.forEach((frame) => {
       const frameNumber = response.frames.indexOf(frame) + 1;
       lines.push(`### Frame ${frameNumber} - ${frame.timestamp.toISOString()}`);
-      lines.push(`![${frame.description || 'Weather imagery'}](${frame.url})`);
+      lines.push(formatFrameLine(frame, detail));
       lines.push('');
     });
 
@@ -146,7 +214,7 @@ export function formatWeatherImageryResponse(response: WeatherImageryResponse): 
     lines.push('');
     const frame = response.frames[0];
     lines.push(`**Timestamp:** ${frame.timestamp.toISOString()}`);
-    lines.push(`![${frame.description || 'Weather imagery'}](${frame.url})`);
+    lines.push(formatFrameLine(frame, detail));
     lines.push('');
   } else {
     lines.push('## ⚠️ No Imagery Available');

--- a/src/handlers/weatherSummaryHandler.ts
+++ b/src/handlers/weatherSummaryHandler.ts
@@ -1,0 +1,169 @@
+/**
+ * Handler for get_weather_summary tool
+ *
+ * A composite tool that answers broad "what's the weather like?" questions in a
+ * single call by aggregating several specialized tools (current conditions,
+ * forecast, alerts, and optionally air quality and lightning) for one location.
+ * Location is resolved once and the resolved coordinates are passed to each
+ * sub-handler so there is no repeated geocoding.
+ */
+
+import { NOAAService } from '../services/noaa.js';
+import { OpenMeteoService } from '../services/openmeteo.js';
+import { NCEIService } from '../services/ncei.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, formatLocationLine } from '../utils/locationResolver.js';
+import { validateDetail, validateForecastDays, DetailLevel } from '../utils/validation.js';
+import { logger } from '../utils/logger.js';
+import { handleGetCurrentConditions } from './currentConditionsHandler.js';
+import { handleGetForecast } from './forecastHandler.js';
+import { handleGetAlerts } from './alertsHandler.js';
+import { handleGetAirQuality } from './airQualityHandler.js';
+import { handleGetLightningActivity } from './lightningHandler.js';
+
+/**
+ * Sections that can be included in a weather summary.
+ */
+export type SummarySection = 'current' | 'forecast' | 'alerts' | 'air_quality' | 'lightning';
+
+const VALID_SECTIONS: SummarySection[] = ['current', 'forecast', 'alerts', 'air_quality', 'lightning'];
+const DEFAULT_SECTIONS: SummarySection[] = ['current', 'forecast', 'alerts'];
+
+interface WeatherSummaryArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  city_name?: string;
+  include?: unknown;
+  detail?: DetailLevel;
+  days?: number;
+}
+
+/**
+ * Validate and normalize the `include` array.
+ * Defaults to current + forecast + alerts; unknown entries are rejected.
+ */
+function validateInclude(value: unknown): SummarySection[] {
+  if (value === undefined) {
+    return DEFAULT_SECTIONS;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('include must be an array of section names');
+  }
+
+  const sections: SummarySection[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !VALID_SECTIONS.includes(entry as SummarySection)) {
+      throw new Error(
+        `Invalid include entry "${entry}". Valid sections: ${VALID_SECTIONS.join(', ')}.`
+      );
+    }
+    if (!sections.includes(entry as SummarySection)) {
+      sections.push(entry as SummarySection);
+    }
+  }
+
+  // Empty array falls back to the default set rather than producing an empty report
+  return sections.length > 0 ? sections : DEFAULT_SECTIONS;
+}
+
+/**
+ * Extract the text payload from a sub-handler result.
+ */
+function textOf(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content
+    .filter(block => block.type === 'text')
+    .map(block => block.text)
+    .join('\n');
+}
+
+export async function handleGetWeatherSummary(
+  args: unknown,
+  noaaService: NOAAService,
+  openMeteoService: OpenMeteoService,
+  nceiService: NCEIService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const typedArgs = (args ?? {}) as WeatherSummaryArgs;
+
+  // Resolve location once; sub-handlers receive the resolved coordinates so they
+  // never re-geocode (coordinates take precedence in resolveLocationAsync).
+  const resolved = await resolveLocationAsync(typedArgs, locationStore, geocodingService);
+  const include = validateInclude(typedArgs.include);
+  const detail = validateDetail(typedArgs.detail, 'summary');
+  const days = validateForecastDays(typedArgs);
+
+  // Shared args for every sub-handler: resolved coordinates plus pass-through of
+  // unit preferences and detail. Coordinates override any name so no geocoding.
+  const subArgs = {
+    ...(typeof args === 'object' && args !== null ? args : {}),
+    latitude: resolved.latitude,
+    longitude: resolved.longitude,
+    location_name: undefined,
+    city_name: undefined,
+    detail
+  };
+
+  let body = `# Weather Summary\n\n`;
+  const locationLine = formatLocationLine(resolved);
+  if (locationLine) {
+    body += locationLine;
+  } else {
+    body += `**Location:** ${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}\n\n`;
+  }
+  body += `**Includes:** ${include.join(', ')}\n\n`;
+  body += `---\n\n`;
+
+  // Run each requested section. A section failure (e.g. alerts outside the US)
+  // degrades to a note instead of failing the whole summary.
+  for (const section of include) {
+    try {
+      let sectionResult: { content: Array<{ type: string; text: string }> };
+      switch (section) {
+        case 'current':
+          sectionResult = await handleGetCurrentConditions(
+            subArgs, noaaService, openMeteoService, nceiService, locationStore, geocodingService
+          );
+          break;
+        case 'forecast':
+          sectionResult = await handleGetForecast(
+            { ...subArgs, days }, noaaService, openMeteoService, locationStore, geocodingService, nceiService
+          );
+          break;
+        case 'alerts':
+          sectionResult = await handleGetAlerts(subArgs, noaaService, locationStore, geocodingService);
+          break;
+        case 'air_quality':
+          sectionResult = await handleGetAirQuality(subArgs, openMeteoService, locationStore, geocodingService);
+          break;
+        case 'lightning':
+          sectionResult = await handleGetLightningActivity(subArgs, locationStore, geocodingService);
+          break;
+        default:
+          continue;
+      }
+      body += textOf(sectionResult).trim();
+      body += `\n\n---\n\n`;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn('Weather summary section failed', { section, error: message });
+      body += `## ${section} (unavailable)\n\n`;
+      body += `⚠️ Could not retrieve ${section} data for this location: ${message}\n\n`;
+      body += `---\n\n`;
+    }
+  }
+
+  body += `*Composite summary. Use the individual tools (get_forecast, get_current_conditions, get_alerts, ...) for deeper detail.*\n`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: body
+      }
+    ]
+  };
+}

--- a/src/handlers/wildfireHandler.ts
+++ b/src/handlers/wildfireHandler.ts
@@ -3,7 +3,9 @@
  */
 
 import { NIFCService } from '../services/nifc.js';
-import { validateCoordinates } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { guessTimezoneFromCoords } from '../utils/timezone.js';
 import { calculateDistance } from '../utils/distance.js';
 import type { WildfireInfo } from '../types/wildfire.js';
@@ -11,15 +13,20 @@ import type { WildfireInfo } from '../types/wildfire.js';
 interface WildfireArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   radius?: number; // search radius in km (default: 100)
 }
 
 export async function handleGetWildfireInfo(
   args: unknown,
-  nifcService: NIFCService
+  nifcService: NIFCService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as WildfireArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
 
   // Validate radius parameter
   let radius = (args as WildfireArgs)?.radius ?? 100; // default 100 km
@@ -172,14 +179,14 @@ export async function handleGetWildfireInfo(
   output += `*Wildfire data is updated throughout the day. Always consult official sources for evacuation orders and emergency information.*\n`;
   output += `*For active incidents and evacuation orders, visit: https://inciweb.nwcg.gov/*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,11 @@ import { handleCheckServiceStatus } from './handlers/statusHandler.js';
 import { handleSearchLocation } from './handlers/locationHandler.js';
 import { handleGetAirQuality } from './handlers/airQualityHandler.js';
 import { handleGetMarineConditions } from './handlers/marineConditionsHandler.js';
-import { getWeatherImagery, formatWeatherImageryResponse } from './handlers/weatherImageryHandler.js';
-import { getLightningActivity, formatLightningActivityResponse } from './handlers/lightningHandler.js';
+import { handleGetWeatherImagery } from './handlers/weatherImageryHandler.js';
+import { handleGetLightningActivity } from './handlers/lightningHandler.js';
 import { handleGetRiverConditions } from './handlers/riverConditionsHandler.js';
 import { handleGetWildfireInfo } from './handlers/wildfireHandler.js';
+import { handleGetWeatherSummary } from './handlers/weatherSummaryHandler.js';
 import {
   handleSaveLocation,
   handleListSavedLocations,
@@ -198,6 +199,47 @@ const UNIT_SCHEMA_PROPERTIES = {
 };
 
 /**
+ * Shared location parameters. Spread into every location-based weather tool so
+ * the AI can provide a location in ONE of three consistent ways: coordinates,
+ * a saved location name, or a free-text city name (geocoded on demand). Tools
+ * using this fragment must declare `required: []` — resolveLocationAsync enforces
+ * that at least one usable form is present at call time.
+ */
+const LOCATION_SCHEMA_PROPERTIES = {
+  latitude: {
+    type: 'number' as const,
+    description: 'Latitude of the location (-90 to 90). Not required if location_name or city_name is provided.',
+    minimum: -90,
+    maximum: 90
+  },
+  longitude: {
+    type: 'number' as const,
+    description: 'Longitude of the location (-180 to 180). Not required if location_name or city_name is provided.',
+    minimum: -180,
+    maximum: 180
+  },
+  location_name: {
+    type: 'string' as const,
+    description: 'Name of a saved location (e.g., "home", "cabin"). Use instead of coordinates to reference a saved location. List them with list_saved_locations.'
+  },
+  city_name: {
+    type: 'string' as const,
+    description: 'Free-text place name to geocode (e.g., "Paris, France", "Bend, Oregon"). Use instead of coordinates when you only have a place name and it is not a saved location. Include state/country for disambiguation when possible.'
+  }
+};
+
+/**
+ * Shared output-verbosity parameter for high-volume tools.
+ */
+const DETAIL_SCHEMA_PROPERTY = {
+  detail: {
+    type: 'string' as const,
+    description: 'Output verbosity: "summary" (shortest), "standard" (default, balanced), or "full" (everything the source provides, e.g. full alert descriptions, uncapped hourly forecast, embedded imagery).',
+    enum: ['summary', 'standard', 'full']
+  }
+};
+
+/**
  * Tool definitions - each tool defined separately for conditional registration
  */
 const TOOL_DEFINITIONS = {
@@ -207,26 +249,7 @@ const TOOL_DEFINITIONS = {
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90). Not required if location_name is provided.',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180). Not required if location_name is provided.',
-          minimum: -180,
-          maximum: 180
-        },
-        location_name: {
-          type: 'string' as const,
-          description: 'Name of a saved location (e.g., "home", "cabin"). Use this instead of latitude/longitude to reference a saved location. List saved locations with list_saved_locations.'
-        },
-        city_name: {
-          type: 'string' as const,
-          description: 'Free-text place name to geocode (e.g., "Paris, France", "Bend, Oregon"). Use this instead of latitude/longitude when you only have a place name and it is not a saved location. Include state/country for disambiguation when possible.'
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         days: {
           type: 'number' as const,
           description: 'Number of days to include in forecast (1-16 for global, 1-7 for US NOAA, default: 7)',
@@ -261,6 +284,7 @@ const TOOL_DEFINITIONS = {
           enum: ['auto', 'noaa', 'openmeteo'],
           default: 'auto'
         },
+        ...DETAIL_SCHEMA_PROPERTY,
         ...UNIT_SCHEMA_PROPERTIES
       },
       required: []
@@ -269,22 +293,11 @@ const TOOL_DEFINITIONS = {
 
   get_current_conditions: {
     name: 'get_current_conditions' as const,
-    description: 'Get the most recent weather observation for a location (US only). Use this for current weather or when asking about "today\'s weather", "right now", or recent conditions without a specific historical date range. Returns the latest observation from the nearest weather station. Optionally includes fire weather indices (Haines Index, Grassland Fire Danger, Red Flag Threat) when requested. For specific past dates or date ranges, use get_historical_weather instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
+    description: 'Get the most recent weather observation for a location (US only). Use this for current weather or when asking about "today\'s weather", "right now", or recent conditions without a specific historical date range. Returns the latest observation from the nearest weather station. Optionally includes fire weather indices (Haines Index, Grassland Fire Danger, Red Flag Threat) when requested. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For specific past dates or date ranges, use get_historical_weather instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         include_fire_weather: {
           type: 'boolean' as const,
           description: 'Include fire weather indices (Haines Index, Grassland Fire Danger, Red Flag Threat) in the response (default: false, US only)',
@@ -297,56 +310,35 @@ const TOOL_DEFINITIONS = {
         },
         ...UNIT_SCHEMA_PROPERTIES
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_alerts: {
     name: 'get_alerts' as const,
-    description: 'Get active weather alerts, watches, warnings, and advisories for a location (US only). Use this for safety-critical weather information when asked about "any alerts?", "weather warnings?", "is it safe?", "dangerous weather?", or "weather watches?". Returns severity, urgency, certainty, effective/expiration times, and affected areas. For forecast data, use get_forecast instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
+    description: 'Get active weather alerts, watches, warnings, and advisories for a location (US only). Use this for safety-critical weather information when asked about "any alerts?", "weather warnings?", "is it safe?", "dangerous weather?", or "weather watches?". Returns severity, urgency, certainty, effective/expiration times, and affected areas. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For forecast data, use get_forecast instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         active_only: {
           type: 'boolean' as const,
           description: 'Whether to show only active alerts (default: true)',
           default: true
-        }
+        },
+        ...DETAIL_SCHEMA_PROPERTY
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_historical_weather: {
     name: 'get_historical_weather' as const,
-    description: 'Get historical weather data for a specific date range in the past. Use this when the user asks about weather on specific past dates (e.g., "yesterday", "last week", "November 4, 2024", "30 years ago"). Automatically uses NOAA API for recent dates (last 7 days, US only) or Open-Meteo API for older dates (worldwide, back to 1940). Do NOT use for current conditions - use get_current_conditions instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
+    description: 'Get historical weather data for a specific date range in the past. Use this when the user asks about weather on specific past dates (e.g., "yesterday", "last week", "November 4, 2024", "30 years ago"). Automatically uses NOAA API for recent dates (last 7 days, US only) or Open-Meteo API for older dates (worldwide, back to 1940). Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. Do NOT use for current conditions - use get_current_conditions instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         start_date: {
           type: 'string' as const,
           description: 'Start date in ISO format (YYYY-MM-DD or ISO 8601 datetime)',
@@ -364,7 +356,36 @@ const TOOL_DEFINITIONS = {
         },
         ...UNIT_SCHEMA_PROPERTIES
       },
-      required: ['latitude', 'longitude', 'start_date', 'end_date']
+      required: ['start_date', 'end_date']
+    }
+  },
+
+  get_weather_summary: {
+    name: 'get_weather_summary' as const,
+    description: 'Get a combined weather overview for a location in a SINGLE call. Best for broad questions like "What\'s the weather like in Seattle?", "Is it safe to hike today?", or "Give me a weather rundown". Aggregates current conditions, forecast, and active alerts by default, and can also include air quality and lightning. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For a single specific data product (just the forecast, just alerts, etc.), call that specialized tool directly. Sections that are unavailable for a location (e.g. US-only alerts abroad) are noted rather than failing the whole summary.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        ...LOCATION_SCHEMA_PROPERTIES,
+        include: {
+          type: 'array' as const,
+          description: 'Which sections to include (default: ["current", "forecast", "alerts"]). Add "air_quality" and/or "lightning" for a fuller picture.',
+          items: {
+            type: 'string' as const,
+            enum: ['current', 'forecast', 'alerts', 'air_quality', 'lightning']
+          }
+        },
+        days: {
+          type: 'number' as const,
+          description: 'Number of forecast days to include when the forecast section is requested (1-16, default: 7)',
+          minimum: 1,
+          maximum: 16,
+          default: 7
+        },
+        ...DETAIL_SCHEMA_PROPERTY,
+        ...UNIT_SCHEMA_PROPERTIES
+      },
+      required: []
     }
   },
 
@@ -402,78 +423,45 @@ const TOOL_DEFINITIONS = {
 
   get_air_quality: {
     name: 'get_air_quality' as const,
-    description: 'Get air quality data including AQI (Air Quality Index), pollutant concentrations, and UV index for a location (global coverage). Use this when asked about "air quality", "pollution", "AQI", "UV index", "safe to exercise outside", or health-related environmental conditions. Returns current conditions and optional hourly forecast. Shows appropriate AQI scale (US AQI for US locations, European EAQI elsewhere) with health recommendations. Pollutants include PM2.5, PM10, ozone, NO2, SO2, and CO.',
+    description: 'Get air quality data including AQI (Air Quality Index), pollutant concentrations, and UV index for a location (global coverage). Use this when asked about "air quality", "pollution", "AQI", "UV index", "safe to exercise outside", or health-related environmental conditions. Returns current conditions and optional hourly forecast. Shows appropriate AQI scale (US AQI for US locations, European EAQI elsewhere) with health recommendations. Pollutants include PM2.5, PM10, ozone, NO2, SO2, and CO. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         forecast: {
           type: 'boolean' as const,
           description: 'Include hourly air quality forecast for next 5 days (default: false, shows current only)',
           default: false
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_marine_conditions: {
     name: 'get_marine_conditions' as const,
-    description: 'Get marine conditions including wave height, swell, ocean currents, and sea state for a location (global coverage). Use this when asked about "ocean conditions", "wave height", "surf conditions", "safe to boat", "marine forecast", "swell", or "sea state". Returns current conditions and optional daily/hourly forecast. Includes significant wave height, wind waves, swell, wave period, and ocean currents. Shows safety assessment for maritime activities. NOTE: Data has limited accuracy in coastal areas and is NOT suitable for coastal navigation - always consult official marine forecasts.',
+    description: 'Get marine conditions including wave height, swell, ocean currents, and sea state for a location (global coverage). Use this when asked about "ocean conditions", "wave height", "surf conditions", "safe to boat", "marine forecast", "swell", or "sea state". Returns current conditions and optional daily/hourly forecast. Includes significant wave height, wind waves, swell, wave period, and ocean currents. Shows safety assessment for maritime activities. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. NOTE: Data has limited accuracy in coastal areas and is NOT suitable for coastal navigation - always consult official marine forecasts.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         forecast: {
           type: 'boolean' as const,
           description: 'Include marine forecast for next 5 days (default: false, shows current only)',
           default: false
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_weather_imagery: {
     name: 'get_weather_imagery' as const,
-    description: 'Get weather imagery including radar, satellite, and precipitation maps for a location. Use this when asked about "show radar", "satellite image", "precipitation map", "weather map", "animated radar", or "what does radar show". Returns image URLs with timestamps for current or animated weather visualization. Precipitation/radar is global via RainViewer; satellite is GOES GeoColor (Western Hemisphere) via NASA GIBS. Includes disclaimer about data delays and official forecast consultation. For numerical forecast data, use get_forecast instead.',
+    description: 'Get weather imagery including radar, satellite, and precipitation maps for a location. Use this when asked about "show radar", "satellite image", "precipitation map", "weather map", "animated radar", or "what does radar show". Returns image URLs with timestamps for current or animated weather visualization. Precipitation/radar is global via RainViewer; satellite is GOES GeoColor (Western Hemisphere) via NASA GIBS. By default returns direct image URLs; use detail="full" to embed Markdown images. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For numerical forecast data, use get_forecast instead.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         type: {
           type: 'string' as const,
           description: 'Type of imagery: "radar" or "precipitation" (global, RainViewer) or "satellite" (Western Hemisphere GOES GeoColor, NASA GIBS). Default: "precipitation"',
@@ -484,30 +472,20 @@ const TOOL_DEFINITIONS = {
           type: 'boolean' as const,
           description: 'Return animated frames showing progression over time (default: false)',
           default: false
-        }
+        },
+        ...DETAIL_SCHEMA_PROPERTY
       },
-      required: ['latitude', 'longitude', 'type']
+      required: ['type']
     }
   },
 
   get_lightning_activity: {
     name: 'get_lightning_activity' as const,
-    description: 'Get real-time lightning strike activity and safety assessment for a location (global coverage). Use this when asked about "lightning nearby", "lightning strikes", "thunderstorm activity", "is it safe from lightning", or "lightning danger". Returns recent strikes within specified radius and time window, including distance, polarity, intensity, and critical safety recommendations. Provides 4-level safety assessment (safe/elevated/high/extreme) based on proximity. SAFETY-CRITICAL tool for outdoor activities and severe weather monitoring.',
+    description: 'Get real-time lightning strike activity and safety assessment for a location (global coverage). Use this when asked about "lightning nearby", "lightning strikes", "thunderstorm activity", "is it safe from lightning", or "lightning danger". Returns recent strikes within specified radius and time window, including distance, polarity, intensity, and critical safety recommendations. Provides 4-level safety assessment (safe/elevated/high/extreme) based on proximity. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. SAFETY-CRITICAL tool for outdoor activities and severe weather monitoring.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         radius: {
           type: 'number' as const,
           description: 'Search radius in kilometers (1-500, default: 100)',
@@ -523,28 +501,17 @@ const TOOL_DEFINITIONS = {
           default: 60
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_river_conditions: {
     name: 'get_river_conditions' as const,
-    description: 'Monitor river levels and flood status for a location (US only). Use this when asked about "river flooding", "river level", "flood stage", "streamflow", "safe to kayak", or "river conditions". Returns current river gauge data within specified radius including river stage, flow rate, flood category levels (action/minor/moderate/major), and forecasted conditions. Provides safety assessment based on flood stages. SAFETY-CRITICAL tool for flood-prone areas and water recreation.',
+    description: 'Monitor river levels and flood status for a location (US only). Use this when asked about "river flooding", "river level", "flood stage", "streamflow", "safe to kayak", or "river conditions". Returns current river gauge data within specified radius including river stage, flow rate, flood category levels (action/minor/moderate/major), and forecasted conditions. Provides safety assessment based on flood stages. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. SAFETY-CRITICAL tool for flood-prone areas and water recreation.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         radius: {
           type: 'number' as const,
           description: 'Search radius in kilometers (1-500, default: 50)',
@@ -553,28 +520,17 @@ const TOOL_DEFINITIONS = {
           default: 50
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_wildfire_info: {
     name: 'get_wildfire_info' as const,
-    description: 'Monitor active wildfires and fire perimeters for a location (US focus). Use this when asked about "wildfires nearby", "fire danger", "active fires", "wildfire smoke", "fire perimeters", or "evacuation risk". Returns active wildfire information within specified radius including fire name, size, containment percentage, distance from location, and safety assessment. Provides critical evacuation awareness and air quality impact information. SAFETY-CRITICAL tool for wildfire-prone areas.',
+    description: 'Monitor active wildfires and fire perimeters for a location (US focus). Use this when asked about "wildfires nearby", "fire danger", "active fires", "wildfire smoke", "fire perimeters", or "evacuation risk". Returns active wildfire information within specified radius including fire name, size, containment percentage, distance from location, and safety assessment. Provides critical evacuation awareness and air quality impact information. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. SAFETY-CRITICAL tool for wildfire-prone areas.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         radius: {
           type: 'number' as const,
           description: 'Search radius in kilometers (1-500, default: 100)',
@@ -583,7 +539,7 @@ const TOOL_DEFINITIONS = {
           default: 100
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
@@ -720,17 +676,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'get_current_conditions':
         return await withAnalytics('get_current_conditions', async () =>
-          handleGetCurrentConditions(args, noaaService, openMeteoService, nceiService)
+          handleGetCurrentConditions(args, noaaService, openMeteoService, nceiService, locationStore, geocodingService)
         );
 
       case 'get_alerts':
         return await withAnalytics('get_alerts', async () =>
-          handleGetAlerts(args, noaaService)
+          handleGetAlerts(args, noaaService, locationStore, geocodingService)
         );
 
       case 'get_historical_weather':
         return await withAnalytics('get_historical_weather', async () =>
-          handleGetHistoricalWeather(args, noaaService, openMeteoService)
+          handleGetHistoricalWeather(args, noaaService, openMeteoService, locationStore, geocodingService)
+        );
+
+      case 'get_weather_summary':
+        return await withAnalytics('get_weather_summary', async () =>
+          handleGetWeatherSummary(args, noaaService, openMeteoService, nceiService, locationStore, geocodingService)
         );
 
       case 'check_service_status':
@@ -745,50 +706,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'get_air_quality':
         return await withAnalytics('get_air_quality', async () =>
-          handleGetAirQuality(args, openMeteoService)
+          handleGetAirQuality(args, openMeteoService, locationStore, geocodingService)
         );
 
       case 'get_marine_conditions':
         return await withAnalytics('get_marine_conditions', async () =>
-          handleGetMarineConditions(args, noaaService, openMeteoService)
+          handleGetMarineConditions(args, noaaService, openMeteoService, locationStore, geocodingService)
         );
 
       case 'get_weather_imagery':
-        return await withAnalytics('get_weather_imagery', async () => {
-          const result = await getWeatherImagery(args as any);
-          const formatted = formatWeatherImageryResponse(result);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: formatted
-              }
-            ]
-          };
-        });
+        return await withAnalytics('get_weather_imagery', async () =>
+          handleGetWeatherImagery(args, locationStore, geocodingService)
+        );
 
       case 'get_lightning_activity':
-        return await withAnalytics('get_lightning_activity', async () => {
-          const result = await getLightningActivity(args as any);
-          const formatted = formatLightningActivityResponse(result);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: formatted
-              }
-            ]
-          };
-        });
+        return await withAnalytics('get_lightning_activity', async () =>
+          handleGetLightningActivity(args, locationStore, geocodingService)
+        );
 
       case 'get_river_conditions':
         return await withAnalytics('get_river_conditions', async () =>
-          handleGetRiverConditions(args, noaaService)
+          handleGetRiverConditions(args, noaaService, locationStore, geocodingService)
         );
 
       case 'get_wildfire_info':
         return await withAnalytics('get_wildfire_info', async () =>
-          handleGetWildfireInfo(args, nifcService)
+          handleGetWildfireInfo(args, nifcService, locationStore, geocodingService)
         );
 
       case 'save_location':

--- a/src/utils/locationResolver.ts
+++ b/src/utils/locationResolver.ts
@@ -23,6 +23,47 @@ export interface ResolvedLocation {
 }
 
 /**
+ * Build a header line describing how a location name was resolved.
+ *
+ * Returns an empty string for direct-coordinate requests (nothing to disclose),
+ * otherwise a Markdown line showing the matched name and coordinates so an
+ * ambiguous saved/geocoded lookup is transparent to the user. Shared across all
+ * weather handlers so location disclosure is consistent.
+ *
+ * @param resolved - Result from resolveLocation/resolveLocationAsync
+ * @returns Markdown line (with trailing blank line) or '' for coordinate input
+ */
+export function formatLocationLine(resolved: ResolvedLocation): string {
+  if (resolved.source === 'coordinates' || !resolved.location_name) {
+    return '';
+  }
+
+  const coords = `${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}`;
+  return `**Location:** ${resolved.location_name} (${coords})\n\n`;
+}
+
+/**
+ * Prepend the resolved-location header to a handler's text content, if any.
+ *
+ * Mutates the first text block of a standard `{ content: [...] }` handler result
+ * so name-based lookups (saved location or geocoded city) surface what matched.
+ * A no-op for direct-coordinate requests.
+ *
+ * @param result - Handler result whose first text block will be prefixed
+ * @param resolved - Result from resolveLocationAsync
+ * @returns The same result object (for convenient chaining)
+ */
+export function prependLocationLine<
+  T extends { content: Array<{ type: string; text: string }> }
+>(result: T, resolved: ResolvedLocation): T {
+  const locationLine = formatLocationLine(resolved);
+  if (locationLine && result.content.length > 0 && result.content[0]?.type === 'text') {
+    result.content[0].text = locationLine + result.content[0].text;
+  }
+  return result;
+}
+
+/**
  * Cached geocode result for a free-text city name.
  * City coordinates are effectively static, so these are cached with an
  * Infinity TTL (see CacheConfig.ttl.geocoding).

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -157,6 +157,40 @@ export function validateGranularity(value: unknown): 'daily' | 'hourly' {
 }
 
 /**
+ * Output verbosity levels for high-volume weather tools.
+ * - summary: shortest useful answer (fewest entries, headline-only)
+ * - standard: sensible default balancing detail and token cost
+ * - full: everything the source provides (long descriptions, all entries)
+ */
+export type DetailLevel = 'summary' | 'standard' | 'full';
+
+/**
+ * Validate the shared `detail` output-control parameter.
+ * @param value - Value to validate (from tool args)
+ * @param defaultValue - Level to use when omitted (defaults to 'standard')
+ * @returns Validated detail level
+ * @throws {Error} If value is present but not a valid level
+ */
+export function validateDetail(
+  value: unknown,
+  defaultValue: DetailLevel = 'standard'
+): DetailLevel {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid detail: must be a string, received ${typeof value}`);
+  }
+
+  if (value !== 'summary' && value !== 'standard' && value !== 'full') {
+    throw new Error(`Invalid detail: "${value}". Must be one of "summary", "standard", or "full".`);
+  }
+
+  return value;
+}
+
+/**
  * Validate optional boolean with default
  * @param value - Value to validate
  * @param name - Parameter name for error messages

--- a/tests/unit/alerts-detail.test.ts
+++ b/tests/unit/alerts-detail.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the get_alerts `detail` output control and location resolution.
+ *
+ * A minimal NOAAService stub returns one alert with a long description and
+ * instruction so we can assert what each verbosity level includes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleGetAlerts } from '../../src/handlers/alertsHandler.js';
+import type { NOAAService } from '../../src/services/noaa.js';
+import type { LocationStore } from '../../src/services/locationStore.js';
+import type { GeocodingService } from '../../src/services/geocoding.js';
+
+const DESCRIPTION = 'A very long National Weather Service description that is expensive to include.';
+const INSTRUCTION = 'Move to higher ground immediately.';
+
+function makeNoaaStub(): NOAAService {
+  return {
+    getStations: vi.fn(async () => ({ features: [] })),
+    getAlerts: vi.fn(async () => ({
+      updated: '2026-07-13T12:00:00Z',
+      features: [
+        {
+          properties: {
+            event: 'Flood Warning',
+            severity: 'Severe',
+            urgency: 'Immediate',
+            certainty: 'Likely',
+            headline: 'Flood Warning in effect',
+            description: DESCRIPTION,
+            areaDesc: 'Test County',
+            effective: '2026-07-13T12:00:00Z',
+            expires: '2026-07-13T18:00:00Z',
+            response: 'Avoid',
+            senderName: 'NWS',
+            instruction: INSTRUCTION,
+          },
+        },
+      ],
+    })),
+  } as unknown as NOAAService;
+}
+
+const store = {} as unknown as LocationStore;
+const geocoding = {} as unknown as GeocodingService;
+
+async function getAlertsText(args: Record<string, unknown>): Promise<string> {
+  const result = await handleGetAlerts(args, makeNoaaStub(), store, geocoding);
+  return result.content[0].text;
+}
+
+describe('get_alerts detail control', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('standard (default) includes instructions but omits the full description', async () => {
+    const text = await getAlertsText({ latitude: 40, longitude: -100 });
+    expect(text).toContain('Flood Warning');
+    expect(text).toContain(INSTRUCTION);
+    expect(text).not.toContain(DESCRIPTION);
+    expect(text).toContain('detail="full"');
+  });
+
+  it('summary omits both description and instructions', async () => {
+    const text = await getAlertsText({ latitude: 40, longitude: -100, detail: 'summary' });
+    expect(text).toContain('Flood Warning');
+    expect(text).not.toContain(DESCRIPTION);
+    expect(text).not.toContain(INSTRUCTION);
+  });
+
+  it('full includes the complete description and instructions', async () => {
+    const text = await getAlertsText({ latitude: 40, longitude: -100, detail: 'full' });
+    expect(text).toContain(DESCRIPTION);
+    expect(text).toContain(INSTRUCTION);
+    expect(text).not.toContain('detail="full"');
+  });
+
+  it('rejects an invalid detail level', async () => {
+    await expect(
+      getAlertsText({ latitude: 40, longitude: -100, detail: 'loud' })
+    ).rejects.toThrow(/detail/i);
+  });
+});

--- a/tests/unit/imagery-handler.test.ts
+++ b/tests/unit/imagery-handler.test.ts
@@ -280,7 +280,13 @@ describe('Weather Imagery Handler', () => {
 
       expect(formatted).toContain('## 📸 Current Imagery');
       expect(formatted).toContain('**Timestamp:** 2024-01-01T12:00:00.000Z');
-      expect(formatted).toContain('![Precipitation radar](https://example.com/frame.png)');
+      // Default (standard) surfaces the direct URL as text, not an embedded image
+      expect(formatted).toContain('**Image URL:** https://example.com/frame.png');
+      expect(formatted).not.toContain('![Precipitation radar]');
+
+      // detail="full" embeds the image as Markdown for rich clients
+      const full = formatWeatherImageryResponse(response, 'full');
+      expect(full).toContain('![Precipitation radar](https://example.com/frame.png)');
     });
 
     it('should format response with multiple frames (animated)', () => {

--- a/tests/unit/locationResolver.test.ts
+++ b/tests/unit/locationResolver.test.ts
@@ -9,7 +9,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   resolveLocationAsync,
   clearCityGeocodeCache,
+  formatLocationLine,
+  prependLocationLine,
 } from '../../src/utils/locationResolver.js';
+import type { ResolvedLocation } from '../../src/utils/locationResolver.js';
 import type { LocationStore } from '../../src/services/locationStore.js';
 import type { GeocodingService, GeocodingResult } from '../../src/services/geocoding.js';
 import type { SavedLocation } from '../../src/types/savedLocations.js';
@@ -228,5 +231,66 @@ describe('resolveLocationAsync', () => {
         /coordinates|location_name|city_name/i
       );
     });
+  });
+});
+
+describe('formatLocationLine', () => {
+  it('returns an empty string for direct coordinate input', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      source: 'coordinates',
+    };
+    expect(formatLocationLine(resolved)).toBe('');
+  });
+
+  it('discloses the matched name and coordinates for a saved location', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 47.6062,
+      longitude: -122.3321,
+      source: 'saved_location',
+      location_name: 'home',
+    };
+    expect(formatLocationLine(resolved)).toBe('**Location:** home (47.6062, -122.3321)\n\n');
+  });
+
+  it('discloses the geocoder display name for a city lookup', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 48.8566,
+      longitude: 2.3522,
+      source: 'geocoded',
+      location_name: 'Paris, Île-de-France, France',
+    };
+    expect(formatLocationLine(resolved)).toContain('Paris, Île-de-France, France');
+    expect(formatLocationLine(resolved)).toContain('48.8566, 2.3522');
+  });
+});
+
+describe('prependLocationLine', () => {
+  it('prepends the location line to the first text block for a name lookup', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 47.6062,
+      longitude: -122.3321,
+      source: 'saved_location',
+      location_name: 'home',
+    };
+    const result = { content: [{ type: 'text', text: '# Forecast\n' }] };
+
+    const out = prependLocationLine(result, resolved);
+
+    expect(out.content[0].text).toBe('**Location:** home (47.6062, -122.3321)\n\n# Forecast\n');
+  });
+
+  it('is a no-op for direct coordinate input', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      source: 'coordinates',
+    };
+    const result = { content: [{ type: 'text', text: '# Forecast\n' }] };
+
+    prependLocationLine(result, resolved);
+
+    expect(result.content[0].text).toBe('# Forecast\n');
   });
 });

--- a/tests/unit/tool-config.test.ts
+++ b/tests/unit/tool-config.test.ts
@@ -65,6 +65,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig(undefined);
 
       const enabled = toolConfig.getEnabledTools();
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
@@ -79,50 +80,68 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('basic');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(9); // Updated for v1.7.0: added 4 saved-location tools
+      // v1.11.0 "summary-first" default: 6 tools led by get_weather_summary
+      expect(enabled).toHaveLength(6);
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
       expect(enabled).toContain('search_location');
       expect(enabled).toContain('check_service_status');
+      // Personalization, history, and specialized tools are promoted out of basic
+      expect(enabled).not.toContain('save_location');
+      expect(enabled).not.toContain('get_historical_weather');
+      expect(enabled).not.toContain('get_air_quality');
     });
 
     it('should load "standard" preset', async () => {
       const toolConfig = await createToolConfig('standard');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(10); // Updated for v1.7.0: added 4 saved-location tools
+      // v1.11.0: basic + historical, air_quality, and saved-location CRUD
+      expect(enabled).toHaveLength(12);
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
       expect(enabled).toContain('get_historical_weather');
+      expect(enabled).toContain('get_air_quality');
       expect(enabled).toContain('search_location');
       expect(enabled).toContain('check_service_status');
+      expect(enabled).toContain('save_location');
+      // Specialized safety tools are still full-only
+      expect(enabled).not.toContain('get_marine_conditions');
+      expect(enabled).not.toContain('get_wildfire_info');
     });
 
     it('should load "full" preset', async () => {
       const toolConfig = await createToolConfig('full');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(11); // Updated for v1.7.0: added 4 saved-location tools
-      expect(enabled).toContain('get_forecast');
-      expect(enabled).toContain('get_current_conditions');
-      expect(enabled).toContain('get_alerts');
+      // v1.11.0: full is the complete set (17 tools, same membership as "all")
+      expect(enabled).toHaveLength(17);
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_historical_weather');
-      expect(enabled).toContain('search_location');
-      expect(enabled).toContain('check_service_status');
       expect(enabled).toContain('get_air_quality');
+      expect(enabled).toContain('get_marine_conditions');
+      expect(enabled).toContain('get_weather_imagery');
+      expect(enabled).toContain('get_lightning_activity');
+      expect(enabled).toContain('get_river_conditions');
+      expect(enabled).toContain('get_wildfire_info');
+      expect(enabled).toContain('save_location');
     });
 
     it('should load "all" preset', async () => {
       const toolConfig = await createToolConfig('all');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(16); // Updated for v1.7.0: added 4 saved-location tools
+      // v1.11.0: 16 previous tools + get_weather_summary = 17
+      expect(enabled).toHaveLength(17);
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
       expect(enabled).toContain('get_historical_weather');
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('check_service_status');
       expect(enabled).toContain('search_location');
       expect(enabled).toContain('get_air_quality');
@@ -207,7 +226,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('all,-get_marine_conditions');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(15); // Updated for v1.7.0: 16 total tools - 1 removed = 15
+      expect(enabled).toHaveLength(16); // v1.11.0: 17 total tools - 1 removed = 16
       expect(enabled).not.toContain('get_marine_conditions');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_air_quality');

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -10,6 +10,7 @@ import {
   validateGranularity,
   validateOptionalBoolean,
   validateHistoricalWeatherParams,
+  validateDetail,
 } from '../../src/utils/validation.js';
 
 describe('Validation Utilities', () => {
@@ -374,6 +375,30 @@ describe('Validation Utilities', () => {
       expect(() => validateLatitude(Number.MAX_VALUE)).toThrow();
       expect(() => validateLatitude(Number.MIN_VALUE)).not.toThrow();
       expect(() => validateLatitude(-0)).not.toThrow();
+    });
+  });
+
+  describe('validateDetail', () => {
+    it('defaults to "standard" when undefined', () => {
+      expect(validateDetail(undefined)).toBe('standard');
+    });
+
+    it('honors a custom default when undefined', () => {
+      expect(validateDetail(undefined, 'summary')).toBe('summary');
+    });
+
+    it('accepts each valid level', () => {
+      expect(validateDetail('summary')).toBe('summary');
+      expect(validateDetail('standard')).toBe('standard');
+      expect(validateDetail('full')).toBe('full');
+    });
+
+    it('rejects an unknown level', () => {
+      expect(() => validateDetail('verbose')).toThrow(/detail/i);
+    });
+
+    it('rejects a non-string value', () => {
+      expect(() => validateDetail(3 as unknown)).toThrow(/string/i);
     });
   });
 });

--- a/tests/unit/weather-summary-handler.test.ts
+++ b/tests/unit/weather-summary-handler.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the get_weather_summary composite handler.
+ *
+ * The sub-handlers are mocked so these tests focus on the summary handler's own
+ * behavior: section selection, aggregation, single location resolution, and
+ * graceful degradation when a section fails.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const currentMock = vi.fn();
+const forecastMock = vi.fn();
+const alertsMock = vi.fn();
+const airQualityMock = vi.fn();
+const lightningMock = vi.fn();
+
+vi.mock('../../src/handlers/currentConditionsHandler.js', () => ({
+  handleGetCurrentConditions: (...args: unknown[]) => currentMock(...args),
+}));
+vi.mock('../../src/handlers/forecastHandler.js', () => ({
+  handleGetForecast: (...args: unknown[]) => forecastMock(...args),
+}));
+vi.mock('../../src/handlers/alertsHandler.js', () => ({
+  handleGetAlerts: (...args: unknown[]) => alertsMock(...args),
+}));
+vi.mock('../../src/handlers/airQualityHandler.js', () => ({
+  handleGetAirQuality: (...args: unknown[]) => airQualityMock(...args),
+}));
+vi.mock('../../src/handlers/lightningHandler.js', () => ({
+  handleGetLightningActivity: (...args: unknown[]) => lightningMock(...args),
+}));
+
+import { handleGetWeatherSummary } from '../../src/handlers/weatherSummaryHandler.js';
+
+function textResult(text: string) {
+  return { content: [{ type: 'text', text }] };
+}
+
+const services = {
+  noaa: {} as any,
+  openMeteo: {} as any,
+  ncei: {} as any,
+  // Coordinate input means resolveLocationAsync never touches these
+  locationStore: {} as any,
+  geocoding: {} as any,
+};
+
+function callSummary(args: Record<string, unknown>) {
+  return handleGetWeatherSummary(
+    args,
+    services.noaa,
+    services.openMeteo,
+    services.ncei,
+    services.locationStore,
+    services.geocoding
+  );
+}
+
+describe('handleGetWeatherSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentMock.mockResolvedValue(textResult('# Current Weather Conditions\nSunny'));
+    forecastMock.mockResolvedValue(textResult('# Weather Forecast (Daily)\nWarm'));
+    alertsMock.mockResolvedValue(textResult('# Weather Alerts\nNone'));
+    airQualityMock.mockResolvedValue(textResult('# Air Quality Report\nGood'));
+    lightningMock.mockResolvedValue(textResult('# Lightning Activity Report\nSafe'));
+  });
+
+  it('includes current, forecast, and alerts by default', async () => {
+    const result = await callSummary({ latitude: 47.6, longitude: -122.3 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('# Weather Summary');
+    expect(text).toContain('**Includes:** current, forecast, alerts');
+    expect(text).toContain('Current Weather Conditions');
+    expect(text).toContain('Weather Forecast');
+    expect(text).toContain('Weather Alerts');
+
+    expect(currentMock).toHaveBeenCalledTimes(1);
+    expect(forecastMock).toHaveBeenCalledTimes(1);
+    expect(alertsMock).toHaveBeenCalledTimes(1);
+    expect(airQualityMock).not.toHaveBeenCalled();
+    expect(lightningMock).not.toHaveBeenCalled();
+  });
+
+  it('honors an explicit include list', async () => {
+    const result = await callSummary({
+      latitude: 47.6,
+      longitude: -122.3,
+      include: ['forecast', 'air_quality'],
+    });
+    const text = result.content[0].text;
+
+    expect(text).toContain('**Includes:** forecast, air_quality');
+    expect(forecastMock).toHaveBeenCalledTimes(1);
+    expect(airQualityMock).toHaveBeenCalledTimes(1);
+    expect(currentMock).not.toHaveBeenCalled();
+    expect(alertsMock).not.toHaveBeenCalled();
+  });
+
+  it('passes resolved coordinates (not a name) to every sub-handler', async () => {
+    await callSummary({ latitude: 47.6, longitude: -122.3 });
+
+    const firstCallArgs = forecastMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(firstCallArgs.latitude).toBe(47.6);
+    expect(firstCallArgs.longitude).toBe(-122.3);
+    // location_name/city_name stripped so no sub-handler re-geocodes
+    expect(firstCallArgs.location_name).toBeUndefined();
+    expect(firstCallArgs.city_name).toBeUndefined();
+  });
+
+  it('degrades gracefully when a section fails', async () => {
+    alertsMock.mockRejectedValue(new Error('alerts unavailable outside the US'));
+
+    const result = await callSummary({ latitude: 48.85, longitude: 2.35 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('alerts (unavailable)');
+    expect(text).toContain('alerts unavailable outside the US');
+    // Other sections still render
+    expect(text).toContain('Current Weather Conditions');
+    expect(text).toContain('Weather Forecast');
+  });
+
+  it('rejects an invalid include entry', async () => {
+    await expect(
+      callSummary({ latitude: 47.6, longitude: -122.3, include: ['forecast', 'bogus'] })
+    ).rejects.toThrow(/invalid include/i);
+  });
+
+  it('falls back to defaults for an empty include array', async () => {
+    await callSummary({ latitude: 47.6, longitude: -122.3, include: [] });
+
+    expect(currentMock).toHaveBeenCalledTimes(1);
+    expect(forecastMock).toHaveBeenCalledTimes(1);
+    expect(alertsMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Implements the findings from `docs/development/CODE_REVIEW_2026-07-13.md`.

## Summary

- **Universal location resolution.** Every location-based tool (`get_current_conditions`, `get_alerts`, `get_historical_weather`, `get_air_quality`, `get_marine_conditions`, `get_weather_imagery`, `get_lightning_activity`, `get_river_conditions`, `get_wildfire_info`) now accepts `latitude`+`longitude`, a saved `location_name`, **or** a free-text `city_name` (geocoded on demand) via a shared `LOCATION_SCHEMA_PROPERTIES` fragment and `resolveLocationAsync`. Name lookups echo the resolved place in a `**Location:**` header. Fixes the review's High finding where saved-location guidance advertised calls the schemas rejected.
- **New `get_weather_summary` composite tool.** One call aggregates current + forecast + alerts (optionally air quality + lightning), resolving location once and degrading gracefully when a section is unavailable (e.g. US-only alerts abroad).
- **`detail` output control** (`summary` | `standard` | `full`, default `standard`) on `get_forecast` (hourly cap), `get_alerts` (full NWS description only at `full`), and `get_weather_imagery` (direct URLs by default, embedded images at `full`).
- **Preset ladder reworked "summary-first".** Default `basic` is now 6 tools led by `get_weather_summary`; `standard` adds history, air quality, and saved-location tools (12); `full` is the complete 17-tool set (= `all`). Since every tool accepts `city_name`/`location_name`, the 6-tool default answers most weather questions on its own.
- **NOAA forecast** fetches point data once and reuses `gridId`/`gridX`/`gridY` (avoids duplicate upstream lookups).
- **`search_location`** now escapes provider-returned `name`/`display_name` for Markdown.

## Testing

- `npm run build` clean; **1,149 tests passing** (adds coverage for `validateDetail`, `formatLocationLine`/`prependLocationLine`, the summary handler, and alerts detail gating).
- End-to-end smoke test over stdio confirmed the tool list (17 tools), the summary-first default preset (6 tools), and `full` == `all` (17).

## Docs

README, `docs/TOOLS.md`, `CLAUDE.md`, and `CHANGELOG.md` updated; version bumped to **1.11.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)