### PR TITLE
Release: v1.8.3 → v1.11.0 (city_name, unit localization, universal location resolution, weather summary)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,27 @@ CACHE_MAX_SIZE=1000
 API_TIMEOUT_MS=30000
 
 # ============================================================================
+# UNITS / LOCALIZATION (v1.10.0)
+# ============================================================================
+# Default unit system for weather output (default: imperial)
+# Options: imperial (°F, mph, inHg, miles) or metric (°C, km/h, hPa, km)
+# Individual tool calls can override this per request via the "units" parameter.
+WEATHER_UNITS=imperial
+
+# Optional per-unit overrides (take precedence over WEATHER_UNITS).
+# Leave unset to follow the system preset above.
+#   WEATHER_TEMPERATURE_UNIT    F | C
+#   WEATHER_WIND_SPEED_UNIT     mph | kmh | ms | kn
+#   WEATHER_PRECIPITATION_UNIT  inch | mm
+#   WEATHER_PRESSURE_UNIT       inHg | hPa
+#   WEATHER_DISTANCE_UNIT       mi | km
+#   WEATHER_TIME_FORMAT         12h | 24h
+# Example: imperial everything, but wind in knots and 24-hour clock:
+#   WEATHER_UNITS=imperial
+#   WEATHER_WIND_SPEED_UNIT=kn
+#   WEATHER_TIME_FORMAT=24h
+
+# ============================================================================
 # LIGHTNING DETECTION (v1.5.0)
 # ============================================================================
 # MQTT broker URL for Blitzortung lightning detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-13
+
+### Added
+- **Unit localization for weather output** - Temperature, wind speed, precipitation, pressure, and distance/visibility/elevation can now be rendered in imperial or metric units. Set a server-wide default with the `WEATHER_UNITS` environment variable (`imperial` | `metric`, default `imperial`), or override per request with a `units` parameter on `get_forecast`, `get_current_conditions`, and `get_historical_weather`. This closes the gap that previously forced forks to hardcode Celsius in source.
+- **Per-unit overrides** - Pin individual units independently of the system, via env (`WEATHER_TEMPERATURE_UNIT`, `WEATHER_WIND_SPEED_UNIT`, `WEATHER_PRECIPITATION_UNIT`, `WEATHER_PRESSURE_UNIT`, `WEATHER_DISTANCE_UNIT`) or per-call params (`temperature_unit`, `wind_speed_unit`, `pressure_unit`, etc.). Wind supports `mph`, `kmh`, `ms`, and `kn` (knots); pressure supports `inHg` and `hPa`.
+- **12h / 24h clock format** - Times (forecast headers, sunrise/sunset, observation times) honor a `WEATHER_TIME_FORMAT` env default or per-call `time_format` parameter.
+
+### Changed
+- The Open-Meteo request now asks upstream for the requested units directly (no double conversion), and the NOAA forecast path uses the NWS `units=us|si` parameter. Unit-system signatures are included in cache keys so imperial and metric responses stay distinct.
+- Climate-normals output (`formatNormals`) is now unit-aware and matches the requested system.
+- Minor: the climate-normals "Normal Precipitation" line now uses the `in` label (was `"`), matching the rest of the forecast output.
+
+### Notes
+- Default output is unchanged (imperial), so existing users see no difference unless they opt in.
+- Domain-specialized readings keep their conventional units: fire-weather mixing height/transport wind, river gauge stage, and the marine tool's dual metric/imperial wave output are unaffected by this setting.
+
 ## [1.8.2] - 2026-07-07
 
 Documentation and packaging release — no functional changes to the server or tools.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-07-13
+
+### Fixed
+- **`get_historical_weather` header date shift** - The `**Period:**` line built a `Date` from the requested `start_date`/`end_date` and rendered it with `toLocaleDateString()`, which shifted the displayed range one day earlier in server timezones behind UTC (e.g. a `2024-01-10 → 2024-01-11` request showed `1/9/2024 to 1/10/2024`). Now displays the requested ISO dates directly. Observation data was always correct; only the header was wrong.
+- **`get_historical_weather` observation count** - The hourly header reported the total number of observations fetched rather than the number actually shown (e.g. `Number of observations: 48` when `limit: 3` returned 3 rows). Now shows the displayed count with the available total for context (`3 (of 48 available)`).
+
 ## [1.8.2] - 2026-07-07
 
 Documentation and packaging release — no functional changes to the server or tools.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-13
+
+### Added
+- **Universal location resolution across all weather tools** - Every location-based tool (`get_current_conditions`, `get_alerts`, `get_historical_weather`, `get_air_quality`, `get_marine_conditions`, `get_weather_imagery`, `get_lightning_activity`, `get_river_conditions`, `get_wildfire_info`) now accepts the same three location forms that `get_forecast` did: `latitude`+`longitude`, a saved `location_name`, or a free-text `city_name` (geocoded on demand). A shared `LOCATION_SCHEMA_PROPERTIES` fragment keeps the tool schemas consistent, and name-based lookups echo the resolved place and coordinates in a `**Location:**` header. This resolves the previous mismatch where saved-location guidance advertised calls the tool schemas rejected.
+- **`get_weather_summary` composite tool** - Answers broad "what's the weather like?" questions in a single call by aggregating current conditions, forecast, and alerts (optionally air quality and lightning) for one location. Accepts an `include` array, `detail`, and `days`. Location is resolved once and passed to each section so there is no repeated geocoding; a section that is unavailable (e.g. US-only alerts abroad) is noted rather than failing the whole summary.
+- **`detail` output control** - `get_forecast`, `get_alerts`, and `get_weather_imagery` accept `detail: "summary" | "standard" | "full"` (default `standard`) to trade completeness for token cost. Hourly forecasts are capped (24h summary / 48h standard) unless `full`; alerts include the full NWS description only at `full`; imagery returns direct URLs by default and embeds Markdown images only at `full`.
+
+### Changed
+- **Preset tiers reworked around a "summary-first" default.** The default `basic` preset (used when `ENABLED_TOOLS` is unset — what most users get) is now 6 tools led by `get_weather_summary`: `get_weather_summary`, `get_forecast`, `get_current_conditions`, `get_alerts`, `search_location`, `check_service_status`. `standard` adds history, air quality, and the four saved-location management tools (12 total). `full` adds the specialized environmental/safety tools (marine, imagery, lightning, river, wildfire) and is now the complete 17-tool set, identical to `all`. Because every tool accepts `city_name`/`location_name`, the default set answers most weather questions on its own.
+- The NOAA forecast path fetches point data once and reuses `gridId`/`gridX`/`gridY` for the forecast and gridpoint calls, avoiding duplicate upstream point lookups on a cold cache.
+
+### Fixed
+- `search_location` now escapes provider-returned strings (`name`, `display_name`) before embedding them in Markdown, matching the existing escaping of the user query.
+
 ## [1.10.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-13
+
+### Added
+- **`city_name` parameter for `get_forecast`** - Request a forecast by free-text place name (e.g. `city_name="Paris, France"` or `city_name="Bend, Oregon"`) without first saving the location or looking up coordinates. The name is geocoded on demand via the existing multi-provider geocoding service (Census/Nominatim/Open-Meteo), and the resolved place is disclosed in the output as a `**Location:**` header so an ambiguous match is transparent. Coordinates and saved `location_name` still take precedence when provided. (Inspired by the community `jablum` fork.)
+- **Geocode caching** - City-name lookups are cached with an infinite TTL (a place's coordinates are static), so repeated forecasts for the same city do not re-hit the geocoding providers.
+
 ## [1.8.2] - 2026-07-07
 
 Documentation and packaging release — no functional changes to the server or tools.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This document provides context and guidelines for AI assistants (Claude, etc.) w
 **Weather MCP Server** is a Model Context Protocol (MCP) server providing weather data from NOAA and Open-Meteo APIs. It enables AI assistants to fetch real-time weather forecasts, current conditions, historical data, air quality, marine conditions, and severe weather alerts.
 
 - **Language:** TypeScript (Node.js)
-- **Version:** 1.10.0 (Production Ready)
+- **Version:** 1.11.0 (Production Ready)
 - **License:** MIT
 - **MCP SDK:** @modelcontextprotocol/sdk v1.21.0
 
@@ -68,24 +68,28 @@ src/
 4. **Caching Strategy:** LRU cache with TTL based on data volatility (see `src/config/cache.ts`)
 5. **Error Hierarchy:** Custom error classes for different failure scenarios
 
-## Key Features (16 MCP Tools)
+## Key Features (17 MCP Tools)
 
-1. **get_forecast** - 7-day forecasts (NOAA/Open-Meteo, auto-select by location) - Supports saved locations via `location_name` and free-text place names via `city_name` (geocoded)
+All location-based tools accept coordinates, a saved `location_name`, or a
+free-text `city_name` (geocoded on demand) — see [Currently Supported Tools](#currently-supported-tools).
+
+1. **get_forecast** - 7-day forecasts (NOAA/Open-Meteo, auto-select by location); `detail` output control
 2. **get_current_conditions** - Current weather + fire weather indices (NOAA, US only)
-3. **get_alerts** - Weather alerts/warnings (NOAA, US only)
+3. **get_alerts** - Weather alerts/warnings (NOAA, US only); `detail` output control
 4. **get_historical_weather** - Historical data 1940-present (Open-Meteo, global)
-5. **check_service_status** - API health check (all services)
-6. **search_location** - Location search/geocoding (Nominatim/OSM, better small town coverage)
-7. **get_air_quality** - Air quality index + pollutants (Open-Meteo, global)
-8. **get_marine_conditions** - Wave height, swell, currents (Open-Meteo, global)
-9. **get_weather_imagery** - Weather radar/precipitation imagery (RainViewer, global)
-10. **get_lightning_activity** - Real-time lightning detection (Blitzortung.org, global)
-11. **get_river_conditions** - River levels and flood monitoring (NOAA/USGS, US only)
-12. **get_wildfire_info** - Active wildfire tracking (NIFC, US only)
-13. **save_location** - Save frequently used locations with aliases (NEW in v1.7.0)
-14. **list_saved_locations** - View all saved locations (NEW in v1.7.0)
-15. **get_saved_location** - Get details for a saved location (NEW in v1.7.0)
-16. **remove_saved_location** - Delete a saved location (NEW in v1.7.0)
+5. **get_weather_summary** - One-call overview: current + forecast + alerts (+ optional air quality, lightning) (NEW in v1.11.0)
+6. **check_service_status** - API health check (all services)
+7. **search_location** - Location search/geocoding (Nominatim/OSM, better small town coverage)
+8. **get_air_quality** - Air quality index + pollutants (Open-Meteo, global)
+9. **get_marine_conditions** - Wave height, swell, currents (Open-Meteo, global)
+10. **get_weather_imagery** - Weather radar/precipitation imagery (RainViewer, global); `detail` controls URL vs embedded images
+11. **get_lightning_activity** - Real-time lightning detection (Blitzortung.org, global)
+12. **get_river_conditions** - River levels and flood monitoring (NOAA/USGS, US only)
+13. **get_wildfire_info** - Active wildfire tracking (NIFC, US only)
+14. **save_location** - Save frequently used locations with aliases (NEW in v1.7.0)
+15. **list_saved_locations** - View all saved locations (NEW in v1.7.0)
+16. **get_saved_location** - Get details for a saved location (NEW in v1.7.0)
+17. **remove_saved_location** - Delete a saved location (NEW in v1.7.0)
 
 ## Development Guidelines
 
@@ -468,14 +472,17 @@ your_tool: {
 
 ### Currently Supported Tools
 
-- ✅ `get_forecast` - Full support for `location_name` (saved) and `city_name` (geocoded on demand)
+As of v1.11.0, **every location-based weather tool** accepts `location_name`
+(saved) and `city_name` (geocoded on demand) in addition to `latitude`/`longitude`,
+via the shared `resolveLocationAsync` helper and the `LOCATION_SCHEMA_PROPERTIES`
+schema fragment in `src/index.ts`. Name-based lookups echo the resolved place in a
+`**Location:**` header (see `formatLocationLine`/`prependLocationLine` in
+`src/utils/locationResolver.ts`):
 
-**Coming Soon:**
-- `get_current_conditions`
-- `get_alerts`
-- `get_air_quality`
-- `get_marine_conditions`
-- All other weather tools
+- ✅ `get_forecast`, `get_current_conditions`, `get_alerts`, `get_historical_weather`
+- ✅ `get_air_quality`, `get_marine_conditions`, `get_weather_imagery`
+- ✅ `get_lightning_activity`, `get_river_conditions`, `get_wildfire_info`
+- ✅ `get_weather_summary` (composite; resolves once, fans out to the above)
 
 ## Common Tasks
 
@@ -538,12 +545,13 @@ npm audit             # No critical vulnerabilities
 
 ## Project Status
 
-- **Version:** 1.10.0
+- **Version:** 1.11.0
 - **Status:** Production Ready ✅
+- **New in v1.11.0:** Universal location resolution (`location_name`/`city_name` on every location-based tool), `get_weather_summary` composite tool, `detail` output control (forecast/alerts/imagery), and a "summary-first" 6-tool default `basic` preset led by `get_weather_summary` (history, air quality, saved-location CRUD, and specialized tools live in `standard`/`full`)
 - **New in v1.10.0:** Unit localization — imperial/metric (plus per-unit overrides and 12h/24h) via `WEATHER_UNITS` env or a per-call `units` parameter on forecast/current/historical tools
 - **New in v1.9.0:** `city_name` parameter for `get_forecast` — request a forecast by free-text place name (geocoded on demand, with caching)
 - **Security Rating:** A- (Excellent, 93/100)
-- **Test Coverage:** 1,129 tests, 100% pass rate
+- **Test Coverage:** 1,149 tests, 100% pass rate
 - **Code Quality:** A+ (Excellent, 97.5/100)
 
 ## Useful References
@@ -566,6 +574,6 @@ npm audit             # No critical vulnerabilities
 
 ---
 
-**Last Updated:** 2026-07-13 (v1.10.0)
+**Last Updated:** 2026-07-13 (v1.11.0)
 
 This document should be updated whenever major architectural changes are made or new patterns are introduced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This document provides context and guidelines for AI assistants (Claude, etc.) w
 **Weather MCP Server** is a Model Context Protocol (MCP) server providing weather data from NOAA and Open-Meteo APIs. It enables AI assistants to fetch real-time weather forecasts, current conditions, historical data, air quality, marine conditions, and severe weather alerts.
 
 - **Language:** TypeScript (Node.js)
-- **Version:** 1.8.2 (Production Ready)
+- **Version:** 1.9.0 (Production Ready)
 - **License:** MIT
 - **MCP SDK:** @modelcontextprotocol/sdk v1.21.0
 
@@ -70,7 +70,7 @@ src/
 
 ## Key Features (16 MCP Tools)
 
-1. **get_forecast** - 7-day forecasts (NOAA/Open-Meteo, auto-select by location) - Now supports saved locations via `location_name`
+1. **get_forecast** - 7-day forecasts (NOAA/Open-Meteo, auto-select by location) - Supports saved locations via `location_name` and free-text place names via `city_name` (geocoded)
 2. **get_current_conditions** - Current weather + fire weather indices (NOAA, US only)
 3. **get_alerts** - Weather alerts/warnings (NOAA, US only)
 4. **get_historical_weather** - Historical data 1940-present (Open-Meteo, global)
@@ -459,7 +459,7 @@ your_tool: {
 
 ### Currently Supported Tools
 
-- ✅ `get_forecast` - Full support for `location_name`
+- ✅ `get_forecast` - Full support for `location_name` (saved) and `city_name` (geocoded on demand)
 
 **Coming Soon:**
 - `get_current_conditions`
@@ -529,11 +529,11 @@ npm audit             # No critical vulnerabilities
 
 ## Project Status
 
-- **Version:** 1.8.2
+- **Version:** 1.9.0
 - **Status:** Production Ready ✅
-- **New in v1.8.2:** Documentation overhaul: restructured README, new tool reference (docs/TOOLS.md), refreshed npm/registry metadata
+- **New in v1.9.0:** `city_name` parameter for `get_forecast` — request a forecast by free-text place name (geocoded on demand, with caching)
 - **Security Rating:** A- (Excellent, 93/100)
-- **Test Coverage:** 1,084 tests, 100% pass rate
+- **Test Coverage:** 1,105 tests, 100% pass rate
 - **Code Quality:** A+ (Excellent, 97.5/100)
 
 ## Useful References
@@ -556,6 +556,6 @@ npm audit             # No critical vulnerabilities
 
 ---
 
-**Last Updated:** 2026-07-07 (v1.8.2)
+**Last Updated:** 2026-07-13 (v1.9.0)
 
 This document should be updated whenever major architectural changes are made or new patterns are introduced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This document provides context and guidelines for AI assistants (Claude, etc.) w
 **Weather MCP Server** is a Model Context Protocol (MCP) server providing weather data from NOAA and Open-Meteo APIs. It enables AI assistants to fetch real-time weather forecasts, current conditions, historical data, air quality, marine conditions, and severe weather alerts.
 
 - **Language:** TypeScript (Node.js)
-- **Version:** 1.8.2 (Production Ready)
+- **Version:** 1.10.0 (Production Ready)
 - **License:** MIT
 - **MCP SDK:** @modelcontextprotocol/sdk v1.21.0
 
@@ -270,11 +270,20 @@ CACHE_MAX_SIZE=1000            # Max cache entries (100-10000, default: 1000)
 # API Configuration
 API_TIMEOUT_MS=30000           # API timeout in milliseconds (5000-120000, default: 30000)
 
+# Units / Localization (v1.10.0)
+WEATHER_UNITS=imperial         # imperial | metric (default: imperial)
+# Optional per-unit overrides (follow WEATHER_UNITS if unset):
+#   WEATHER_TEMPERATURE_UNIT (F|C), WEATHER_WIND_SPEED_UNIT (mph|kmh|ms|kn),
+#   WEATHER_PRECIPITATION_UNIT (inch|mm), WEATHER_PRESSURE_UNIT (inHg|hPa),
+#   WEATHER_DISTANCE_UNIT (mi|km), WEATHER_TIME_FORMAT (12h|24h)
+
 # Logging
 LOG_LEVEL=1                    # 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (default: 1)
 ```
 
-All environment variables are validated with bounds checking in `src/config/cache.ts`.
+Cache/API/logging variables are validated in `src/config/cache.ts`; unit variables
+are parsed and validated in `src/config/units.ts`. Per-call unit parameters are
+resolved by `src/utils/unitPreferences.ts` and formatted via `src/utils/unitFormat.ts`.
 
 ## Caching Strategy
 
@@ -529,11 +538,11 @@ npm audit             # No critical vulnerabilities
 
 ## Project Status
 
-- **Version:** 1.8.2
+- **Version:** 1.10.0
 - **Status:** Production Ready ✅
-- **New in v1.8.2:** Documentation overhaul: restructured README, new tool reference (docs/TOOLS.md), refreshed npm/registry metadata
+- **New in v1.10.0:** Unit localization — imperial/metric (plus per-unit overrides and 12h/24h) via `WEATHER_UNITS` env or a per-call `units` parameter on forecast/current/historical tools
 - **Security Rating:** A- (Excellent, 93/100)
-- **Test Coverage:** 1,084 tests, 100% pass rate
+- **Test Coverage:** 1,116 tests, 100% pass rate
 - **Code Quality:** A+ (Excellent, 97.5/100)
 
 ## Useful References
@@ -556,6 +565,6 @@ npm audit             # No critical vulnerabilities
 
 ---
 
-**Last Updated:** 2026-07-07 (v1.8.2)
+**Last Updated:** 2026-07-13 (v1.10.0)
 
 This document should be updated whenever major architectural changes are made or new patterns are introduced.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Tests](https://img.shields.io/badge/tests-1%2C129%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 
-**Give your AI assistant real weather data — 16 tools, zero API keys, zero signup, zero cost.**
+**Give your AI assistant real weather data — 17 tools, zero API keys, zero signup, zero cost.**
 
 Weather MCP is a [Model Context Protocol](https://modelcontextprotocol.io) server that connects AI assistants (Claude, Cursor, Cline, Zed, and any other MCP client) to live weather data: forecasts, current conditions, alerts, air quality, marine conditions, lightning, radar, rivers, wildfires, and 85+ years of historical weather. It's built entirely on free public data sources — NOAA, Open-Meteo, USGS, NIFC, RainViewer, and Blitzortung.org — so there is nothing to sign up for and no key to paste in.
 
@@ -47,13 +47,13 @@ Choose this one if you want:
 - **No API keys** — install to first forecast in under a minute. Nothing to configure, nothing to leak into a repo.
 - **Fully open source** — MIT licensed, readable TypeScript, 1,129 tests. Audit it, fork it, fix it.
 - **Privacy-respecting** — your queries go directly from your machine to public weather APIs. No middleman server, no telemetry.
-- **Breadth** — 16 tools covering weather, safety hazards (lightning, floods, wildfires), marine conditions, air quality, and historical data back to 1940. Most weather MCPs stop at forecasts.
+- **Breadth** — 17 tools covering weather, safety hazards (lightning, floods, wildfires), marine conditions, air quality, and historical data back to 1940. Most weather MCPs stop at forecasts.
 
 The tradeoff is honest: US data (NOAA) is richer than international data (Open-Meteo), some tools are US-only, and free APIs come with fair-use rate limits. See [Coverage & Limitations](#coverage--limitations).
 
 ## Tools
 
-All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
+All 17 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 
 | Tool | What it does | Coverage |
 |------|-------------|----------|
@@ -61,6 +61,7 @@ All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 | `get_current_conditions` | Real-time observations: temperature, wind, heat index/wind chill, snow depth, optional fire-weather indices | 🇺🇸 US |
 | `get_alerts` | Active watches, warnings, and advisories sorted by severity | 🇺🇸 US |
 | `get_historical_weather` | Hourly/daily observations from 1940 to present | 🌍 Global |
+| `get_weather_summary` | One-call overview combining current conditions, forecast, and alerts (optionally air quality and lightning) | 🌍 Global |
 | `search_location` | Geocode place names to coordinates ("Paris" → 48.85, 2.35) | 🌍 Global |
 | `get_air_quality` | AQI (US/European scales), pollutants, UV index, health guidance | 🌍 Global |
 | `get_marine_conditions` | Wave height, swell, ocean currents, Douglas Sea Scale — includes Great Lakes and major US bays | 🌍 Global |
@@ -74,7 +75,11 @@ All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 | `get_saved_location` | Details for one saved location | — |
 | `remove_saved_location` | Delete a saved location | — |
 
-> **Default preset:** to keep your AI's context lean, the server exposes 5 essential tools by default (`forecast`, `current_conditions`, `alerts`, `search_location`, `check_service_status`). Enable everything with one environment variable — see [Tool Selection](#tool-selection).
+> **Default preset:** with no configuration, the server exposes 6 tools led by `get_weather_summary` (one call covers most "what's the weather?" questions), plus `forecast`, `current_conditions`, `alerts`, `search_location`, and `check_service_status`. Enable everything with one environment variable — see [Tool Selection](#tool-selection).
+
+> **Consistent location input:** every location-based tool accepts the same three forms — `latitude`+`longitude`, a saved `location_name` (e.g. `"home"`), or a free-text `city_name` (e.g. `"Bend, Oregon"`, geocoded automatically). When a name is used, the response echoes the resolved place and coordinates.
+
+> **Output verbosity:** high-volume tools (`get_forecast`, `get_alerts`, `get_weather_imagery`) accept `detail: "summary" | "standard" | "full"` (default `standard`) to trade completeness for token cost — e.g. `full` returns the complete alert text and uncapped hourly forecast.
 
 ## Feature highlights
 
@@ -185,10 +190,10 @@ Control which tools are exposed to reduce context overhead:
 
 | Preset | Tools |
 |--------|-------|
-| `basic` (default) | forecast, current_conditions, alerts, search_location, check_service_status |
-| `standard` | basic + historical_weather |
-| `full` | standard + air_quality |
-| `all` | everything — all 16 tools including marine, imagery, lightning, rivers, wildfire, and saved locations |
+| `basic` (default) | weather_summary, forecast, current_conditions, alerts, search_location, check_service_status |
+| `standard` | basic + historical_weather, air_quality, and saved-location tools |
+| `full` | everything — standard + marine, imagery, lightning, rivers, wildfire (same as `all`) |
+| `all` | all 17 tools |
 
 ```bash
 ENABLED_TOOLS=all                               # Use a preset
@@ -280,7 +285,7 @@ To report a vulnerability, see [SECURITY.md](./SECURITY.md).
 
 ## Documentation
 
-- **[Tool Reference](./docs/TOOLS.md)** — all 16 tools: parameters, examples, sample output
+- **[Tool Reference](./docs/TOOLS.md)** — all 17 tools: parameters, examples, sample output
 - **[Client Setup](./docs/CLIENT_SETUP.md)** — step-by-step for 8 MCP clients
 - **[Error Handling](./docs/ERROR_HANDLING.md)** — how failures are reported
 - **[Testing Guide](./docs/testing/TESTING_GUIDE.md)** — manual testing procedures

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/@dangahagan%2Fweather-mcp.svg)](https://www.npmjs.com/package/@dangahagan/weather-mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.dgahagan/weather-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-1%2C084%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
+[![Tests](https://img.shields.io/badge/tests-1%2C105%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 
 **Give your AI assistant real weather data — 16 tools, zero API keys, zero signup, zero cost.**
@@ -45,7 +45,7 @@ Choose this one if you want:
 
 - **Genuinely free** — every data source is a free public API. No trial that expires, no credit card, no rate-limited "free tier" bait.
 - **No API keys** — install to first forecast in under a minute. Nothing to configure, nothing to leak into a repo.
-- **Fully open source** — MIT licensed, readable TypeScript, 1,084 tests. Audit it, fork it, fix it.
+- **Fully open source** — MIT licensed, readable TypeScript, 1,105 tests. Audit it, fork it, fix it.
 - **Privacy-respecting** — your queries go directly from your machine to public weather APIs. No middleman server, no telemetry.
 - **Breadth** — 16 tools covering weather, safety hazards (lightning, floods, wildfires), marine conditions, air quality, and historical data back to 1940. Most weather MCPs stop at forecasts.
 
@@ -57,7 +57,7 @@ All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 
 | Tool | What it does | Coverage |
 |------|-------------|----------|
-| `get_forecast` | Daily/hourly forecasts up to 16 days, sunrise/sunset, UV, precipitation probability, optional climate-normals comparison | 🌍 Global |
+| `get_forecast` | Daily/hourly forecasts up to 16 days by coordinates, saved location, or city name; sunrise/sunset, UV, precipitation probability, optional climate-normals comparison | 🌍 Global |
 | `get_current_conditions` | Real-time observations: temperature, wind, heat index/wind chill, snow depth, optional fire-weather indices | 🇺🇸 US |
 | `get_alerts` | Active watches, warnings, and advisories sorted by severity | 🇺🇸 US |
 | `get_historical_weather` | Hourly/daily observations from 1940 to present | 🌍 Global |
@@ -234,7 +234,7 @@ Being honest about what free public data can and can't do:
 ```bash
 npm run build          # Compile TypeScript
 npm run dev            # Run in development mode
-npm test               # Run all 1,084 tests (~2 seconds)
+npm test               # Run all 1,105 tests (~2 seconds)
 npm run test:coverage  # Coverage report
 npm run audit          # Dependency vulnerability scan
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/@dangahagan%2Fweather-mcp.svg)](https://www.npmjs.com/package/@dangahagan/weather-mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.dgahagan/weather-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-1%2C084%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
+[![Tests](https://img.shields.io/badge/tests-1%2C116%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 
 **Give your AI assistant real weather data — 16 tools, zero API keys, zero signup, zero cost.**
@@ -45,7 +45,7 @@ Choose this one if you want:
 
 - **Genuinely free** — every data source is a free public API. No trial that expires, no credit card, no rate-limited "free tier" bait.
 - **No API keys** — install to first forecast in under a minute. Nothing to configure, nothing to leak into a repo.
-- **Fully open source** — MIT licensed, readable TypeScript, 1,084 tests. Audit it, fork it, fix it.
+- **Fully open source** — MIT licensed, readable TypeScript, 1,116 tests. Audit it, fork it, fix it.
 - **Privacy-respecting** — your queries go directly from your machine to public weather APIs. No middleman server, no telemetry.
 - **Breadth** — 16 tools covering weather, safety hazards (lightning, floods, wildfires), marine conditions, air quality, and historical data back to 1940. Most weather MCPs stop at forecasts.
 
@@ -84,6 +84,7 @@ All 16 tools, documented in detail in **[docs/TOOLS.md](./docs/TOOLS.md)**:
 - **Safety-aware output** — lightning, wildfire, flood, and marine tools include graded safety assessments and plain-language recommendations, not just raw numbers.
 - **Winter weather** — snow depth, snowfall accumulation, and ice accumulation forecasts with sensible trace-amount filtering.
 - **Timezone-aware** — every timestamp is rendered in the location's local time with DST handled correctly.
+- **Imperial or metric** — pick your units server-wide (`WEATHER_UNITS`) or per request (`units: "metric"`), with fine-grained overrides (wind in knots, pressure in hPa, 24-hour clock). Defaults to imperial. See [Units & Localization](#units--localization).
 - **Built-in caching** — an LRU cache with per-data-type TTLs (5 minutes for alerts, 2 hours for forecasts, forever for finalized historical data) makes repeat queries return in <10ms and cuts upstream API calls by 50–80%.
 - **Actionable errors** — failures explain what happened and link to the upstream status page instead of dumping a stack trace.
 
@@ -198,11 +199,32 @@ ENABLED_TOOLS=all,-marine                       # Remove from a preset
 
 Short aliases are supported: `forecast`, `current`, `alerts`, `historical`, `status`, `search`, `aqi`, `marine`, `radar`, `lightning`, and more.
 
+### Units & Localization
+
+Output defaults to **imperial** (°F, mph, inHg, miles) and can be switched to **metric** (°C, km/h, hPa, km) server-wide or per request. Precedence: a per-call parameter beats a per-unit env override, which beats the `WEATHER_UNITS` system default.
+
+```bash
+WEATHER_UNITS=metric            # switch everything to metric
+WEATHER_WIND_SPEED_UNIT=kn      # ...but wind in knots
+WEATHER_TIME_FORMAT=24h         # 24-hour clock
+```
+
+Or per call — the AI can honor "in Celsius" on the fly:
+
+```jsonc
+{ "latitude": 47.6, "longitude": -122.3, "units": "metric" }
+{ "latitude": 47.6, "longitude": -122.3, "wind_speed_unit": "kn", "pressure_unit": "hPa" }
+```
+
+Supported on `get_forecast`, `get_current_conditions`, and `get_historical_weather`. Wind accepts `mph`/`kmh`/`ms`/`kn`; pressure `inHg`/`hPa`. Domain-specialized readings (fire-weather heights, river gauge stage, and the marine tool's dual-unit wave output) keep their conventional units.
+
 ### Other settings
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `ENABLED_TOOLS` | `basic` | Tool preset or list (see above) |
+| `WEATHER_UNITS` | `imperial` | Default unit system: `imperial` or `metric` |
+| `WEATHER_TEMPERATURE_UNIT` … | — | Per-unit overrides: `_TEMPERATURE_`(F/C), `_WIND_SPEED_`(mph/kmh/ms/kn), `_PRECIPITATION_`(inch/mm), `_PRESSURE_`(inHg/hPa), `_DISTANCE_`(mi/km), `_TIME_FORMAT`(12h/24h) |
 | `CACHE_ENABLED` | `true` | Enable/disable response caching |
 | `CACHE_MAX_SIZE` | `1000` | Max cache entries (100–10000) |
 | `API_TIMEOUT_MS` | `30000` | Upstream API timeout (5000–120000) |
@@ -234,7 +256,7 @@ Being honest about what free public data can and can't do:
 ```bash
 npm run build          # Compile TypeScript
 npm run dev            # Run in development mode
-npm test               # Run all 1,084 tests (~2 seconds)
+npm test               # Run all 1,116 tests (~2 seconds)
 npm run test:coverage  # Coverage report
 npm run audit          # Dependency vulnerability scan
 ```

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -44,20 +44,22 @@ Get weather forecast for any location worldwide.
 - `latitude` (required*): Latitude coordinate (-90 to 90)
 - `longitude` (required*): Longitude coordinate (-180 to 180)
 - `location_name` (optional): Name of a saved location (e.g., "home") — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode (e.g., "Paris, France", "Bend, Oregon") — use instead of coordinates when you only have a place name
 - `days` (optional): Number of days in forecast (1-16, default: 7)
 - `granularity` (optional): "daily" or "hourly" (default: "daily")
 - `include_precipitation_probability` (optional): Include rain chances (default: true)
 - `include_normals` (optional): Include climate normals for comparison (default: false)
 - `source` (optional): "auto" (default), "noaa" (US only), or "openmeteo" (global)
 
-*Coordinates not required when `location_name` is provided.
+*Coordinates not required when `location_name` or `city_name` is provided. Precedence: coordinates > `location_name` > `city_name`.
 
 **Description:**
-Automatically selects the best data source: NOAA for US locations (more detailed) or Open-Meteo for international locations. Supports extended forecasts up to 16 days. Includes sunrise/sunset times, daylight duration, temperature, precipitation, wind, and UV index.
+Automatically selects the best data source: NOAA for US locations (more detailed) or Open-Meteo for international locations. Supports extended forecasts up to 16 days. Includes sunrise/sunset times, daylight duration, temperature, precipitation, wind, and UV index. When a location is resolved from `location_name` or `city_name`, the matched place is shown in a `**Location:**` header so ambiguous names are transparent.
 
 **Examples:**
 ```
 "Get a 7-day forecast for Paris (48.8534, 2.3488)"
+"What's the forecast for Bend, Oregon?"   (uses city_name — no coordinates needed)
 "Hourly forecast for Tokyo for the next 3 days"
 "16-day extended forecast for Sydney, Australia"
 ```

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -33,6 +33,7 @@ Complete reference for all 16 MCP tools provided by the Weather MCP Server.
 Also in this document:
 - [Finding Coordinates](#finding-coordinates)
 - [Using Saved Locations with Weather Tools](#using-saved-locations-with-weather-tools)
+- [Units & Localization](#units--localization)
 - [Error Handling & Service Status](#error-handling--service-status)
 
 ---
@@ -49,6 +50,8 @@ Get weather forecast for any location worldwide.
 - `include_precipitation_probability` (optional): Include rain chances (default: true)
 - `include_normals` (optional): Include climate normals for comparison (default: false)
 - `source` (optional): "auto" (default), "noaa" (US only), or "openmeteo" (global)
+- `units` (optional): "imperial" (default) or "metric" — see [Units & Localization](#units--localization)
+- Unit overrides (optional): `temperature_unit`, `wind_speed_unit`, `precipitation_unit`, `pressure_unit`, `distance_unit`, `time_format`
 
 *Coordinates not required when `location_name` is provided.
 
@@ -82,6 +85,7 @@ Get current weather conditions for a location (US only).
 - `longitude` (required): Longitude coordinate (-180 to 180)
 - `include_fire_weather` (optional): Include fire weather indices (default: false)
 - `include_normals` (optional): Include climate normals for comparison (default: false)
+- `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
 
 **Example:**
 ```
@@ -134,6 +138,7 @@ Get historical weather observations for a location.
 - `start_date` (required): Start date in ISO format (YYYY-MM-DD)
 - `end_date` (required): End date in ISO format (YYYY-MM-DD)
 - `limit` (optional): Max observations to return (1-500, default: 168)
+- `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
 
 **Data Source Selection:**
 The server automatically chooses the best data source based on your date range:
@@ -584,6 +589,32 @@ get_forecast(location_name="home")
 - `get_forecast` - Weather forecasts using saved locations
 
 **Coming Soon:** Support for saved locations in all weather tools (current conditions, alerts, air quality, marine conditions, etc.)
+
+## Units & Localization
+
+Weather output defaults to **imperial** units and can be switched to **metric** either server-wide (environment variables) or per request (tool parameters). Precedence, highest first: a per-call `*_unit` override → a per-call `units` preset → a per-unit env override → the `WEATHER_UNITS` env default → imperial.
+
+**Per-call parameters** (on `get_forecast`, `get_current_conditions`, `get_historical_weather`):
+
+| Parameter | Values | Applies to |
+|-----------|--------|------------|
+| `units` | `imperial`, `metric` | Whole system (sets all of the below) |
+| `temperature_unit` | `F`, `C` | Temperature, dewpoint, feels-like, normals |
+| `wind_speed_unit` | `mph`, `kmh`, `ms`, `kn` | Wind speed and gusts |
+| `precipitation_unit` | `inch`, `mm` | Precipitation, snowfall |
+| `pressure_unit` | `inHg`, `hPa` | Barometric pressure |
+| `distance_unit` | `mi`, `km` | Visibility, elevation |
+| `time_format` | `12h`, `24h` | Clock times (headers, sunrise/sunset) |
+
+**Environment defaults:** `WEATHER_UNITS` (`imperial`\|`metric`), plus `WEATHER_TEMPERATURE_UNIT`, `WEATHER_WIND_SPEED_UNIT`, `WEATHER_PRECIPITATION_UNIT`, `WEATHER_PRESSURE_UNIT`, `WEATHER_DISTANCE_UNIT`, `WEATHER_TIME_FORMAT`.
+
+**Examples:**
+```
+"What's the forecast for Berlin in Celsius?"  → units: "metric"
+"Wind in knots for the marina"                → wind_speed_unit: "kn"
+```
+
+**Note:** Fire-weather heights/transport wind, river gauge stage, and the marine tool's wave output use their domain-standard units and are not affected by this setting.
 
 ## Error Handling & Service Status
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,8 +1,10 @@
 # Tool Reference
 
-Complete reference for all 16 MCP tools provided by the Weather MCP Server.
+Complete reference for all 17 MCP tools provided by the Weather MCP Server.
 
-> **Note on tool presets:** By default the server exposes the `basic` preset (5 tools). Set `ENABLED_TOOLS=all` to enable everything. See [Tool Selection](../README.md#tool-selection) in the README.
+> **Note on tool presets:** By default the server exposes the `basic` preset (6 tools, led by `get_weather_summary`). Set `ENABLED_TOOLS=all` to enable everything. See [Tool Selection](../README.md#tool-selection) in the README.
+
+> **Common parameters (all location-based tools):** Every weather tool accepts the location in one of three ways — `latitude`+`longitude`, a saved `location_name` (e.g. `"home"`), or a free-text `city_name` (e.g. `"Bend, Oregon"`, geocoded on demand). Precedence: coordinates > `location_name` > `city_name`. When a name is used, the response echoes the resolved place in a `**Location:**` header. The high-volume tools (`get_forecast`, `get_alerts`, `get_weather_imagery`) also accept `detail`: `summary` | `standard` (default) | `full`.
 
 ## Contents
 
@@ -11,24 +13,25 @@ Complete reference for all 16 MCP tools provided by the Weather MCP Server.
 2. [get_current_conditions](#2-get_current_conditions) — Real-time observations, US
 3. [get_alerts](#3-get_alerts) — Watches/warnings/advisories, US
 4. [get_historical_weather](#4-get_historical_weather) — 1940–present, global
-5. [search_location](#5-search_location) — Geocoding, global
-6. [check_service_status](#6-check_service_status) — API health checks
+5. [get_weather_summary](#5-get_weather_summary) — One-call combined overview, global
+6. [search_location](#6-search_location) — Geocoding, global
+7. [check_service_status](#7-check_service_status) — API health checks
 
 **Environment & Safety**
 
-7. [get_air_quality](#7-get_air_quality) — AQI + pollutants, global
-8. [get_marine_conditions](#8-get_marine_conditions) — Waves/swell/currents, global
-9. [get_weather_imagery](#9-get_weather_imagery) — Radar, precipitation, and satellite imagery
-10. [get_lightning_activity](#10-get_lightning_activity) — Strike detection, global
-11. [get_river_conditions](#11-get_river_conditions) — River levels/flooding, US
-12. [get_wildfire_info](#12-get_wildfire_info) — Active fires, US
+8. [get_air_quality](#8-get_air_quality) — AQI + pollutants, global
+9. [get_marine_conditions](#9-get_marine_conditions) — Waves/swell/currents, global
+10. [get_weather_imagery](#10-get_weather_imagery) — Radar, precipitation, and satellite imagery
+11. [get_lightning_activity](#11-get_lightning_activity) — Strike detection, global
+12. [get_river_conditions](#12-get_river_conditions) — River levels/flooding, US
+13. [get_wildfire_info](#13-get_wildfire_info) — Active fires, US
 
 **Saved Locations**
 
-13. [save_location](#13-save_location)
-14. [list_saved_locations](#14-list_saved_locations)
-15. [get_saved_location](#15-get_saved_location)
-16. [remove_saved_location](#16-remove_saved_location)
+14. [save_location](#14-save_location)
+15. [list_saved_locations](#15-list_saved_locations)
+16. [get_saved_location](#16-get_saved_location)
+17. [remove_saved_location](#17-remove_saved_location)
 
 Also in this document:
 - [Finding Coordinates](#finding-coordinates)
@@ -83,11 +86,15 @@ Automatically selects the best data source: NOAA for US locations (more detailed
 Get current weather conditions for a location (US only).
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `include_fire_weather` (optional): Include fire weather indices (default: false)
 - `include_normals` (optional): Include climate normals for comparison (default: false)
 - `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Example:**
 ```
@@ -109,9 +116,14 @@ What are the current weather conditions in New York? (latitude: 40.7128, longitu
 Get active weather alerts, watches, warnings, and advisories for US locations.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `active_only` (optional): Show only active alerts (default: true)
+- `detail` (optional): `summary` (headline + timing), `standard` (default; adds instructions), or `full` (adds the complete NWS description)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Retrieves current weather alerts from the NOAA API for safety-critical weather information. Returns severity levels (Extreme, Severe, Moderate, Minor), urgency indicators, effective/expiration times, and affected areas. Alerts are automatically sorted by severity with the most critical first.
@@ -135,12 +147,16 @@ Retrieves current weather alerts from the NOAA API for safety-critical weather i
 Get historical weather observations for a location.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `start_date` (required): Start date in ISO format (YYYY-MM-DD)
 - `end_date` (required): End date in ISO format (YYYY-MM-DD)
 - `limit` (optional): Max observations to return (1-500, default: 168)
 - `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Data Source Selection:**
 The server automatically chooses the best data source based on your date range:
@@ -191,7 +207,34 @@ If you get "No historical data available":
 - Note: Most recent data has a 5-day delay
 - Very recent dates (last 5 days) may not be available in archival data yet
 
-### 5. search_location
+### 5. get_weather_summary
+Get a combined weather overview for a location in a single call.
+
+**Parameters:**
+- `latitude` / `longitude` (required*): Coordinates (-90 to 90 / -180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
+- `include` (optional): Array of sections to include — any of `current`, `forecast`, `alerts`, `air_quality`, `lightning` (default: `["current", "forecast", "alerts"]`)
+- `days` (optional): Forecast days when the forecast section is included (1-16, default: 7)
+- `detail` (optional): `summary` (default here), `standard`, or `full`
+- `units` (optional): "imperial" (default) or "metric", plus per-unit overrides — see [Units & Localization](#units--localization)
+
+*Coordinates not required when `location_name` or `city_name` is provided. Precedence: coordinates > `location_name` > `city_name`.
+
+**Description:**
+Best for broad questions like "What's the weather like in Seattle?" or "Is it safe to hike today?". Aggregates several specialized tools for one location in a single response, resolving the location once so there is no repeated geocoding. Sections that are unavailable for a location (e.g. US-only alerts abroad) are noted rather than failing the whole summary. For a single specific data product, call that specialized tool directly.
+
+**Examples:**
+```
+"Give me a weather rundown for Bend, Oregon"
+"What's the weather like at home, and is there any lightning?"  (include=["current","forecast","lightning"])
+```
+
+**Returns:**
+- A `# Weather Summary` header with the resolved location and the included sections
+- Each requested section's full output (current conditions, forecast, alerts, air quality, lightning), separated by rules
+
+### 6. search_location
 Find coordinates for any location worldwide by name.
 
 **Parameters:**
@@ -216,7 +259,7 @@ Converts location names to coordinates. Returns multiple matches with detailed m
 - Country and region information
 - Feature type (capital, city, airport, etc.)
 
-### 6. check_service_status
+### 7. check_service_status
 Check the operational status of weather APIs and cache performance.
 
 **Parameters:** None
@@ -236,13 +279,17 @@ Check if the weather services are operational
 - Status page links and recommended actions if issues are detected
 - Overall service availability summary
 
-### 7. get_air_quality
+### 8. get_air_quality
 Get comprehensive air quality data for any location worldwide.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `forecast` (optional): Include hourly forecast for next 5 days (default: false)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides current air quality conditions using the Open-Meteo Air Quality API with automatic AQI scale selection (US AQI for US locations, European EAQI elsewhere). Includes health recommendations, pollutant concentrations, and UV index.
@@ -262,13 +309,17 @@ Provides current air quality conditions using the Open-Meteo Air Quality API wit
 - Activity recommendations for sensitive groups
 - Optional 5-day hourly forecast
 
-### 8. get_marine_conditions
+### 9. get_marine_conditions
 Get marine weather conditions including wave height, swell, ocean currents, and sea state with automatic source selection for Great Lakes and coastal bays.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `forecast` (optional): Include 5-day marine forecast (default: false)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides comprehensive marine weather data with intelligent dual-source support:
@@ -295,14 +346,19 @@ Provides comprehensive marine weather data with intelligent dual-source support:
 - Wave period for planning and safety
 - Optional 5-day forecast with daily summaries
 
-### 9. get_weather_imagery
+### 10. get_weather_imagery
 Get weather radar, precipitation, and satellite imagery for visual weather analysis.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `type` (optional): Imagery type - "precipitation" (default), "radar", or "satellite"
 - `animated` (optional): Return animated loop vs static image (default: false)
+- `detail` (optional): `summary`/`standard` (default) surface direct image URLs; `full` embeds Markdown images
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 - `layers` (optional): Additional map layers (reserved for future use)
 
 **Description:**
@@ -327,14 +383,18 @@ Provides access to weather imagery from two sources: precipitation/radar tiles f
 
 **Note:** Precipitation/radar coverage is global (RainViewer). Satellite coverage is Western Hemisphere only (GOES GeoColor via NASA GIBS).
 
-### 10. get_lightning_activity
+### 11. get_lightning_activity
 Get real-time lightning strike detection and safety assessment for outdoor activity planning.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `radius` (optional): Search radius in kilometers (1-500, default: 100)
 - `timeWindow` (optional): Historical time window in minutes (1-180, default: 60)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides real-time lightning strike detection from the Blitzortung.org global lightning detection network. Includes comprehensive safety assessment with 4 risk levels based on strike proximity. Critical for outdoor safety planning including boating, hiking, golfing, and other outdoor activities.
@@ -368,13 +428,17 @@ Provides real-time lightning strike detection from the Blitzortung.org global li
 
 **Note:** Data provided by Blitzortung.org, a free community-operated lightning detection network. May have regional coverage variations.
 
-### 11. get_river_conditions
+### 12. get_river_conditions
 Monitor river levels and flood status using NOAA and USGS data sources.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `radius` (optional): Search radius in kilometers (1-500, default: 50)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides comprehensive river and streamflow monitoring for flood safety and recreation planning. Automatically finds the nearest river gauges within the specified radius and reports current water levels, flood stages, and flow rates. Uses NOAA National Water Prediction Service (NWPS) for gauge locations and USGS Water Services for real-time streamflow data.
@@ -399,13 +463,17 @@ Provides comprehensive river and streamflow monitoring for flood safety and recr
 
 **Note:** US coverage only. Data provided by NOAA National Water Prediction Service and USGS Water Services.
 
-### 12. get_wildfire_info
+### 13. get_wildfire_info
 Monitor active wildfires and fire perimeters for safety and evacuation planning.
 
 **Parameters:**
-- `latitude` (required): Latitude coordinate (-90 to 90)
-- `longitude` (required): Longitude coordinate (-180 to 180)
+- `latitude` (required*): Latitude coordinate (-90 to 90)
+- `longitude` (required*): Longitude coordinate (-180 to 180)
+- `location_name` (optional): Name of a saved location — use instead of coordinates
+- `city_name` (optional): Free-text place name to geocode — use instead of coordinates
 - `radius` (optional): Search radius in kilometers (1-500, default: 100)
+
+*Coordinates not required when `location_name` or `city_name` is provided.
 
 **Description:**
 Provides critical wildfire monitoring and safety information using NIFC (National Interagency Fire Center) data. Reports active wildfires and prescribed burns within the specified radius, including fire size, containment status, and proximity-based safety assessments. Essential for residents in fire-prone regions and outdoor activity planning.
@@ -435,7 +503,7 @@ Provides critical wildfire monitoring and safety information using NIFC (Nationa
 
 **Note:** Data from NIFC WFIGS (Wildland Fire Interagency Geospatial Services). Always consult official sources for evacuation orders at https://inciweb.nwcg.gov/
 
-### 13. save_location
+### 14. save_location
 Save a location with an alias for easy reuse in weather queries.
 
 **Parameters:**
@@ -480,7 +548,7 @@ Saves a location to persistent storage (`~/.weather-mcp/locations.json`) for eas
 - Coordinates, timezone, and administrative region
 - Usage examples showing how to use with weather tools
 
-### 14. list_saved_locations
+### 15. list_saved_locations
 View all saved locations.
 
 **Parameters:** None
@@ -500,7 +568,7 @@ Lists all locations saved in your persistent storage with their aliases, names, 
 - Usage examples for each location
 - Total count of saved locations
 
-### 15. get_saved_location
+### 16. get_saved_location
 Get details for a specific saved location.
 
 **Parameters:**
@@ -522,7 +590,7 @@ Retrieves detailed information about a specific saved location, including coordi
 - Save and update timestamps
 - Usage examples
 
-### 16. remove_saved_location
+### 17. remove_saved_location
 Remove a saved location.
 
 **Parameters:**

--- a/docs/development/CODE_REVIEW_2026-07-13.md
+++ b/docs/development/CODE_REVIEW_2026-07-13.md
@@ -1,0 +1,317 @@
+# Code Review - 2026-07-13
+
+## Scope
+
+Reviewed the Weather MCP TypeScript server with emphasis on:
+
+- MCP tool count and whether the tool set is easy for AI assistants to use.
+- Opportunities to preserve the feature set while reducing tool-choice friction.
+- Output quality, token efficiency, and user-facing consistency.
+- Local build/type/test signal available from this workspace.
+
+## Summary
+
+The project exposes 16 MCP tools in code. The domain split is mostly sensible: forecasts, current conditions, alerts, historical weather, environmental/safety tools, imagery, and saved-location management each have distinct user intents and data sources. I would not remove the core weather/environmental tools.
+
+The biggest usability problem is not the total number of tools. It is that the location model is inconsistent. `get_forecast` accepts coordinates, saved `location_name`, or `city_name`, but most other weather tools only accept raw coordinates. Saved-location responses and docs imply broader support than the handlers actually provide. This will cause assistants to make invalid calls and forces unnecessary `search_location` hops.
+
+The second major issue is preset/documentation drift. The code's default `basic` preset contains 9 tools, while README/docs describe it as 5 tools. That matters because tool count is part of the user-facing product promise.
+
+## Findings
+
+### High: Saved-location guidance advertises calls that the tool schemas reject
+
+References:
+
+- `src/handlers/savedLocationsHandler.ts:241`
+- `src/handlers/savedLocationsHandler.ts:243`
+- `src/handlers/savedLocationsHandler.ts:244`
+- `src/handlers/savedLocationsHandler.ts:429`
+- `src/handlers/savedLocationsHandler.ts:430`
+- `src/handlers/savedLocationsHandler.ts:431`
+- `src/handlers/savedLocationsHandler.ts:432`
+- `src/index.ts:300`
+- `src/index.ts:328`
+- `src/index.ts:427`
+
+The save/get saved-location responses tell users and assistants that saved locations can be used with "any weather tool", including examples like:
+
+- `get_current_conditions(location_name="home")`
+- `get_alerts(location_name="home")`
+- `get_air_quality(location_name="home")`
+
+However, `get_current_conditions`, `get_alerts`, and `get_air_quality` schemas require `latitude` and `longitude`, and their handlers call `validateCoordinates(args)` directly. The same coordinate-only pattern exists for marine, imagery, lightning, river, and wildfire tools.
+
+Impact:
+
+- Assistants will follow the tool's own output and make calls that fail validation.
+- Saved locations feel unreliable even though the underlying location store works.
+- The server spends tool calls explaining invalid usage instead of answering weather questions.
+
+Recommendation:
+
+Extend the existing `resolveLocationAsync` pattern to all coordinate-based weather tools. Each tool should accept the same location alternatives:
+
+- `latitude` + `longitude`
+- `location_name`
+- `city_name`
+
+Then add a shared schema fragment so tool definitions stay consistent. If that is too large for one release, immediately correct the saved-location output to list only supported calls, then add universal location resolution as the next usability release.
+
+### Medium: Default tool preset documentation is wrong
+
+References:
+
+- `src/config/tools.ts:38`
+- `src/config/tools.ts:40`
+- `src/config/tools.ts:49`
+- `README.md:186`
+- `README.md:188`
+- `docs/TOOLS.md:5`
+
+The actual default `basic` preset includes 9 tools:
+
+- `get_forecast`
+- `get_current_conditions`
+- `get_alerts`
+- `search_location`
+- `check_service_status`
+- `save_location`
+- `list_saved_locations`
+- `get_saved_location`
+- `remove_saved_location`
+
+The README says default basic is 5 tools, and `docs/TOOLS.md` explicitly says "basic preset (5 tools)".
+
+Impact:
+
+- Users trying to reduce context overhead get a larger tool surface than documented.
+- Evaluating MCP usability becomes confusing because the advertised and actual default are different.
+
+Recommendation:
+
+Decide whether saved-location CRUD belongs in the default preset.
+
+Best usability options:
+
+1. Keep `basic` at 5 tools as documented: forecast, current, alerts, search, status. Move saved-location tools to `standard` or a new `locations` add-on.
+2. Keep code as-is and update README/docs to say default is 9 tools.
+
+I lean toward option 1 if "easier for AI assistants" is the priority. Saved locations are valuable, but they are management tools and add four choices to every default install.
+
+### Medium: Location lookup is not consistently available across weather tools
+
+References:
+
+- `src/index.ts:206`
+- `src/index.ts:222`
+- `src/index.ts:226`
+- `src/index.ts:300`
+- `src/index.ts:328`
+- `src/index.ts:455`
+- `src/index.ts:489`
+- `src/index.ts:526`
+- `src/index.ts:556`
+- `src/index.ts:586`
+- `src/utils/locationResolver.ts:153`
+
+`get_forecast` has the right assistant-friendly interface: the model can pass a city name directly, and the server handles geocoding/caching. Other location-based tools still force coordinates. This means a natural user question like "Is there lightning near Bend?" requires the assistant to call `search_location`, parse output text, then call `get_lightning_activity`.
+
+Impact:
+
+- More tool calls.
+- More chances for parsing mistakes.
+- `search_location` becomes a workaround instead of a deliberate disambiguation tool.
+
+Recommendation:
+
+Make direct geocoding and saved-location resolution a platform capability, not a forecast-only feature. Add a shared `LOCATION_SCHEMA_PROPERTIES` fragment and a helper like:
+
+```ts
+resolveWeatherLocation(args, locationStore, geocodingService)
+```
+
+Return the resolved display name in every weather output when the input was `location_name` or `city_name`, matching the forecast handler's existing behavior.
+
+### Medium: Output defaults are often too verbose for assistant workflows
+
+References:
+
+- `src/handlers/forecastHandler.ts:300`
+- `src/handlers/forecastHandler.ts:309`
+- `src/handlers/forecastHandler.ts:324`
+- `src/handlers/alertsHandler.ts:91`
+- `src/handlers/alertsHandler.ts:110`
+- `src/handlers/weatherImageryHandler.ts:120`
+
+The tools return rich Markdown, which is good for users, but some defaults can be expensive:
+
+- Hourly forecast can emit up to `days * 24`, with schema allowing 16 days. That can be 384 hourly sections.
+- Alerts include full descriptions and instructions for every alert.
+- Imagery embeds Markdown image tags directly, which may be useful in some clients but noisy in text-only agents.
+
+Impact:
+
+- Larger context usage.
+- Harder assistant summarization.
+- Slower responses for common "quick answer" questions.
+
+Recommendation:
+
+Add a common output-control parameter to high-volume tools:
+
+- `detail`: `summary | standard | full`
+- default `standard`
+
+Suggested behavior:
+
+- Forecast hourly default should cap to 24-48 hours unless the user explicitly requests more.
+- Alerts default should include headline/severity/timing/instruction summary, with `full` for full descriptions.
+- Imagery should include direct URLs and metadata first, with Markdown image embedding behind `render_markdown_images: true` or `detail: full`.
+
+This preserves the feature set while making the tools more predictable for AI assistants.
+
+### Low: NOAA forecast path can avoid repeated point/grid lookups
+
+References:
+
+- `src/handlers/forecastHandler.ts:292`
+- `src/handlers/forecastHandler.ts:301`
+- `src/handlers/forecastHandler.ts:367`
+- `src/handlers/forecastHandler.ts:381`
+- `src/services/noaa.ts:360`
+- `src/services/noaa.ts:405`
+
+`formatNOAAForecast` calls `getPointData` for timezone, then calls `getForecastByCoordinates`, which calls `getPointData` again. It may also call `getGridpointDataByCoordinates` for severe weather and again for winter data, although caching reduces the network impact.
+
+Impact:
+
+- With cache enabled, this is mostly extra cache lookups and code complexity.
+- With cache disabled or cold cache, it can become extra upstream calls.
+
+Recommendation:
+
+Fetch point data once and pass `gridId`, `gridX`, and `gridY` to lower-level NOAA service methods. A helper returning `{ pointData, forecast, gridpointData? }` would make this path clearer and reduce accidental duplicate upstream requests.
+
+### Low: `search_location` escapes the query but not provider-returned strings
+
+References:
+
+- `src/handlers/locationHandler.ts:60`
+- `src/handlers/locationHandler.ts:66`
+- `src/handlers/locationHandler.ts:74`
+
+The user query is Markdown-escaped, but returned fields such as `location.name` and `location.display_name` are inserted raw. These fields come from external providers and can contain characters that alter Markdown rendering.
+
+Impact:
+
+- Low security risk, but malformed provider text could produce confusing output.
+
+Recommendation:
+
+Apply the same `escapeMarkdown` helper to all provider-returned text fields used in Markdown output.
+
+## Tool Surface Assessment
+
+Current total: 16 tools.
+
+Actual default: 9 tools from the `basic` preset.
+
+Advertised default: 5 tools in README/docs.
+
+### Keep As Separate Tools
+
+These tool boundaries make sense and should stay separate because they represent distinct user intents or data products:
+
+- `get_forecast`
+- `get_current_conditions`
+- `get_alerts`
+- `get_historical_weather`
+- `search_location`
+- `check_service_status`
+- `get_air_quality`
+- `get_marine_conditions`
+- `get_weather_imagery`
+- `get_lightning_activity`
+- `get_river_conditions`
+- `get_wildfire_info`
+
+The environmental and safety tools overlap geographically but not semantically. Combining them into one large "environment" tool would likely make parameters and output less clear.
+
+### Best Candidates To Combine
+
+The four saved-location management tools are the only strong consolidation candidate:
+
+- `save_location`
+- `list_saved_locations`
+- `get_saved_location`
+- `remove_saved_location`
+
+They could become one `manage_saved_locations` tool with an `action` enum: `save`, `list`, `get`, `remove`.
+
+Tradeoff:
+
+- Fewer MCP tools and less default context.
+- More conditional input schema complexity.
+
+If compatibility matters, keep the existing four tools but remove them from `basic` and expose them in `standard`, `all`, or a new `locations` preset.
+
+### Consider Adding A Composite Tool
+
+Rather than eliminating domain tools, consider adding one high-level tool:
+
+`get_weather_summary`
+
+Purpose:
+
+- Answer common user questions with one call.
+- Inputs: same shared location fields, `include` array (`current`, `forecast`, `alerts`, `air_quality`, `lightning`, etc.), `detail`, `days`.
+- Defaults: current + forecast + alerts when available.
+
+This would be easier for assistants than deciding among 16 specialized tools for broad prompts like "What's the weather like in Seattle today, and is it safe to hike?"
+
+Keep specialized tools for precise follow-up questions.
+
+## Output Improvements
+
+Recommended cross-tool output pattern:
+
+1. Start with a short summary line.
+2. Include location resolution when a name was used.
+3. Put safety-critical issues before routine details.
+4. Include data source and timestamp.
+5. Make verbose details opt-in.
+
+Example shape:
+
+```md
+# Weather Summary
+
+**Location:** Bend, Oregon (44.0582, -121.3153)
+**Updated:** 2026-07-13 09:15 PDT
+
+**Bottom line:** Warm and dry today. No active NOAA alerts. Air quality is moderate.
+
+## Key Details
+...
+
+---
+*Data sources: NOAA, Open-Meteo*
+```
+
+## Verification
+
+Commands run:
+
+- `npx tsc --noEmit` - passed.
+- `npm run build` - not verified in this sandbox. It failed because TypeScript attempted to write compiled files under `/home/dgahagan/.../dist`, which is read-only in this environment; the writable workspace path is `/var/home/dgahagan/...`.
+- `npm test` - not verified in this sandbox. Vitest attempted to write a bundled config under `/home/dgahagan/.../node_modules/.vite-temp`, which is read-only here.
+
+## Recommended Priority Order
+
+1. Fix the saved-location mismatch, preferably by adding shared location resolution to every coordinate-based weather tool.
+2. Align the default preset docs and implementation.
+3. Add output `detail` controls for high-volume tools.
+4. Decide whether saved-location CRUD should remain four separate tools or move out of the default preset.
+5. Optimize NOAA forecast point/grid lookup reuse.
+6. Escape provider-returned strings in `search_location`.

--- a/docs/testing/DEFECT_FIX_PLAN.md
+++ b/docs/testing/DEFECT_FIX_PLAN.md
@@ -1,0 +1,77 @@
+# Defect Fix Plan — from Live Test Report v1.8.2
+
+**Source:** [LIVE_TEST_REPORT_v1.8.2.md](./LIVE_TEST_REPORT_v1.8.2.md) (2026-07-07)
+**Status legend:** ✅ Fixed | 🔄 In progress | ⬜ Not started
+
+> **Work-in-progress note for future sessions:** F1 and F2 are being fixed first
+> (2026-07-07). F3–F7 and O1–O8 are planned but NOT yet started — pick them up
+> from this table. Update the Status column and "Fixed in" column as defects land.
+
+## Defects
+
+| ID | Sev | Summary | Status | Fixed in |
+|----|-----|---------|--------|----------|
+| F1 | High | Sunrise/sunset (and daily headings) double timezone shift on Open-Meteo forecasts | ✅ Fixed | main, 2026-07-07 |
+| F2 | High | Lightning tool reports "SAFE, 0 strikes" from a cold/partial strike buffer — safety false negative | ✅ Fixed | main, 2026-07-07 |
+| F3 | Med | River conditions leak raw `-999` NWPS sentinels and year-1 dates; "✅ NOT DEFINED" category; missing flood-stage thresholds | ⬜ | |
+| F4 | Med | Wildfire safety assessment is distance-only (1-acre fire → "HIGH ALERT / prepare for evacuation"); size 0 = "0 acres" instead of "not reported" | ⬜ | |
+| F5 | Med | Satellite imagery returns dead (404) tile URLs for locations outside GOES coverage | ⬜ | |
+| F6 | Low | Saved-location smart update wipes `description`/`alternateNames`/`notes` (savedLocationsHandler.ts:192-194) | ⬜ | |
+| F7 | Low | Saved-location output advertises `location_name` on tools that don't support it | ⬜ | |
+
+## Observations (polish)
+
+| ID | Summary | Status |
+|----|---------|--------|
+| O1 | `days>7` at US/NOAA location silently clamped with no notice | ⬜ |
+| O2 | Alerts header says "N **active** alerts" even with `active_only=false` | ⬜ |
+| O3 | Non-US alerts query leaks raw NOAA "out of bounds" error instead of friendly US-only message | ⬜ |
+| O4 | Historical "Period:" header off by one day (server-local `toLocaleDateString()` on naive timestamps, historicalWeatherHandler.ts:56,121,200) — same family as F1 | ⬜ |
+| O5 | Historical "Number of observations" shows pre-limit count; empty-hour headings; NOAA newest-first vs Open-Meteo oldest-first | ⬜ |
+| O6 | Marine landlocked "Unknown" uses 🟤 (legend: extremely dangerous); should say "not an ocean location" | ⬜ |
+| O7 | River/wildfire non-US empty states say "area is clear" without disclosing US-only coverage | ⬜ |
+| O8 | Saved-location list shows UTC date, detail shows local datetime | ⬜ |
+
+## Fix Notes
+
+### F1 — Timezone double shift (fixed)
+
+Root cause: `DateTime.fromISO(s, { setZone: false }).setZone(tz)` parses Open-Meteo's
+timezone-naive location-local ISO strings in the **server's** zone, then converts to the
+location zone — applying the offset twice. NOAA strings carry explicit UTC offsets, so they
+were unaffected.
+
+Fix: parse with `{ zone: tz }` so naive strings are interpreted directly in the location
+zone; offset-bearing strings keep their instant and are converted for display (Luxon
+semantics), so NOAA formatting is unchanged.
+
+Sites fixed:
+- `src/utils/timezone.ts` — `formatInTimezone`, `formatDateInTimezone`,
+  `formatTimeInTimezone`, `formatTimeRangeInTimezone` (shared by Open-Meteo hourly
+  forecast path and others)
+- `src/handlers/forecastHandler.ts` — daily heading, sunrise, sunset
+
+Remaining same-family work is tracked as **O4** (historical handler uses plain `Date` +
+`toLocaleDateString()`, needs the same treatment).
+
+### F2 — Lightning false "SAFE" from cold buffer (fixed)
+
+Root cause: strikes are collected into an in-memory rolling buffer fed by per-geohash MQTT
+subscriptions that begin on the **first query for an area** (plus a 10 s accumulation
+wait). A fresh server — or a long-running server asked about a new area — has essentially
+no coverage, yet reported "🟢 SAFE, 0 strikes" for the full requested time window.
+
+Fix:
+- `BlitzortungService` tracks when each geohash was first subscribed
+  (`geohashFirstSubscribed`, cleaned up on LRU eviction and stale pruning) and exposes
+  `getCoverageStart(lat, lon, radius)` = the moment the *entire* queried area became
+  monitored (null if any part is unmonitored/disconnected).
+- `LightningActivityResponse` gains a `coverage` block (`monitoringSince`,
+  `coverageMinutes`, `isComplete`).
+- Handler: when coverage < requested window and no strikes were seen, the safety message
+  states the result is **inconclusive**, recommendations lead with a re-check suggestion,
+  and the formatter renders "SAFE (LIMITED DATA)" plus a ⚠️ limited-coverage warning and a
+  "Monitoring Coverage: X of Y minutes" statistics line.
+
+Verification for both: `npm run build`, full `npm test` suite, plus live MCP calls
+(Tokyo sunrise ≈ 4:32 AM; lightning report shows limited-coverage warning on fresh server).

--- a/docs/testing/LIVE_TEST_REPORT_v1.8.2.md
+++ b/docs/testing/LIVE_TEST_REPORT_v1.8.2.md
@@ -1,0 +1,166 @@
+# Live Test Report — Weather MCP Server v1.8.2
+
+**Date:** 2026-07-07
+**Tester:** Claude Code (live MCP session) — ~76 test cases across all 16 tools
+**Build under test:** Local `dist/` build. The session's server process launched from the pre-release build, but `git diff v1.8.0..v1.8.2 -- src/` is empty (both releases were docs-only), so all findings apply verbatim to v1.8.2 / current `main` (`cd29f7a`).
+**Method:** Exploratory edge-case testing via live MCP tool calls — polar coordinates, the antimeridian, Null Island, 1940s reanalysis data, world extremes (Vostok, Death Valley), unicode/injection inputs, invalid raw JSON-RPC requests bypassing client schema validation, and full write-path exercise of saved locations (original `locations.json` backed up and verified byte-identical after cleanup).
+
+---
+
+## Executive Summary
+
+The server is in very good shape: **all 16 tools returned useful, well-formatted responses across every happy path and nearly every extreme input**, error messages are consistently helpful, server-side input validation is airtight (hostile raw JSON-RPC requests were all rejected cleanly with no crashes or stack traces), and the saved-locations write path left storage byte-identical after a save/update/remove cycle.
+
+Seven genuine defects were found. The two most important:
+
+1. **Sunrise/sunset times are wrong for all non-US (Open-Meteo) forecasts** — a timezone double-shift renders Tokyo's sunrise as "5:32 PM".
+2. **The lightning tool reports "🟢 SAFE, 0 strikes" from an empty buffer** — including at NYC *during an active thunderstorm* — because its MQTT strike buffer only accumulates while the process is running. For a safety-critical tool, a fresh server always reports "safe".
+
+| Severity | Count | IDs |
+|----------|-------|-----|
+| High (safety/correctness) | 2 | F1, F2 |
+| Medium | 3 | F3, F4, F5 |
+| Low | 2 | F6, F7 |
+| Observations (polish) | 8 | O1–O8 |
+
+---
+
+## Findings (Defects)
+
+### F1 — Sunrise/sunset double timezone shift on Open-Meteo forecasts (HIGH)
+
+**Where:** `src/handlers/forecastHandler.ts:508-514`
+
+Open-Meteo returns sunrise/sunset as timezone-naive, *location-local* ISO strings (the API is called with a `timezone` parameter). The handler does:
+
+```ts
+DateTime.fromISO(daily.sunrise[i], { setZone: false }).setZone(forecast.timezone)
+```
+
+`setZone: false` parses the naive string in the **server's** zone, then `.setZone()` converts to the location zone — applying the offset twice.
+
+**Evidence (server in EDT):**
+- Tokyo: "Sunrise: 5:32 PM / Sunset: 8:00 AM" (actual: ~4:32 AM / ~7:00 PM JST). 4:32 EDT → 08:32 UTC → 17:32 JST = 5:32 PM, exact match for the double shift.
+- Null Island (0,0): "Sunrise 10:01 AM" in Etc/GMT (actual ~6:01 AM UTC) — +4 h, the EDT offset.
+- Fiji: "Sunrise: 10:29 PM".
+
+US forecasts are unaffected only because the NOAA path doesn't render sunrise. **Fix:** parse directly in the location zone: `DateTime.fromISO(daily.sunrise[i], { zone: forecast.timezone })`.
+
+### F2 — Lightning tool reports "SAFE" from an empty strike buffer (HIGH, safety)
+
+**Where:** `src/services/blitzortung.ts` (rolling 2-h in-memory MQTT buffer)
+
+The strike buffer only fills while the server process is running and connected. A freshly started server answers every query with "🟢 Safety Status: SAFE — Total Strikes: 0" for up to 2 hours, regardless of actual conditions.
+
+**Evidence:** NYC (500 km / 120 min) returned SAFE/0 strikes while NYC's own NOAA forecast showed active "Showers And Thunderstorms" (81% precip) at query time. Congo basin — the most lightning-active region on Earth — also returned 0 at max radius/window. Tampa in July, 0.
+
+**Recommendation:** Track connection/collection start time; when buffer age < requested `timeWindow`, say so ("monitoring for 3 of the requested 120 minutes — results may be incomplete") and downgrade the confidence of the SAFE verdict instead of implying verified absence of lightning.
+
+### F3 — River conditions leak raw `-999` sentinels and year-1 dates (MEDIUM)
+
+**Where:** river conditions formatter (NWPS/USGS data path)
+
+Gauges without current observations/forecasts render NWPS missing-data sentinels verbatim: "Forecasted Stage: **-999.00 ft**", "Flow Rate: **-999.00 kcfs (-999000 cfs)**", "Valid Time: **Dec 31, 1, 6:09 PM**" (year-1 epoch). In New Orleans — the most flood-critical city tested — 4 of the 5 nearest gauges showed only this noise. Also: "Flood Category: **✅ NOT DEFINED**" pairs a green check with an undefined category, and the flood-stage threshold values (action/minor/moderate/major) promised by the tool description never render. Core discovery works well (530 gauges at max radius, correct distances, clean truncation).
+
+### F4 — Wildfire safety assessment ignores fire size (MEDIUM)
+
+A 1-acre brush fire 14.5 km from Boston produced "🟠 **HIGH ALERT** … Prepare for possible evacuation". The assessment is distance-only. Also: unreported sizes render as literal "**Size:** 0 acres (0 hectares)" instead of "not yet reported", and "1 acres" grammar. Discovery/rendering otherwise solid (18 fires near Boise at 500 km, Alaska interior coverage, containment bars, truncation notes).
+
+### F5 — Dead satellite-imagery URLs outside GOES coverage (MEDIUM)
+
+**Where:** `get_weather_imagery` type=satellite
+
+Tokyo returns a GOES-East tile URL that **404s** (verified with curl; the equivalent Denver tile returns 200 with a 111 KB PNG). The disclaimer says out-of-range locations "may appear blank" — the link is actually broken. Should detect GOES-East/West longitude coverage and return a clear "outside satellite coverage" error (or select GOES-West where applicable).
+
+### F6 — Smart update silently wipes `description`, `alternateNames`, `notes` (LOW)
+
+**Where:** `src/handlers/savedLocationsHandler.ts:192-194`
+
+The partial-update path preserves coordinates, timezone, admin fields, and activities, but `description`/`alternateNames`/`notes` are always taken from the incoming args — an activities-only update overwrites them with `undefined`. **Reproduced:** saved `test-geocode` with a description; updated only `activities`; description gone from `locations.json`.
+
+### F7 — Saved-location output advertises `location_name` on tools that don't support it (LOW)
+
+`save_location` and `get_saved_location` responses suggest `get_current_conditions(location_name=…)`, `get_alerts(location_name=…)`, `get_air_quality(location_name=…)` and say "can be used with **any** weather tool". Only `get_forecast` accepts `location_name` (per schemas and CLAUDE.md). Following the printed examples produces errors.
+
+---
+
+## Observations (polish, not defects)
+
+| ID | Tool | Observation |
+|----|------|-------------|
+| O1 | get_forecast | `days=16` at a US/NOAA location silently returns 7 days (14 periods) with no clamp notice |
+| O2 | get_alerts | With `active_only=false`, header still reads "14 **active** alerts found" while listing expired alerts |
+| O3 | get_alerts | Non-US point (Toronto) surfaces raw NOAA `Parameter "point" is invalid: out of bounds` instead of the friendly "outside NOAA coverage (US only)" message other tools use |
+| O4 | get_historical_weather | "Period:" header is a day earlier than requested (e.g. request 1940-01-01 → "12/31/1939") — same server-local-TZ formatting family as F1 (`historicalWeatherHandler.ts:56` uses `toLocaleDateString()` on naive timestamps) |
+| O5 | get_historical_weather | "Number of observations" shows the pre-`limit` fetch count (48) while only `limit` entries (10) render; hours with no data render as bare empty headings; NOAA path is newest-first while Open-Meteo path is oldest-first |
+| O6 | get_marine_conditions | Landlocked "Unknown" state uses the 🟤 icon that the legend defines as ">9m extremely dangerous"; message could say "not an ocean location" |
+| O7 | get_river_conditions / get_wildfire_info | Non-US empty results say "no gauges/fires found — area is clear" without disclosing US-only coverage (matters during e.g. Australian fire season) |
+| O8 | list vs get saved location | List shows "Saved: 11/16/2025" (UTC date) while detail shows "11/15/2025, 11:52:45 PM" (local) for the same record |
+
+**Not a bug:** `check_service_status` reported "Installed Version: 1.8.0" during testing — the session's server process predated the release commit; version is read correctly from `package.json` at startup (`src/index.ts:55-63`).
+
+---
+
+## Per-Tool Results
+
+### 1. check_service_status — ✅ PASS
+NOAA + Open-Meteo status, cache statistics, version + upgrade tip all rendered.
+
+### 2. get_forecast — ✅ PASS (F1, O1)
+- NYC 7-day + `include_normals` + `include_severe_weather`: NOAA, 14 periods, thunderstorm probability + climate-normals departure sections.
+- Tokyo 16-day: full 16 days via Open-Meteo. Seattle hourly: 24 hourly periods via NOAA.
+- **North Pole (90,0):** 24 h daylight, July snow. **South Pole (-90,0):** −50 °F, 0 h polar night, elevation 2774 m. **Null Island (0,0):** ocean point returns data.
+- **Antimeridian (−16.5, ±179.99):** both sides work, consistent Pacific/Fiji timezone.
+- `source=noaa` for Paris → clean "outside NOAA coverage" error. `location_name="home"` resolves; `location_name="narnia"` → helpful error listing available aliases.
+
+### 3. get_current_conditions — ✅ PASS
+Denver (+fire weather indices, mixing height, transport wind, climate normals), Utqiaġvik AK (station PABR, Arctic), San Juan PR (station TJSJ, territories covered, heat index), London → clean US-only error.
+
+### 4. get_alerts — ✅ PASS (O2, O3)
+Miami: live Heat Advisory with full CAP detail (severity/urgency/certainty, onset, instructions, recommended response). OKC `active_only=false`: 14 alerts including expired July 4 severe-thunderstorm warnings. Anchorage: clean no-alerts state.
+
+### 5. get_historical_weather — ✅ PASS (O4, O5)
+- **Berlin 1940-01-01** (first day of the archive): works. **D-Day, Normandy 1944-06-06:** overcast, 11–12 mph westerly — matches the historical record. **Vostok 1983-07-21** (Earth's coldest recorded day): −106 °F reanalysis at 3498 m. **Death Valley 2021-07-09:** 109 °F at midnight, elevation −59 m handled.
+- Recent US dates correctly route to "NOAA Real-time API".
+- Error paths all excellent: future date, start > end, pre-1940, and `"not-a-date"` each get specific, actionable messages.
+
+### 6. search_location — ✅ PASS
+Unicode "東京" → Tokyo JP; one-letter village "Y, Somme, France" found; "Springfield" ×10 disambiguated with confidence ranking; nonsense query → 3-provider fallback report (Census.gov, Nominatim, Open-Meteo) with suggestions; SQL-injection string treated as a literal query — no injection surface.
+
+### 7. get_air_quality — ✅ PASS
+Delhi: European AQI 81 "Very Poor" (correct non-US scale) with US AQI 140 cross-reference, health guidance, UV with clear-sky note, aerosol optical depth. LA: US AQI scale + 24 h banded forecast (120 h of data). Near South Pole: pristine air (PM2.5 0.4 µg/m³), UV 0 in polar night.
+
+### 8. get_marine_conditions — ✅ PASS (O6)
+Mid-Atlantic: full wind-wave/swell decomposition, currents in m/s + knots, safety legend. **Drake Passage + forecast:** 5.3 m now, 5-day forecast peaking 8.0 m "Very Rough". **Lake Michigan:** dedicated Great Lakes NOAA path with region label. Landlocked Denver: graceful no-data state.
+
+### 9. get_weather_imagery — ⚠️ PASS with F5
+Miami precipitation URL verified **200 OK** (PNG). Chicago animated radar: 13 frames. Denver satellite tile verified **200 OK** (111 KB PNG). Tokyo satellite: dead link (F5).
+
+### 10. get_lightning_activity — ❌ FAIL (F2)
+All queries (Tampa 200 km/120 min, Congo basin 500 km/120 min, NYC-under-thunderstorm 500 km/120 min, min-bounds 1 km/5 min) returned "SAFE, 0 strikes" from the cold buffer. Formatting, parameter bounds, and disclaimers are fine; the data path is the problem.
+
+### 11. get_river_conditions — ⚠️ PASS with F3 (parallel agent)
+St. Louis: 16 gauges, nearest Mississippi gauge 1.7 km with real stage/flow/forecast. Leadville at max 500 km radius: 530 gauges, clean nearest-5 truncation. London: graceful zero-gauge state. Sentinel leakage per F3.
+
+### 12. get_wildfire_info — ⚠️ PASS with F4 (parallel agent)
+Sacramento: Antelope fire (NV) with distance, containment bar, days active. Boise 500 km: 18 fires across 5 states. Fairbanks: 19 Alaska-interior fires. Boston: real 1-acre incident found (over-alerting per F4). Sydney: no crash (disclosure gap per O7).
+
+### 13–16. save_location / list_saved_locations / get_saved_location / remove_saved_location — ✅ PASS (F6, F7, O8)
+- Geocoded save ("Reykjavík, Iceland"), coordinate save with unicode alias `Test-Coords-Café` → normalized `test-coords-café`, activities/notes/alternate-names round-trip.
+- Case-insensitive lookup including unicode fold (`TEST-COORDS-CAFÉ` → `é`).
+- End-to-end: saved McMurdo alias → `get_forecast(location_name=…)` → correct Antarctic polar-night forecast.
+- Validation: missing query+coords, >50-char alias, >50-char activity, remove/get of nonexistent alias — all clean, specific errors (nonexistent-alias errors list available aliases).
+- After removing test entries, `locations.json` was **byte-identical** to the pre-test backup.
+
+### Raw JSON-RPC hostile-input tests (bypassing client schema validation) — ✅ PASS
+Sent directly to a fresh `dist/index.js` over stdio: `latitude: 999` → "Invalid latitude: 999. Must be between -90 and 90"; string latitude → coordinates-or-location_name guidance; empty args → "must be a finite number, received undefined"; unknown tool name → clean not-enabled error; `radius: 99999` → "must be a number between 1 and 500 km"; 60-char alias → "50 characters or less". No crashes, no stack traces, no internal detail leakage.
+
+---
+
+## Suggested Fix Priority
+
+1. **F1** — one-line fix in `forecastHandler.ts:508` (`{ zone: forecast.timezone }`), plus the same audit for `historicalWeatherHandler.ts` date headers (O4).
+2. **F2** — disclose buffer/collection age in lightning reports; a SAFE verdict from a cold buffer is a false negative in a safety-critical tool.
+3. **F3** — map NWPS `-999` sentinels and year-1 timestamps to "N/A"; render flood-stage thresholds.
+4. **F5** — coverage check before emitting satellite URLs.
+5. **F4, F6, F7, O-series** — small formatter/copy fixes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.8.2",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dangahagan/weather-mcp",
-      "version": "1.8.2",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dangahagan/weather-mcp",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dangahagan/weather-mcp",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "MCP server giving AI assistants 16 weather tools with zero API keys: global forecasts, current conditions, alerts, air quality, marine conditions, lightning detection, radar imagery, river levels, wildfire tracking, and historical weather back to 1940. Built entirely on free public APIs (NOAA, Open-Meteo, USGS, NIFC).",
   "mcpName": "io.github.dgahagan/weather-mcp",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "MCP server giving AI assistants 16 weather tools with zero API keys: global forecasts, current conditions, alerts, air quality, marine conditions, lightning detection, radar imagery, river levels, wildfire tracking, and historical weather back to 1940. Built entirely on free public APIs (NOAA, Open-Meteo, USGS, NIFC).",
   "mcpName": "io.github.dgahagan/weather-mcp",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.8.2",
+  "version": "1.10.0",
   "description": "MCP server giving AI assistants 16 weather tools with zero API keys: global forecasts, current conditions, alerts, air quality, marine conditions, lightning detection, radar imagery, river levels, wildfire tracking, and historical weather back to 1940. Built entirely on free public APIs (NOAA, Open-Meteo, USGS, NIFC).",
   "mcpName": "io.github.dgahagan/weather-mcp",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "MCP server giving AI assistants 16 weather tools with zero API keys: global forecasts, current conditions, alerts, air quality, marine conditions, lightning detection, radar imagery, river levels, wildfire tracking, and historical weather back to 1940. Built entirely on free public APIs (NOAA, Open-Meteo, USGS, NIFC).",
   "mcpName": "io.github.dgahagan/weather-mcp",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,13 +2,13 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.dgahagan/weather-mcp",
   "title": "Weather Data MCP Server",
-  "description": "16 weather tools, no API keys: forecasts, alerts, air quality, marine, radar, lightning, wildfires.",
-  "version": "1.10.0",
+  "description": "17 weather tools, no API keys: a one-call weather summary plus forecasts, alerts, air quality, marine, radar, lightning, wildfires.",
+  "version": "1.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@dangahagan/weather-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.dgahagan/weather-mcp",
   "title": "Weather Data MCP Server",
   "description": "16 weather tools, no API keys: forecasts, alerts, air quality, marine, radar, lightning, wildfires.",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@dangahagan/weather-mcp",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.dgahagan/weather-mcp",
   "title": "Weather Data MCP Server",
   "description": "16 weather tools, no API keys: forecasts, alerts, air quality, marine, radar, lightning, wildfires.",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@dangahagan/weather-mcp",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.dgahagan/weather-mcp",
   "title": "Weather Data MCP Server",
   "description": "16 weather tools, no API keys: forecasts, alerts, air quality, marine, radar, lightning, wildfires.",
-  "version": "1.8.2",
+  "version": "1.10.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@dangahagan/weather-mcp",
-      "version": "1.8.2",
+      "version": "1.10.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/config/cache.ts
+++ b/src/config/cache.ts
@@ -74,6 +74,10 @@ export const CacheConfig = {
     // These are geographic and never change
     gridCoordinates: Infinity,
 
+    // City name -> coordinates geocoding lookups
+    // A place's coordinates are effectively static
+    geocoding: Infinity,
+
     // Weather station lists
     // Stations rarely change
     stations: 24 * HOUR,

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -19,6 +19,7 @@ export type ToolName =
   | 'get_current_conditions'
   | 'get_alerts'
   | 'get_historical_weather'
+  | 'get_weather_summary'
   | 'check_service_status'
   | 'search_location'
   | 'get_air_quality'
@@ -36,50 +37,60 @@ export type ToolName =
  * Tool presets for easy configuration
  */
 const TOOL_PRESETS: Record<string, ToolName[]> = {
-  // Essential weather tools - minimal overhead
+  // The DEFAULT preset (used when ENABLED_TOOLS is unset), so this is what most
+  // users actually see. Led by get_weather_summary (one call answers the common
+  // "what's the weather?" question), with the atomic follow-up tools and
+  // geocoding/health-check helpers. Every tool accepts city_name/location_name,
+  // so this 6-tool set covers the bulk of real usage on its own.
   basic: [
+    'get_weather_summary',
     'get_forecast',
     'get_current_conditions',
     'get_alerts',
     'search_location',
-    'check_service_status',
-    'save_location',
-    'list_saved_locations',
-    'get_saved_location',
-    'remove_saved_location'
+    'check_service_status'
   ],
 
-  // Basic + historical data
+  // Basic + history, air quality, and saved-location personalization
   standard: [
+    'get_weather_summary',
     'get_forecast',
     'get_current_conditions',
     'get_alerts',
     'get_historical_weather',
-    'search_location',
-    'check_service_status',
-    'save_location',
-    'list_saved_locations',
-    'get_saved_location',
-    'remove_saved_location'
-  ],
-
-  // Standard + environmental data
-  full: [
-    'get_forecast',
-    'get_current_conditions',
-    'get_alerts',
-    'get_historical_weather',
-    'search_location',
-    'check_service_status',
     'get_air_quality',
+    'search_location',
+    'check_service_status',
     'save_location',
     'list_saved_locations',
     'get_saved_location',
     'remove_saved_location'
   ],
 
-  // All available tools
+  // Standard + the specialized environmental & safety tools (everything)
+  full: [
+    'get_weather_summary',
+    'get_forecast',
+    'get_current_conditions',
+    'get_alerts',
+    'get_historical_weather',
+    'get_air_quality',
+    'get_marine_conditions',
+    'get_weather_imagery',
+    'get_lightning_activity',
+    'get_river_conditions',
+    'get_wildfire_info',
+    'search_location',
+    'check_service_status',
+    'save_location',
+    'list_saved_locations',
+    'get_saved_location',
+    'remove_saved_location'
+  ],
+
+  // All available tools (identical set to `full`)
   all: [
+    'get_weather_summary',
     'get_forecast',
     'get_current_conditions',
     'get_alerts',
@@ -110,6 +121,9 @@ const TOOL_ALIASES: Record<string, ToolName> = {
   'warnings': 'get_alerts',
   'historical': 'get_historical_weather',
   'history': 'get_historical_weather',
+  'summary': 'get_weather_summary',
+  'weather_summary': 'get_weather_summary',
+  'overview': 'get_weather_summary',
   'status': 'check_service_status',
   'location': 'search_location',
   'search': 'search_location',
@@ -246,6 +260,7 @@ function isToolName(name: string): name is ToolName {
     'get_current_conditions',
     'get_alerts',
     'get_historical_weather',
+    'get_weather_summary',
     'check_service_status',
     'search_location',
     'get_air_quality',

--- a/src/config/units.ts
+++ b/src/config/units.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit / localization configuration for weather output.
+ *
+ * The server defaults to imperial units (preserving historical behavior for
+ * existing users). A server-wide default can be set via environment variables,
+ * and individual tool calls may override it per request (see
+ * `src/utils/unitPreferences.ts`).
+ *
+ * Environment variables:
+ *   WEATHER_UNITS              imperial | metric            (default: imperial)
+ *   WEATHER_TEMPERATURE_UNIT   F | C                        (override)
+ *   WEATHER_WIND_SPEED_UNIT    mph | kmh | ms | kn          (override)
+ *   WEATHER_PRECIPITATION_UNIT inch | mm                    (override)
+ *   WEATHER_PRESSURE_UNIT      inHg | hPa                   (override)
+ *   WEATHER_DISTANCE_UNIT      mi | km                      (override)
+ *   WEATHER_TIME_FORMAT        12h | 24h                    (override)
+ */
+
+export type UnitSystem = 'imperial' | 'metric';
+export type TemperatureUnit = 'F' | 'C';
+export type WindSpeedUnit = 'mph' | 'kmh' | 'ms' | 'kn';
+export type PrecipitationUnit = 'inch' | 'mm';
+export type PressureUnit = 'inHg' | 'hPa';
+export type DistanceUnit = 'mi' | 'km';
+export type TimeFormat = '12h' | '24h';
+
+/**
+ * A fully-resolved set of unit preferences. Every weather output path formats
+ * values according to one of these.
+ */
+export interface UnitPreferences {
+  temperature: TemperatureUnit;
+  windSpeed: WindSpeedUnit;
+  precipitation: PrecipitationUnit;
+  pressure: PressureUnit;
+  distance: DistanceUnit;
+  timeFormat: TimeFormat;
+}
+
+/** Imperial preset — the historical default. */
+export const IMPERIAL_PREFERENCES: UnitPreferences = {
+  temperature: 'F',
+  windSpeed: 'mph',
+  precipitation: 'inch',
+  pressure: 'inHg',
+  distance: 'mi',
+  timeFormat: '12h',
+};
+
+/** Metric preset. */
+export const METRIC_PREFERENCES: UnitPreferences = {
+  temperature: 'C',
+  windSpeed: 'kmh',
+  precipitation: 'mm',
+  pressure: 'hPa',
+  distance: 'km',
+  timeFormat: '24h',
+};
+
+/**
+ * Return the base preset for a unit system.
+ */
+export function systemPreferences(system: UnitSystem): UnitPreferences {
+  return system === 'metric' ? { ...METRIC_PREFERENCES } : { ...IMPERIAL_PREFERENCES };
+}
+
+/**
+ * Accepted spellings for each unit, normalized to the canonical token.
+ * Kept permissive so both the env layer and per-call params can share it.
+ */
+const NORMALIZERS = {
+  system: new Map<string, UnitSystem>([
+    ['imperial', 'imperial'], ['us', 'imperial'], ['metric', 'metric'], ['si', 'metric'],
+  ]),
+  temperature: new Map<string, TemperatureUnit>([
+    ['f', 'F'], ['fahrenheit', 'F'], ['°f', 'F'],
+    ['c', 'C'], ['celsius', 'C'], ['centigrade', 'C'], ['°c', 'C'],
+  ]),
+  windSpeed: new Map<string, WindSpeedUnit>([
+    ['mph', 'mph'], ['mi/h', 'mph'],
+    ['kmh', 'kmh'], ['km/h', 'kmh'], ['kph', 'kmh'],
+    ['ms', 'ms'], ['m/s', 'ms'], ['mps', 'ms'],
+    ['kn', 'kn'], ['kt', 'kn'], ['kts', 'kn'], ['knot', 'kn'], ['knots', 'kn'],
+  ]),
+  precipitation: new Map<string, PrecipitationUnit>([
+    ['inch', 'inch'], ['inches', 'inch'], ['in', 'inch'],
+    ['mm', 'mm'], ['millimeter', 'mm'], ['millimeters', 'mm'],
+  ]),
+  pressure: new Map<string, PressureUnit>([
+    ['inhg', 'inHg'], ['in', 'inHg'],
+    ['hpa', 'hPa'], ['mb', 'hPa'], ['mbar', 'hPa'], ['millibar', 'hPa'], ['millibars', 'hPa'],
+  ]),
+  distance: new Map<string, DistanceUnit>([
+    ['mi', 'mi'], ['mile', 'mi'], ['miles', 'mi'],
+    ['km', 'km'], ['kilometer', 'km'], ['kilometers', 'km'],
+  ]),
+  timeFormat: new Map<string, TimeFormat>([
+    ['12h', '12h'], ['12', '12h'], ['12-hour', '12h'], ['ampm', '12h'],
+    ['24h', '24h'], ['24', '24h'], ['24-hour', '24h'], ['military', '24h'],
+  ]),
+} as const;
+
+/**
+ * Normalize a raw string to a canonical unit token, or return undefined if the
+ * value is unrecognized. Exported for reuse by the per-call resolver.
+ */
+export function normalizeUnit<K extends keyof typeof NORMALIZERS>(
+  kind: K,
+  raw: string | undefined
+): (typeof NORMALIZERS)[K] extends Map<string, infer V> ? V | undefined : never {
+  const map = NORMALIZERS[kind] as Map<string, unknown>;
+  if (raw === undefined || raw === null) return undefined as never;
+  return map.get(String(raw).trim().toLowerCase()) as never;
+}
+
+/**
+ * Resolve an environment override for one unit field, warning on invalid input.
+ */
+function envOverride<K extends keyof typeof NORMALIZERS>(
+  kind: K,
+  key: string
+): ((typeof NORMALIZERS)[K] extends Map<string, infer V> ? V : never) | undefined {
+  const raw = process.env[key];
+  if (raw === undefined || raw.trim() === '') return undefined;
+  const normalized = normalizeUnit(kind, raw);
+  if (normalized === undefined) {
+    console.warn(`Invalid ${key}: "${raw}". Ignoring and using default.`);
+    return undefined;
+  }
+  return normalized as never;
+}
+
+/**
+ * Build the server-wide default preferences from the environment.
+ */
+function loadUnitPreferences(): UnitPreferences {
+  const system = envOverride('system', 'WEATHER_UNITS') ?? 'imperial';
+  const base = systemPreferences(system);
+
+  return {
+    temperature: envOverride('temperature', 'WEATHER_TEMPERATURE_UNIT') ?? base.temperature,
+    windSpeed: envOverride('windSpeed', 'WEATHER_WIND_SPEED_UNIT') ?? base.windSpeed,
+    precipitation: envOverride('precipitation', 'WEATHER_PRECIPITATION_UNIT') ?? base.precipitation,
+    pressure: envOverride('pressure', 'WEATHER_PRESSURE_UNIT') ?? base.pressure,
+    distance: envOverride('distance', 'WEATHER_DISTANCE_UNIT') ?? base.distance,
+    timeFormat: envOverride('timeFormat', 'WEATHER_TIME_FORMAT') ?? base.timeFormat,
+  };
+}
+
+/**
+ * The server-wide default unit preferences, resolved once at startup from the
+ * environment. Per-call tool parameters layer on top of this.
+ */
+export const defaultUnitPreferences: UnitPreferences = loadUnitPreferences();

--- a/src/handlers/airQualityHandler.ts
+++ b/src/handlers/airQualityHandler.ts
@@ -3,7 +3,10 @@
  */
 
 import { OpenMeteoService } from '../services/openmeteo.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean } from '../utils/validation.js';
 import {
   getUSAQICategory,
   getEuropeanAQICategory,
@@ -17,15 +20,20 @@ import type { OpenMeteoAirQualityResponse } from '../types/openmeteo.js';
 interface AirQualityArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   forecast?: boolean;
 }
 
 export async function handleGetAirQuality(
   args: unknown,
-  openMeteoService: OpenMeteoService
+  openMeteoService: OpenMeteoService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as AirQualityArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const forecast = validateOptionalBoolean(
     (args as AirQualityArgs)?.forecast,
     'forecast',
@@ -43,14 +51,14 @@ export async function handleGetAirQuality(
   // Format the air quality data for display
   const output = formatAirQuality(airQualityData, latitude, longitude, forecast);
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/handlers/alertsHandler.ts
+++ b/src/handlers/alertsHandler.ts
@@ -3,26 +3,37 @@
  */
 
 import { NOAAService } from '../services/noaa.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean, validateDetail } from '../utils/validation.js';
 import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js';
 
 interface AlertsArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   active_only?: boolean;
+  detail?: 'summary' | 'standard' | 'full';
 }
 
 export async function handleGetAlerts(
   args: unknown,
-  noaaService: NOAAService
+  noaaService: NOAAService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as AlertsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const active_only = validateOptionalBoolean(
     (args as AlertsArgs)?.active_only,
     'active_only',
     true
   );
+  // Output verbosity: 'full' includes the complete NWS description text.
+  const detail = validateDetail((args as AlertsArgs)?.detail);
 
   // Get timezone for proper time formatting
   let timezone = guessTimezoneFromCoords(latitude, longitude); // fallback
@@ -107,26 +118,35 @@ export async function handleGetAlerts(
         output += `**Ends:** ${formatInTimezone(props.ends, timezone)}\n`;
       }
 
-      output += `\n**Description:**\n${props.description}\n`;
+      // Full NWS description text is verbose; include it only at detail=full.
+      if (detail === 'full' && props.description) {
+        output += `\n**Description:**\n${props.description}\n`;
+      }
 
-      if (props.instruction) {
+      // Actionable instructions are surfaced at standard and full (not summary).
+      if (detail !== 'summary' && props.instruction) {
         output += `\n**Instructions:**\n${props.instruction}\n`;
       }
 
       output += `\n**Recommended Response:** ${props.response}\n`;
       output += `**Sender:** ${props.senderName}\n\n`;
     }
+
+    if (detail !== 'full') {
+      output += `*Showing ${detail === 'summary' ? 'a condensed summary' : 'standard detail'}. `;
+      output += `Use detail="full" for complete alert descriptions.*\n\n`;
+    }
   }
 
   output += `---\n`;
   output += `*Data source: NOAA National Weather Service*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }

--- a/src/handlers/currentConditionsHandler.ts
+++ b/src/handlers/currentConditionsHandler.ts
@@ -7,6 +7,15 @@ import { OpenMeteoService } from '../services/openmeteo.js';
 import { NCEIService } from '../services/ncei.js';
 import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
 import { convertToFahrenheit } from '../utils/temperatureConversion.js';
+import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
+import {
+  formatTemperatureQV,
+  formatWindSpeedQV,
+  formatPressureQV,
+  formatVisibilityQV,
+  formatHeightFromFt,
+  formatPrecipFromMm,
+} from '../utils/unitFormat.js';
 import { DisplayThresholds } from '../config/displayThresholds.js';
 import {
   getHainesCategory,
@@ -21,7 +30,7 @@ import { extractSnowDepth, formatSnowData, hasWinterWeather } from '../utils/sno
 import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js';
 import { getClimateNormals, formatNormals, getDateComponents } from '../utils/normals.js';
 
-interface CurrentConditionsArgs {
+interface CurrentConditionsArgs extends UnitArgs {
   latitude?: number;
   longitude?: number;
   include_fire_weather?: boolean;
@@ -46,6 +55,7 @@ export async function handleGetCurrentConditions(
     'include_normals',
     false
   );
+  const prefs = resolveUnitPreferences(args as CurrentConditionsArgs);
 
   // Get current observation
   const observation = await noaaService.getCurrentConditions(latitude, longitude);
@@ -69,23 +79,25 @@ export async function handleGetCurrentConditions(
   // Format current conditions
   let output = `# Current Weather Conditions\n\n`;
   output += `**Station:** ${props.station}\n`;
-  output += `**Time:** ${formatInTimezone(props.timestamp, timezone)}\n\n`;
+  output += `**Time:** ${formatInTimezone(props.timestamp, timezone, 'medium', prefs.timeFormat)}\n\n`;
 
   // Main conditions
   if (props.textDescription) {
     output += `**Conditions:** ${props.textDescription}\n`;
   }
 
-  // Temperature section
+  // Temperature section.
+  // Canonical Fahrenheit values drive the display-threshold comparisons; the
+  // strings shown to the user are formatted in the caller's preferred unit.
   const tempF = convertToFahrenheit(props.temperature.value, props.temperature.unitCode);
   if (tempF !== null) {
-    output += `**Temperature:** ${Math.round(tempF)}°F\n`;
+    output += `**Temperature:** ${formatTemperatureQV(props.temperature, prefs)}\n`;
 
     // Show heat index when temperature is high and heat index is available
     if (props.heatIndex) {
       const heatIndexF = convertToFahrenheit(props.heatIndex.value, props.heatIndex.unitCode);
       if (heatIndexF !== null && tempF > DisplayThresholds.temperature.showHeatIndex && heatIndexF > tempF) {
-        output += `**Feels Like (Heat Index):** ${Math.round(heatIndexF)}°F\n`;
+        output += `**Feels Like (Heat Index):** ${formatTemperatureQV(props.heatIndex, prefs)}\n`;
       }
     }
 
@@ -93,7 +105,7 @@ export async function handleGetCurrentConditions(
     if (props.windChill) {
       const windChillF = convertToFahrenheit(props.windChill.value, props.windChill.unitCode);
       if (windChillF !== null && tempF < DisplayThresholds.temperature.showWindChill && windChillF < tempF) {
-        output += `**Feels Like (Wind Chill):** ${Math.round(windChillF)}°F\n`;
+        output += `**Feels Like (Wind Chill):** ${formatTemperatureQV(props.windChill, prefs)}\n`;
       }
     }
   }
@@ -103,30 +115,27 @@ export async function handleGetCurrentConditions(
   const min24F = props.minTemperatureLast24Hours ? convertToFahrenheit(props.minTemperatureLast24Hours.value, props.minTemperatureLast24Hours.unitCode) : null;
   if (max24F !== null || min24F !== null) {
     let range = `**24-Hour Range:**`;
-    if (max24F !== null) range += ` High ${Math.round(max24F)}°F`;
+    if (max24F !== null) range += ` High ${formatTemperatureQV(props.maxTemperatureLast24Hours, prefs)}`;
     if (max24F !== null && min24F !== null) range += ` /`;
-    if (min24F !== null) range += ` Low ${Math.round(min24F)}°F`;
+    if (min24F !== null) range += ` Low ${formatTemperatureQV(props.minTemperatureLast24Hours, prefs)}`;
     output += `${range}\n`;
   }
 
   if (props.dewpoint.value !== null) {
-    const dewF = convertToFahrenheit(props.dewpoint.value, props.dewpoint.unitCode);
-    if (dewF !== null) {
-      output += `**Dewpoint:** ${Math.round(dewF)}°F\n`;
-    }
+    output += `**Dewpoint:** ${formatTemperatureQV(props.dewpoint, prefs)}\n`;
   }
 
   if (props.relativeHumidity.value !== null) {
     output += `**Humidity:** ${Math.round(props.relativeHumidity.value)}%\n`;
   }
 
-  // Wind section
+  // Wind section (canonical mph drives the gust-significance comparison)
   if (props.windSpeed && props.windSpeed.value !== null) {
     const windMph = props.windSpeed.unitCode.includes('km_h')
       ? props.windSpeed.value * 0.621371
       : props.windSpeed.value * 2.23694; // m/s to mph
     const windDir = props.windDirection?.value ?? null;
-    output += `**Wind:** ${Math.round(windMph)} mph`;
+    output += `**Wind:** ${formatWindSpeedQV(props.windSpeed, prefs)}`;
     if (windDir !== null) {
       output += ` from ${Math.round(windDir)}°`;
     }
@@ -137,21 +146,20 @@ export async function handleGetCurrentConditions(
         ? props.windGust.value * 0.621371
         : props.windGust.value * 2.23694;
       if (gustMph > windMph * DisplayThresholds.wind.gustSignificanceRatio) {
-        output += `, gusting to ${Math.round(gustMph)} mph`;
+        output += `, gusting to ${formatWindSpeedQV(props.windGust, prefs)}`;
       }
     }
     output += `\n`;
   }
 
   if (props.barometricPressure && props.barometricPressure.value !== null) {
-    const pressureInHg = props.barometricPressure.value * 0.0002953;
-    output += `**Pressure:** ${pressureInHg.toFixed(2)} inHg\n`;
+    output += `**Pressure:** ${formatPressureQV(props.barometricPressure, prefs)}\n`;
   }
 
-  // Enhanced visibility and cloud cover
+  // Enhanced visibility and cloud cover (canonical miles drives the descriptors)
   if (props.visibility && props.visibility.value !== null) {
     const visibilityMiles = props.visibility.value * 0.000621371;
-    output += `**Visibility:** ${visibilityMiles.toFixed(1)} miles`;
+    output += `**Visibility:** ${formatVisibilityQV(props.visibility, prefs)}`;
 
     // Add descriptive text for visibility
     if (visibilityMiles < DisplayThresholds.visibility.denseFog) {
@@ -185,7 +193,7 @@ export async function handleGetCurrentConditions(
           const heightFt = layer.base.unitCode.includes('m')
             ? layer.base.value * 3.28084
             : layer.base.value;
-          return `${desc} at ${Math.round(heightFt).toLocaleString()} ft`;
+          return `${desc} at ${formatHeightFromFt(heightFt, prefs)}`;
         }
         return desc;
       });
@@ -204,24 +212,18 @@ export async function handleGetCurrentConditions(
     output += `\n## Recent Precipitation\n`;
 
     if (precip1h !== null && props.precipitationLastHour) {
-      const precipIn = props.precipitationLastHour.unitCode.includes('mm')
-        ? precip1h * 0.0393701
-        : precip1h;
-      output += `**Last Hour:** ${precipIn.toFixed(2)} inches\n`;
+      const mm = props.precipitationLastHour.unitCode.includes('mm') ? precip1h : precip1h * 25.4;
+      output += `**Last Hour:** ${formatPrecipFromMm(mm, prefs)}\n`;
     }
 
     if (precip3h !== null && props.precipitationLast3Hours) {
-      const precipIn = props.precipitationLast3Hours.unitCode.includes('mm')
-        ? precip3h * 0.0393701
-        : precip3h;
-      output += `**Last 3 Hours:** ${precipIn.toFixed(2)} inches\n`;
+      const mm = props.precipitationLast3Hours.unitCode.includes('mm') ? precip3h : precip3h * 25.4;
+      output += `**Last 3 Hours:** ${formatPrecipFromMm(mm, prefs)}\n`;
     }
 
     if (precip6h !== null && props.precipitationLast6Hours) {
-      const precipIn = props.precipitationLast6Hours.unitCode.includes('mm')
-        ? precip6h * 0.0393701
-        : precip6h;
-      output += `**Last 6 Hours:** ${precipIn.toFixed(2)} inches\n`;
+      const mm = props.precipitationLast6Hours.unitCode.includes('mm') ? precip6h : precip6h * 25.4;
+      output += `**Last 6 Hours:** ${formatPrecipFromMm(mm, prefs)}\n`;
     }
   }
 
@@ -350,13 +352,16 @@ export async function handleGetCurrentConditions(
         day
       );
 
-      // Format and display normals with current temperature for comparison
+      // Format and display normals with current temperature for comparison.
+      // currentTemps must be in the caller's units to match formatNormals output.
+      const toPref = (f: number): number =>
+        prefs.temperature === 'C' ? Math.round(((f - 32) * 5) / 9) : Math.round(f);
       const currentTemps = {
-        high: max24F !== null ? Math.round(max24F) : undefined,
-        low: min24F !== null ? Math.round(min24F) : undefined
+        high: max24F !== null ? toPref(max24F) : undefined,
+        low: min24F !== null ? toPref(min24F) : undefined
       };
 
-      output += formatNormals(normals, currentTemps);
+      output += formatNormals(normals, currentTemps, prefs);
     } catch (error) {
       // If normals fetch fails, just skip it (don't error the whole request)
       output += `\n## Climate Normals\n\n`;

--- a/src/handlers/currentConditionsHandler.ts
+++ b/src/handlers/currentConditionsHandler.ts
@@ -5,7 +5,10 @@
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
 import { NCEIService } from '../services/ncei.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean } from '../utils/validation.js';
 import { convertToFahrenheit } from '../utils/temperatureConversion.js';
 import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
 import {
@@ -33,6 +36,8 @@ import { getClimateNormals, formatNormals, getDateComponents } from '../utils/no
 interface CurrentConditionsArgs extends UnitArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   include_fire_weather?: boolean;
   include_normals?: boolean;
 }
@@ -41,10 +46,13 @@ export async function handleGetCurrentConditions(
   args: unknown,
   noaaService: NOAAService,
   openMeteoService: OpenMeteoService,
-  nceiService: NCEIService
+  nceiService: NCEIService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as CurrentConditionsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const includeFireWeather = validateOptionalBoolean(
     (args as CurrentConditionsArgs)?.include_fire_weather,
     'include_fire_weather',
@@ -372,12 +380,12 @@ export async function handleGetCurrentConditions(
   output += `\n---\n`;
   output += `*Data source: NOAA National Weather Service*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }

--- a/src/handlers/forecastHandler.ts
+++ b/src/handlers/forecastHandler.ts
@@ -15,6 +15,16 @@ import {
   validateOptionalBoolean,
 } from '../utils/validation.js';
 import { resolveLocation } from '../utils/locationResolver.js';
+import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
+import { UnitPreferences } from '../config/units.js';
+import {
+  temperatureLabel,
+  windSpeedLabel,
+  precipitationLabel,
+  noaaUnitsParam,
+  formatElevationFromM,
+  formatLuxonTime,
+} from '../utils/unitFormat.js';
 import { logger } from '../utils/logger.js';
 import {
   extractSnowfallForecast,
@@ -25,7 +35,7 @@ import {
 import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js';
 import { getClimateNormals, formatNormals, getDateComponents } from '../utils/normals.js';
 
-interface ForecastArgs {
+interface ForecastArgs extends UnitArgs {
   latitude?: number;
   longitude?: number;
   location_name?: string;
@@ -188,6 +198,9 @@ export async function handleGetForecast(
     false
   );
 
+  // Resolve unit preferences (per-call params over the server default)
+  const prefs = resolveUnitPreferences(args as ForecastArgs);
+
   // Get source preference or auto-detect
   const requestedSource = (args as ForecastArgs)?.source || 'auto';
   let useNOAA: boolean;
@@ -211,7 +224,8 @@ export async function handleGetForecast(
       granularity,
       include_precipitation_probability,
       include_severe_weather,
-      include_normals
+      include_normals,
+      prefs
     );
   } else {
     // Use Open-Meteo for international locations
@@ -223,7 +237,8 @@ export async function handleGetForecast(
       days,
       granularity,
       include_precipitation_probability,
-      include_normals
+      include_normals,
+      prefs
     );
   }
 }
@@ -241,8 +256,10 @@ async function formatNOAAForecast(
   granularity: 'daily' | 'hourly',
   include_precipitation_probability: boolean,
   include_severe_weather: boolean,
-  include_normals: boolean
+  include_normals: boolean,
+  prefs: UnitPreferences
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const noaaUnits = noaaUnitsParam(prefs);
   // Get timezone for proper time formatting
   let timezone = guessTimezoneFromCoords(latitude, longitude);
   try {
@@ -253,10 +270,10 @@ async function formatNOAAForecast(
   } catch (error) {
     // Use fallback timezone
   }
-  // Get forecast data based on granularity
+  // Get forecast data based on granularity (units=us|si controls NWS output units)
   const forecast = granularity === 'hourly'
-    ? await noaaService.getHourlyForecastByCoordinates(latitude, longitude)
-    : await noaaService.getForecastByCoordinates(latitude, longitude);
+    ? await noaaService.getHourlyForecastByCoordinates(latitude, longitude, noaaUnits)
+    : await noaaService.getForecastByCoordinates(latitude, longitude, noaaUnits);
 
   // Determine how many periods to show
   let periods;
@@ -271,16 +288,16 @@ async function formatNOAAForecast(
   // Format the forecast for display
   let output = `# Weather Forecast (${granularity === 'hourly' ? 'Hourly' : 'Daily'})\n\n`;
   output += `**Location:** ${latitude.toFixed(4)}, ${longitude.toFixed(4)}\n`;
-  output += `**Elevation:** ${forecast.properties.elevation.value}m\n`;
+  output += `**Elevation:** ${formatElevationFromM(forecast.properties.elevation.value, prefs)}\n`;
   if (forecast.properties.updated) {
-    output += `**Updated:** ${formatInTimezone(forecast.properties.updated, timezone)}\n`;
+    output += `**Updated:** ${formatInTimezone(forecast.properties.updated, timezone, 'medium', prefs.timeFormat)}\n`;
   }
   output += `**Showing:** ${periods.length} ${granularity === 'hourly' ? 'hours' : 'periods'}\n\n`;
 
   for (const period of periods) {
     // For hourly forecasts, use the start time as the header since period names are empty
     const periodHeader = granularity === 'hourly' && !period.name
-      ? formatInTimezone(period.startTime, timezone, 'short')
+      ? formatInTimezone(period.startTime, timezone, 'short', prefs.timeFormat)
       : period.name;
     output += `## ${periodHeader}\n`;
     output += `**Temperature:** ${period.temperature}°${period.temperatureUnit}`;
@@ -394,7 +411,7 @@ async function formatNOAAForecast(
           low: forecastLow
         };
 
-        output += formatNormals(normals, currentTemps);
+        output += formatNormals(normals, currentTemps, prefs);
       }
     } catch (error) {
       // If normals fetch fails, just skip it (don't error the whole request)
@@ -424,19 +441,26 @@ async function formatOpenMeteoForecast(
   days: number,
   granularity: 'daily' | 'hourly',
   include_precipitation_probability: boolean,
-  include_normals: boolean
+  include_normals: boolean,
+  prefs: UnitPreferences
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Get forecast data from Open-Meteo
+  // Unit labels for output (Open-Meteo returns values already in requested units)
+  const tempU = temperatureLabel(prefs);
+  const windU = windSpeedLabel(prefs);
+  const precipU = precipitationLabel(prefs);
+
+  // Get forecast data from Open-Meteo in the requested units
   const forecast = await openMeteoService.getForecast(
     latitude,
     longitude,
     days,
-    granularity === 'hourly'
+    granularity === 'hourly',
+    prefs
   );
 
   let output = `# Weather Forecast (${granularity === 'hourly' ? 'Hourly' : 'Daily'})\n\n`;
   output += `**Location:** ${latitude.toFixed(4)}, ${longitude.toFixed(4)}\n`;
-  output += `**Elevation:** ${forecast.elevation}m\n`;
+  output += `**Elevation:** ${formatElevationFromM(forecast.elevation, prefs)}\n`;
   output += `**Timezone:** ${forecast.timezone}\n`;
   output += `**Forecast Days:** ${days}\n\n`;
 
@@ -446,12 +470,12 @@ async function formatOpenMeteoForecast(
     const numHours = Math.min(hourly.time.length, days * 24);
 
     for (let i = 0; i < numHours; i++) {
-      output += `## ${formatInTimezone(hourly.time[i], forecast.timezone, 'short')}\n`;
+      output += `## ${formatInTimezone(hourly.time[i], forecast.timezone, 'short', prefs.timeFormat)}\n`;
 
       if (hourly.temperature_2m?.[i] !== undefined) {
-        output += `**Temperature:** ${Math.round(hourly.temperature_2m[i])}°F`;
+        output += `**Temperature:** ${Math.round(hourly.temperature_2m[i])}${tempU}`;
         if (hourly.apparent_temperature?.[i] !== undefined) {
-          output += ` (feels like ${Math.round(hourly.apparent_temperature[i])}°F)`;
+          output += ` (feels like ${Math.round(hourly.apparent_temperature[i])}${tempU})`;
         }
         output += `\n`;
       }
@@ -461,17 +485,17 @@ async function formatOpenMeteoForecast(
       }
 
       if (hourly.precipitation?.[i] !== undefined && hourly.precipitation[i] > 0) {
-        output += `**Precipitation:** ${hourly.precipitation[i].toFixed(2)} in\n`;
+        output += `**Precipitation:** ${hourly.precipitation[i].toFixed(2)} ${precipU}\n`;
       }
 
       if (hourly.wind_speed_10m?.[i] !== undefined) {
         const windDir = hourly.wind_direction_10m?.[i] !== undefined
           ? ` ${getWindDirection(hourly.wind_direction_10m[i])}`
           : '';
-        output += `**Wind:** ${Math.round(hourly.wind_speed_10m[i])} mph${windDir}\n`;
+        output += `**Wind:** ${Math.round(hourly.wind_speed_10m[i])} ${windU}${windDir}\n`;
 
         if (hourly.wind_gusts_10m?.[i] !== undefined && hourly.wind_gusts_10m[i] > hourly.wind_speed_10m[i] * 1.2) {
-          output += `**Wind Gusts:** ${Math.round(hourly.wind_gusts_10m[i])} mph\n`;
+          output += `**Wind Gusts:** ${Math.round(hourly.wind_gusts_10m[i])} ${windU}\n`;
         }
       }
 
@@ -497,22 +521,22 @@ async function formatOpenMeteoForecast(
       output += `## ${dt.toLocaleString({ weekday: 'long', month: 'long', day: 'numeric' })}\n`;
 
       if (daily.temperature_2m_max?.[i] !== undefined && daily.temperature_2m_min?.[i] !== undefined) {
-        output += `**Temperature:** High ${Math.round(daily.temperature_2m_max[i])}°F / Low ${Math.round(daily.temperature_2m_min[i])}°F\n`;
+        output += `**Temperature:** High ${Math.round(daily.temperature_2m_max[i])}${tempU} / Low ${Math.round(daily.temperature_2m_min[i])}${tempU}\n`;
       }
 
       if (daily.apparent_temperature_max?.[i] !== undefined && daily.apparent_temperature_min?.[i] !== undefined) {
-        output += `**Feels Like:** High ${Math.round(daily.apparent_temperature_max[i])}°F / Low ${Math.round(daily.apparent_temperature_min[i])}°F\n`;
+        output += `**Feels Like:** High ${Math.round(daily.apparent_temperature_max[i])}${tempU} / Low ${Math.round(daily.apparent_temperature_min[i])}${tempU}\n`;
       }
 
       // Include sunrise/sunset data with timezone
       if (daily.sunrise?.[i]) {
         const sunrise = DateTime.fromISO(daily.sunrise[i], { zone: forecast.timezone });
-        output += `**Sunrise:** ${sunrise.toLocaleString(DateTime.TIME_SIMPLE)}\n`;
+        output += `**Sunrise:** ${formatLuxonTime(sunrise, prefs)}\n`;
       }
 
       if (daily.sunset?.[i]) {
         const sunset = DateTime.fromISO(daily.sunset[i], { zone: forecast.timezone });
-        output += `**Sunset:** ${sunset.toLocaleString(DateTime.TIME_SIMPLE)}\n`;
+        output += `**Sunset:** ${formatLuxonTime(sunset, prefs)}\n`;
       }
 
       if (daily.daylight_duration?.[i] !== undefined) {
@@ -526,17 +550,17 @@ async function formatOpenMeteoForecast(
       }
 
       if (daily.precipitation_sum?.[i] !== undefined && daily.precipitation_sum[i] > 0) {
-        output += `**Precipitation:** ${daily.precipitation_sum[i].toFixed(2)} in\n`;
+        output += `**Precipitation:** ${daily.precipitation_sum[i].toFixed(2)} ${precipU}\n`;
       }
 
       if (daily.wind_speed_10m_max?.[i] !== undefined) {
         const windDir = daily.wind_direction_10m_dominant?.[i] !== undefined
           ? ` ${getWindDirection(daily.wind_direction_10m_dominant[i])}`
           : '';
-        output += `**Wind:** ${Math.round(daily.wind_speed_10m_max[i])} mph${windDir}\n`;
+        output += `**Wind:** ${Math.round(daily.wind_speed_10m_max[i])} ${windU}${windDir}\n`;
 
         if (daily.wind_gusts_10m_max?.[i] !== undefined && daily.wind_gusts_10m_max[i] > daily.wind_speed_10m_max[i] * 1.2) {
-          output += `**Wind Gusts:** ${Math.round(daily.wind_gusts_10m_max[i])} mph\n`;
+          output += `**Wind Gusts:** ${Math.round(daily.wind_gusts_10m_max[i])} ${windU}\n`;
         }
       }
 
@@ -583,7 +607,7 @@ async function formatOpenMeteoForecast(
             : undefined
         };
 
-        output += formatNormals(normals, currentTemps);
+        output += formatNormals(normals, currentTemps, prefs);
       }
     } catch (error) {
       // If normals fetch fails, just skip it (don't error the whole request)

--- a/src/handlers/forecastHandler.ts
+++ b/src/handlers/forecastHandler.ts
@@ -8,13 +8,14 @@ import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
 import { NCEIService } from '../services/ncei.js';
 import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
 import type { GridpointProperties, GridpointDataSeries } from '../types/noaa.js';
 import {
   validateForecastDays,
   validateGranularity,
   validateOptionalBoolean,
 } from '../utils/validation.js';
-import { resolveLocation } from '../utils/locationResolver.js';
+import { resolveLocationAsync, ResolvedLocation } from '../utils/locationResolver.js';
 import { logger } from '../utils/logger.js';
 import {
   extractSnowfallForecast,
@@ -29,6 +30,7 @@ interface ForecastArgs {
   latitude?: number;
   longitude?: number;
   location_name?: string;
+  city_name?: string;
   days?: number;
   granularity?: 'daily' | 'hourly';
   include_precipitation_probability?: boolean;
@@ -166,10 +168,12 @@ export async function handleGetForecast(
   noaaService: NOAAService,
   openMeteoService: OpenMeteoService,
   locationStore: LocationStore,
+  geocodingService: GeocodingService,
   nceiService?: NCEIService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Resolve location from either coordinates or saved location name
-  const { latitude, longitude } = resolveLocation(args as ForecastArgs, locationStore);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as ForecastArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const days = validateForecastDays(args);
   const granularity = validateGranularity((args as ForecastArgs)?.granularity);
   const include_precipitation_probability = validateOptionalBoolean(
@@ -200,8 +204,9 @@ export async function handleGetForecast(
   }
 
   // Use NOAA for US locations or if explicitly requested
+  let result: { content: Array<{ type: string; text: string }> };
   if (useNOAA) {
-    return await formatNOAAForecast(
+    result = await formatNOAAForecast(
       noaaService,
       openMeteoService,
       nceiService,
@@ -215,7 +220,7 @@ export async function handleGetForecast(
     );
   } else {
     // Use Open-Meteo for international locations
-    return await formatOpenMeteoForecast(
+    result = await formatOpenMeteoForecast(
       openMeteoService,
       nceiService,
       latitude,
@@ -226,6 +231,28 @@ export async function handleGetForecast(
       include_normals
     );
   }
+
+  // If the location was resolved from a name (saved or geocoded), show the user
+  // what it matched so an ambiguous city name is transparent.
+  const locationLine = formatLocationLine(resolved);
+  if (locationLine && result.content.length > 0 && result.content[0]?.type === 'text') {
+    result.content[0].text = locationLine + result.content[0].text;
+  }
+
+  return result;
+}
+
+/**
+ * Build a header line describing how a location name was resolved.
+ * Returns an empty string for direct-coordinate requests (nothing to disclose).
+ */
+function formatLocationLine(resolved: ResolvedLocation): string {
+  if (resolved.source === 'coordinates' || !resolved.location_name) {
+    return '';
+  }
+
+  const coords = `${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}`;
+  return `**Location:** ${resolved.location_name} (${coords})\n\n`;
 }
 
 /**

--- a/src/handlers/forecastHandler.ts
+++ b/src/handlers/forecastHandler.ts
@@ -491,8 +491,9 @@ async function formatOpenMeteoForecast(
     const numDays = Math.min(daily.time.length, days);
 
     for (let i = 0; i < numDays; i++) {
-      // Use timezone-aware date formatting
-      const dt = DateTime.fromISO(daily.time[i], { setZone: false }).setZone(forecast.timezone);
+      // Open-Meteo returns location-local naive timestamps; parse directly in the
+      // forecast timezone to avoid a double offset shift via the server's zone
+      const dt = DateTime.fromISO(daily.time[i], { zone: forecast.timezone });
       output += `## ${dt.toLocaleString({ weekday: 'long', month: 'long', day: 'numeric' })}\n`;
 
       if (daily.temperature_2m_max?.[i] !== undefined && daily.temperature_2m_min?.[i] !== undefined) {
@@ -505,12 +506,12 @@ async function formatOpenMeteoForecast(
 
       // Include sunrise/sunset data with timezone
       if (daily.sunrise?.[i]) {
-        const sunrise = DateTime.fromISO(daily.sunrise[i], { setZone: false }).setZone(forecast.timezone);
+        const sunrise = DateTime.fromISO(daily.sunrise[i], { zone: forecast.timezone });
         output += `**Sunrise:** ${sunrise.toLocaleString(DateTime.TIME_SIMPLE)}\n`;
       }
 
       if (daily.sunset?.[i]) {
-        const sunset = DateTime.fromISO(daily.sunset[i], { setZone: false }).setZone(forecast.timezone);
+        const sunset = DateTime.fromISO(daily.sunset[i], { zone: forecast.timezone });
         output += `**Sunset:** ${sunset.toLocaleString(DateTime.TIME_SIMPLE)}\n`;
       }
 

--- a/src/handlers/forecastHandler.ts
+++ b/src/handlers/forecastHandler.ts
@@ -14,8 +14,10 @@ import {
   validateForecastDays,
   validateGranularity,
   validateOptionalBoolean,
+  validateDetail,
+  DetailLevel,
 } from '../utils/validation.js';
-import { resolveLocationAsync, ResolvedLocation } from '../utils/locationResolver.js';
+import { resolveLocationAsync, formatLocationLine } from '../utils/locationResolver.js';
 import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
 import { UnitPreferences } from '../config/units.js';
 import {
@@ -47,6 +49,24 @@ interface ForecastArgs extends UnitArgs {
   include_severe_weather?: boolean;
   include_normals?: boolean;
   source?: 'auto' | 'noaa' | 'openmeteo';
+  detail?: DetailLevel;
+}
+
+/**
+ * Cap the number of hourly forecast entries by verbosity level.
+ * Hourly forecasts can emit up to days*24 entries (384 at 16 days), which is
+ * expensive for assistant contexts. Unless the user asks for detail="full",
+ * cap to a short horizon; the daily view still covers the full requested range.
+ *
+ * @param detail - Requested verbosity
+ * @param days - Number of forecast days requested
+ * @returns Maximum hourly entries to emit
+ */
+function hourlyEntryCap(detail: DetailLevel, days: number): number {
+  const maxHours = days * 24;
+  if (detail === 'full') return maxHours;
+  if (detail === 'summary') return Math.min(24, maxHours);
+  return Math.min(48, maxHours); // standard default
 }
 
 /**
@@ -201,6 +221,8 @@ export async function handleGetForecast(
     'include_normals',
     false
   );
+  // Output verbosity: caps hourly output unless detail="full" (see hourlyEntryCap)
+  const detail = validateDetail((args as ForecastArgs)?.detail);
 
   // Resolve unit preferences (per-call params over the server default)
   const prefs = resolveUnitPreferences(args as ForecastArgs);
@@ -230,7 +252,8 @@ export async function handleGetForecast(
       include_precipitation_probability,
       include_severe_weather,
       include_normals,
-      prefs
+      prefs,
+      detail
     );
   } else {
     // Use Open-Meteo for international locations
@@ -243,7 +266,8 @@ export async function handleGetForecast(
       granularity,
       include_precipitation_probability,
       include_normals,
-      prefs
+      prefs,
+      detail
     );
   }
 
@@ -255,19 +279,6 @@ export async function handleGetForecast(
   }
 
   return result;
-}
-
-/**
- * Build a header line describing how a location name was resolved.
- * Returns an empty string for direct-coordinate requests (nothing to disclose).
- */
-function formatLocationLine(resolved: ResolvedLocation): string {
-  if (resolved.source === 'coordinates' || !resolved.location_name) {
-    return '';
-  }
-
-  const coords = `${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}`;
-  return `**Location:** ${resolved.location_name} (${coords})\n\n`;
 }
 
 /**
@@ -284,29 +295,29 @@ async function formatNOAAForecast(
   include_precipitation_probability: boolean,
   include_severe_weather: boolean,
   include_normals: boolean,
-  prefs: UnitPreferences
+  prefs: UnitPreferences,
+  detail: DetailLevel
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const noaaUnits = noaaUnitsParam(prefs);
-  // Get timezone for proper time formatting
-  let timezone = guessTimezoneFromCoords(latitude, longitude);
-  try {
-    const points = await noaaService.getPointData(latitude, longitude);
-    if (points.properties.timeZone) {
-      timezone = points.properties.timeZone;
-    }
-  } catch (error) {
-    // Use fallback timezone
-  }
+  // Fetch point data once. It yields both the timezone AND the grid coordinates,
+  // so downstream forecast/gridpoint calls use the grid-based methods directly
+  // instead of re-resolving the point (avoids duplicate upstream lookups on a
+  // cold cache). A point-data failure here propagates — the forecast can't be
+  // built without it anyway.
+  const points = await noaaService.getPointData(latitude, longitude);
+  const { gridId, gridX, gridY } = points.properties;
+  const timezone = points.properties.timeZone || guessTimezoneFromCoords(latitude, longitude);
+
   // Get forecast data based on granularity (units=us|si controls NWS output units)
   const forecast = granularity === 'hourly'
-    ? await noaaService.getHourlyForecastByCoordinates(latitude, longitude, noaaUnits)
-    : await noaaService.getForecastByCoordinates(latitude, longitude, noaaUnits);
+    ? await noaaService.getHourlyForecast(gridId, gridX, gridY, noaaUnits)
+    : await noaaService.getForecast(gridId, gridX, gridY, noaaUnits);
 
   // Determine how many periods to show
   let periods;
   if (granularity === 'hourly') {
-    // For hourly, show up to days * 24 hours
-    periods = forecast.properties.periods.slice(0, days * 24);
+    // Hourly output is capped by verbosity (see hourlyEntryCap) unless full
+    periods = forecast.properties.periods.slice(0, hourlyEntryCap(detail, days));
   } else {
     // For daily, show up to days * 2 (day/night periods)
     periods = forecast.properties.periods.slice(0, days * 2);
@@ -320,6 +331,9 @@ async function formatNOAAForecast(
     output += `**Updated:** ${formatInTimezone(forecast.properties.updated, timezone, 'medium', prefs.timeFormat)}\n`;
   }
   output += `**Showing:** ${periods.length} ${granularity === 'hourly' ? 'hours' : 'periods'}\n\n`;
+  if (granularity === 'hourly' && detail !== 'full' && forecast.properties.periods.length > periods.length) {
+    output += `*Hourly output capped at ${periods.length} hours (detail="${detail}"). Use detail="full" for the full ${days}-day hourly forecast.*\n\n`;
+  }
 
   for (const period of periods) {
     // For hourly forecasts, use the start time as the header since period names are empty
@@ -349,8 +363,8 @@ async function formatNOAAForecast(
 
     output += `**Forecast:** ${period.shortForecast}\n\n`;
 
-    // For daily forecasts, include detailed forecast
-    if (granularity === 'daily' && period.detailedForecast) {
+    // For daily forecasts, include the long detailed forecast (omitted at summary)
+    if (granularity === 'daily' && detail !== 'summary' && period.detailedForecast) {
       output += `${period.detailedForecast}\n\n`;
     }
   }
@@ -364,7 +378,7 @@ async function formatNOAAForecast(
   // Add severe weather probabilities if requested
   if (include_severe_weather) {
     try {
-      gridpointData = await noaaService.getGridpointDataByCoordinates(latitude, longitude);
+      gridpointData = await noaaService.getGridpointData(gridId, gridX, gridY);
       const severeWeatherSection = formatSevereWeather(gridpointData.properties);
       if (severeWeatherSection) {
         output += `\n${severeWeatherSection}`;
@@ -379,7 +393,7 @@ async function formatNOAAForecast(
   try {
     // Fetch gridpoint data if we haven't already
     if (!gridpointData) {
-      gridpointData = await noaaService.getGridpointDataByCoordinates(latitude, longitude);
+      gridpointData = await noaaService.getGridpointData(gridId, gridX, gridY);
     }
 
     // Calculate time range for forecast period
@@ -469,7 +483,8 @@ async function formatOpenMeteoForecast(
   granularity: 'daily' | 'hourly',
   include_precipitation_probability: boolean,
   include_normals: boolean,
-  prefs: UnitPreferences
+  prefs: UnitPreferences,
+  detail: DetailLevel
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   // Unit labels for output (Open-Meteo returns values already in requested units)
   const tempU = temperatureLabel(prefs);
@@ -492,9 +507,12 @@ async function formatOpenMeteoForecast(
   output += `**Forecast Days:** ${days}\n\n`;
 
   if (granularity === 'hourly' && forecast.hourly) {
-    // Format hourly data
+    // Format hourly data (capped by verbosity unless detail="full")
     const hourly = forecast.hourly;
-    const numHours = Math.min(hourly.time.length, days * 24);
+    const numHours = Math.min(hourly.time.length, hourlyEntryCap(detail, days));
+    if (detail !== 'full' && hourly.time.length > numHours) {
+      output += `*Hourly output capped at ${numHours} hours (detail="${detail}"). Use detail="full" for the full ${days}-day hourly forecast.*\n\n`;
+    }
 
     for (let i = 0; i < numHours; i++) {
       output += `## ${formatInTimezone(hourly.time[i], forecast.timezone, 'short', prefs.timeFormat)}\n`;

--- a/src/handlers/historicalWeatherHandler.ts
+++ b/src/handlers/historicalWeatherHandler.ts
@@ -5,7 +5,16 @@
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
 import { validateHistoricalWeatherParams } from '../utils/validation.js';
-import { convertToFahrenheit } from '../utils/temperatureConversion.js';
+import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
+import {
+  temperatureLabel,
+  windSpeedLabel,
+  precipitationLabel,
+  formatElevationFromM,
+  formatTemperatureQV,
+  formatWindSpeedQV,
+  formatPressureFromPa,
+} from '../utils/unitFormat.js';
 import { ApiConstants, FormatConstants } from '../config/displayThresholds.js';
 
 export async function handleGetHistoricalWeather(
@@ -15,6 +24,10 @@ export async function handleGetHistoricalWeather(
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   // Validate input parameters with runtime checks
   const { latitude, longitude, start_date, end_date, limit = FormatConstants.defaultHistoricalLimit } = validateHistoricalWeatherParams(args);
+  const prefs = resolveUnitPreferences(args as UnitArgs);
+  const tempU = temperatureLabel(prefs);
+  const windU = windSpeedLabel(prefs);
+  const precipU = precipitationLabel(prefs);
 
   // Parse dates
   const startTime = new Date(start_date);
@@ -46,7 +59,8 @@ export async function handleGetHistoricalWeather(
         longitude,
         start_date.split('T')[0], // Ensure YYYY-MM-DD format
         end_date.split('T')[0],
-        useHourly
+        useHourly,
+        prefs
       );
 
       // Format the response based on data granularity
@@ -54,7 +68,7 @@ export async function handleGetHistoricalWeather(
         // Format hourly observations
         let output = `# Historical Weather Observations (Hourly)\n\n`;
         output += `**Period:** ${startTime.toLocaleDateString()} to ${endTime.toLocaleDateString()}\n`;
-        output += `**Location:** ${weatherData.latitude.toFixed(4)}°N, ${Math.abs(weatherData.longitude).toFixed(4)}°${weatherData.longitude >= 0 ? 'E' : 'W'} (${weatherData.elevation}m elevation)\n`;
+        output += `**Location:** ${weatherData.latitude.toFixed(4)}°N, ${Math.abs(weatherData.longitude).toFixed(4)}°${weatherData.longitude >= 0 ? 'E' : 'W'} (${formatElevationFromM(weatherData.elevation, prefs)} elevation)\n`;
         output += `**Number of observations:** ${weatherData.hourly.time.length}\n`;
         output += `**Data source:** Open-Meteo Historical Weather API (Reanalysis)\n\n`;
 
@@ -64,11 +78,11 @@ export async function handleGetHistoricalWeather(
           output += `## ${time.toLocaleString()}\n`;
 
           if (weatherData.hourly.temperature_2m?.[i] !== null && weatherData.hourly.temperature_2m?.[i] !== undefined) {
-            output += `- **Temperature:** ${Math.round(weatherData.hourly.temperature_2m[i])}°F\n`;
+            output += `- **Temperature:** ${Math.round(weatherData.hourly.temperature_2m[i])}${tempU}\n`;
           }
 
           if (weatherData.hourly.apparent_temperature?.[i] !== null && weatherData.hourly.apparent_temperature?.[i] !== undefined) {
-            output += `- **Feels Like:** ${Math.round(weatherData.hourly.apparent_temperature[i])}°F\n`;
+            output += `- **Feels Like:** ${Math.round(weatherData.hourly.apparent_temperature[i])}${tempU}\n`;
           }
 
           if (weatherData.hourly.weather_code?.[i] !== null && weatherData.hourly.weather_code?.[i] !== undefined) {
@@ -76,15 +90,15 @@ export async function handleGetHistoricalWeather(
           }
 
           if (weatherData.hourly.precipitation?.[i] !== null && weatherData.hourly.precipitation?.[i] !== undefined && weatherData.hourly.precipitation[i] > 0) {
-            output += `- **Precipitation:** ${weatherData.hourly.precipitation[i].toFixed(2)} in\n`;
+            output += `- **Precipitation:** ${weatherData.hourly.precipitation[i].toFixed(2)} ${precipU}\n`;
           }
 
           if (weatherData.hourly.snowfall?.[i] !== null && weatherData.hourly.snowfall?.[i] !== undefined && weatherData.hourly.snowfall[i] > 0) {
-            output += `- **Snowfall:** ${weatherData.hourly.snowfall[i].toFixed(1)} in\n`;
+            output += `- **Snowfall:** ${weatherData.hourly.snowfall[i].toFixed(1)} ${precipU}\n`;
           }
 
           if (weatherData.hourly.wind_speed_10m?.[i] !== null && weatherData.hourly.wind_speed_10m?.[i] !== undefined) {
-            output += `- **Wind:** ${Math.round(weatherData.hourly.wind_speed_10m[i])} mph`;
+            output += `- **Wind:** ${Math.round(weatherData.hourly.wind_speed_10m[i])} ${windU}`;
             if (weatherData.hourly.wind_direction_10m?.[i] !== null && weatherData.hourly.wind_direction_10m?.[i] !== undefined) {
               output += ` from ${Math.round(weatherData.hourly.wind_direction_10m[i])}°`;
             }
@@ -96,8 +110,8 @@ export async function handleGetHistoricalWeather(
           }
 
           if (weatherData.hourly.pressure_msl?.[i] !== null && weatherData.hourly.pressure_msl?.[i] !== undefined) {
-            const pressureInHg = weatherData.hourly.pressure_msl[i] * 0.02953;
-            output += `- **Pressure:** ${pressureInHg.toFixed(2)} inHg\n`;
+            // Open-Meteo returns pressure_msl in hPa regardless of unit params
+            output += `- **Pressure:** ${formatPressureFromPa(weatherData.hourly.pressure_msl[i] * 100, prefs)}\n`;
           }
 
           if (weatherData.hourly.cloud_cover?.[i] !== null && weatherData.hourly.cloud_cover?.[i] !== undefined) {
@@ -119,7 +133,7 @@ export async function handleGetHistoricalWeather(
         // Format daily summaries
         let output = `# Historical Weather Data (Daily Summaries)\n\n`;
         output += `**Period:** ${startTime.toLocaleDateString()} to ${endTime.toLocaleDateString()}\n`;
-        output += `**Location:** ${weatherData.latitude.toFixed(4)}°N, ${Math.abs(weatherData.longitude).toFixed(4)}°${weatherData.longitude >= 0 ? 'E' : 'W'} (${weatherData.elevation}m elevation)\n`;
+        output += `**Location:** ${weatherData.latitude.toFixed(4)}°N, ${Math.abs(weatherData.longitude).toFixed(4)}°${weatherData.longitude >= 0 ? 'E' : 'W'} (${formatElevationFromM(weatherData.elevation, prefs)} elevation)\n`;
         output += `**Number of days:** ${weatherData.daily.time.length}\n`;
         output += `**Data source:** Open-Meteo Historical Weather API (Reanalysis)\n\n`;
 
@@ -128,15 +142,15 @@ export async function handleGetHistoricalWeather(
           output += `## ${date.toLocaleDateString()}\n`;
 
           if (weatherData.daily.temperature_2m_max?.[i] !== null && weatherData.daily.temperature_2m_max?.[i] !== undefined) {
-            output += `- **High Temperature:** ${Math.round(weatherData.daily.temperature_2m_max[i])}°F\n`;
+            output += `- **High Temperature:** ${Math.round(weatherData.daily.temperature_2m_max[i])}${tempU}\n`;
           }
 
           if (weatherData.daily.temperature_2m_min?.[i] !== null && weatherData.daily.temperature_2m_min?.[i] !== undefined) {
-            output += `- **Low Temperature:** ${Math.round(weatherData.daily.temperature_2m_min[i])}°F\n`;
+            output += `- **Low Temperature:** ${Math.round(weatherData.daily.temperature_2m_min[i])}${tempU}\n`;
           }
 
           if (weatherData.daily.temperature_2m_mean?.[i] !== null && weatherData.daily.temperature_2m_mean?.[i] !== undefined) {
-            output += `- **Average Temperature:** ${Math.round(weatherData.daily.temperature_2m_mean[i])}°F\n`;
+            output += `- **Average Temperature:** ${Math.round(weatherData.daily.temperature_2m_mean[i])}${tempU}\n`;
           }
 
           if (weatherData.daily.weather_code?.[i] !== null && weatherData.daily.weather_code?.[i] !== undefined) {
@@ -144,15 +158,15 @@ export async function handleGetHistoricalWeather(
           }
 
           if (weatherData.daily.precipitation_sum?.[i] !== null && weatherData.daily.precipitation_sum?.[i] !== undefined) {
-            output += `- **Precipitation:** ${weatherData.daily.precipitation_sum[i].toFixed(2)} in\n`;
+            output += `- **Precipitation:** ${weatherData.daily.precipitation_sum[i].toFixed(2)} ${precipU}\n`;
           }
 
           if (weatherData.daily.snowfall_sum?.[i] !== null && weatherData.daily.snowfall_sum?.[i] !== undefined && weatherData.daily.snowfall_sum[i] > 0) {
-            output += `- **Snowfall:** ${weatherData.daily.snowfall_sum[i].toFixed(1)} in\n`;
+            output += `- **Snowfall:** ${weatherData.daily.snowfall_sum[i].toFixed(1)} ${precipU}\n`;
           }
 
           if (weatherData.daily.wind_speed_10m_max?.[i] !== null && weatherData.daily.wind_speed_10m_max?.[i] !== undefined) {
-            output += `- **Max Wind Speed:** ${Math.round(weatherData.daily.wind_speed_10m_max[i])} mph\n`;
+            output += `- **Max Wind Speed:** ${Math.round(weatherData.daily.wind_speed_10m_max[i])} ${windU}\n`;
           }
 
           output += `\n`;
@@ -206,10 +220,7 @@ export async function handleGetHistoricalWeather(
       output += `## ${new Date(props.timestamp).toLocaleString()}\n`;
 
       if (props.temperature.value !== null) {
-        const tempF = convertToFahrenheit(props.temperature.value, props.temperature.unitCode);
-        if (tempF !== null) {
-          output += `- **Temperature:** ${Math.round(tempF)}°F\n`;
-        }
+        output += `- **Temperature:** ${formatTemperatureQV(props.temperature, prefs)}\n`;
       }
 
       if (props.textDescription) {
@@ -217,10 +228,7 @@ export async function handleGetHistoricalWeather(
       }
 
       if (props.windSpeed.value !== null) {
-        const windMph = props.windSpeed.unitCode.includes('km_h')
-          ? props.windSpeed.value * 0.621371
-          : props.windSpeed.value * 2.23694;
-        output += `- **Wind:** ${Math.round(windMph)} mph\n`;
+        output += `- **Wind:** ${formatWindSpeedQV(props.windSpeed, prefs)}\n`;
       }
 
       output += `\n`;

--- a/src/handlers/historicalWeatherHandler.ts
+++ b/src/handlers/historicalWeatherHandler.ts
@@ -4,6 +4,9 @@
 
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { validateHistoricalWeatherParams } from '../utils/validation.js';
 import { resolveUnitPreferences, UnitArgs } from '../utils/unitPreferences.js';
 import {
@@ -20,10 +23,19 @@ import { ApiConstants, FormatConstants } from '../config/displayThresholds.js';
 export async function handleGetHistoricalWeather(
   args: unknown,
   noaaService: NOAAService,
-  openMeteoService: OpenMeteoService
+  openMeteoService: OpenMeteoService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude, start_date, end_date, limit = FormatConstants.defaultHistoricalLimit } = validateHistoricalWeatherParams(args);
+  // Resolve location first (coordinates, saved name, or geocoded city), then
+  // validate the date range. Coordinates from resolution are re-validated by
+  // validateHistoricalWeatherParams alongside the dates.
+  const resolved = await resolveLocationAsync(args as { latitude?: number; longitude?: number; location_name?: string; city_name?: string }, locationStore, geocodingService);
+  const { latitude, longitude, start_date, end_date, limit = FormatConstants.defaultHistoricalLimit } = validateHistoricalWeatherParams({
+    ...(args as Record<string, unknown>),
+    latitude: resolved.latitude,
+    longitude: resolved.longitude
+  });
   const prefs = resolveUnitPreferences(args as UnitArgs);
   const tempU = temperatureLabel(prefs);
   const windU = windSpeedLabel(prefs);
@@ -123,14 +135,14 @@ export async function handleGetHistoricalWeather(
           output += `\n`;
         }
 
-        return {
+        return prependLocationLine({
           content: [
             {
               type: 'text',
               text: output
             }
           ]
-        };
+        }, resolved);
       } else if (weatherData.daily) {
         // Format daily summaries
         let output = `# Historical Weather Data (Daily Summaries)\n\n`;
@@ -174,14 +186,14 @@ export async function handleGetHistoricalWeather(
           output += `\n`;
         }
 
-        return {
+        return prependLocationLine({
           content: [
             {
               type: 'text',
               text: output
             }
           ]
-        };
+        }, resolved);
       } else {
         throw new Error('No weather data available in response');
       }
@@ -201,14 +213,14 @@ export async function handleGetHistoricalWeather(
     );
 
     if (!observations.features || observations.features.length === 0) {
-      return {
+      return prependLocationLine({
         content: [
           {
             type: 'text',
             text: `No historical observations found for the specified date range (${start_date} to ${end_date}).\n\nThis may occur because:\n- The dates are outside the station's available data range\n- There are gaps in the observation records for this location\n- The weather station near this location may not have archived data for these dates\n\nNote: Historical weather data availability varies by location and weather station. Some stations have limited historical records.`
           }
         ]
-      };
+      }, resolved);
     }
 
     // Format the observations
@@ -236,13 +248,13 @@ export async function handleGetHistoricalWeather(
       output += `\n`;
     }
 
-    return {
+    return prependLocationLine({
       content: [
         {
           type: 'text',
           text: output
         }
       ]
-    };
+    }, resolved);
   }
 }

--- a/src/handlers/historicalWeatherHandler.ts
+++ b/src/handlers/historicalWeatherHandler.ts
@@ -52,13 +52,15 @@ export async function handleGetHistoricalWeather(
       // Format the response based on data granularity
       if (useHourly && weatherData.hourly) {
         // Format hourly observations
+        const maxObservations = Math.min(limit, weatherData.hourly.time.length);
         let output = `# Historical Weather Observations (Hourly)\n\n`;
-        output += `**Period:** ${startTime.toLocaleDateString()} to ${endTime.toLocaleDateString()}\n`;
+        // Use the requested date strings directly; constructing a Date and calling
+        // toLocaleDateString() would shift the displayed day in non-UTC server zones.
+        output += `**Period:** ${start_date.split('T')[0]} to ${end_date.split('T')[0]}\n`;
         output += `**Location:** ${weatherData.latitude.toFixed(4)}°N, ${Math.abs(weatherData.longitude).toFixed(4)}°${weatherData.longitude >= 0 ? 'E' : 'W'} (${weatherData.elevation}m elevation)\n`;
-        output += `**Number of observations:** ${weatherData.hourly.time.length}\n`;
+        output += `**Number of observations:** ${maxObservations}${maxObservations < weatherData.hourly.time.length ? ` (of ${weatherData.hourly.time.length} available)` : ''}\n`;
         output += `**Data source:** Open-Meteo Historical Weather API (Reanalysis)\n\n`;
 
-        const maxObservations = Math.min(limit, weatherData.hourly.time.length);
         for (let i = 0; i < maxObservations; i++) {
           const time = new Date(weatherData.hourly.time[i]);
           output += `## ${time.toLocaleString()}\n`;
@@ -118,7 +120,7 @@ export async function handleGetHistoricalWeather(
       } else if (weatherData.daily) {
         // Format daily summaries
         let output = `# Historical Weather Data (Daily Summaries)\n\n`;
-        output += `**Period:** ${startTime.toLocaleDateString()} to ${endTime.toLocaleDateString()}\n`;
+        output += `**Period:** ${start_date.split('T')[0]} to ${end_date.split('T')[0]}\n`;
         output += `**Location:** ${weatherData.latitude.toFixed(4)}°N, ${Math.abs(weatherData.longitude).toFixed(4)}°${weatherData.longitude >= 0 ? 'E' : 'W'} (${weatherData.elevation}m elevation)\n`;
         output += `**Number of days:** ${weatherData.daily.time.length}\n`;
         output += `**Data source:** Open-Meteo Historical Weather API (Reanalysis)\n\n`;
@@ -197,7 +199,7 @@ export async function handleGetHistoricalWeather(
 
     // Format the observations
     let output = `# Historical Weather Observations\n\n`;
-    output += `**Period:** ${startTime.toLocaleDateString()} to ${endTime.toLocaleDateString()}\n`;
+    output += `**Period:** ${start_date.split('T')[0]} to ${end_date.split('T')[0]}\n`;
     output += `**Number of observations:** ${observations.features.length}\n`;
     output += `**Data source:** NOAA Real-time API\n\n`;
 

--- a/src/handlers/lightningHandler.ts
+++ b/src/handlers/lightningHandler.ts
@@ -6,6 +6,7 @@
 import {
   LightningActivityParams,
   LightningActivityResponse,
+  LightningMonitoringCoverage,
   LightningStrike,
   LightningStatistics,
   LightningSafetyAssessment,
@@ -198,6 +199,30 @@ export async function getLightningActivity(params: LightningActivityParams): Pro
   const now = new Date();
   const searchStart = new Date(now.getTime() - timeWindow * 60 * 1000);
 
+  // Strikes only accumulate while the area's live subscriptions are active. If
+  // monitoring began after the start of the requested window (fresh server, or
+  // first query for this area), a "no strikes" result is inconclusive — say so
+  // instead of implying verified safety.
+  const coverageStart = blitzortungService.getCoverageStart(latitude, longitude, radius);
+  const coverageMinutes = coverageStart
+    ? Math.max(0, Math.min(timeWindow, (now.getTime() - coverageStart.getTime()) / (1000 * 60)))
+    : 0;
+  const coverage: LightningMonitoringCoverage = {
+    monitoringSince: coverageStart,
+    coverageMinutes,
+    isComplete: coverageMinutes >= timeWindow
+  };
+
+  if (!coverage.isComplete && safety.level === 'safe') {
+    safety.message =
+      'No lightning strikes observed during the limited monitoring period. ' +
+      'This does NOT confirm the absence of lightning activity.';
+    safety.recommendations.unshift(
+      `Live monitoring of this area covers only ${coverageMinutes.toFixed(1)} of the requested ` +
+      `${timeWindow} minutes — treat this result as inconclusive and re-check shortly.`
+    );
+  }
+
   return {
     location: { latitude, longitude },
     searchRadius: radius,
@@ -209,6 +234,7 @@ export async function getLightningActivity(params: LightningActivityParams): Pro
     strikes,
     statistics,
     safety,
+    coverage,
     source: 'Blitzortung.org',
     generatedAt: now,
     disclaimer: 'Lightning data from Blitzortung.org community network. Data may have 5-15 minute delay. For life-safety decisions, consult official weather services and local emergency management. When thunder roars, go indoors!'
@@ -236,10 +262,25 @@ export function formatLightningActivityResponse(response: LightningActivityRespo
     extreme: '🔴'
   }[response.safety.level];
 
-  lines.push(`## ${safetyIcon} Safety Status: ${response.safety.level.toUpperCase()}`);
+  const limitedData = !response.coverage.isComplete;
+  const statusSuffix = limitedData && response.safety.level === 'safe' ? ' (LIMITED DATA)' : '';
+  lines.push(`## ${safetyIcon} Safety Status: ${response.safety.level.toUpperCase()}${statusSuffix}`);
   lines.push('');
   lines.push(response.safety.message);
   lines.push('');
+
+  if (limitedData) {
+    const since = response.coverage.monitoringSince
+      ? ` (since ${response.coverage.monitoringSince.toISOString()})`
+      : '';
+    lines.push(
+      `⚠️ **Limited monitoring coverage:** Live strike collection for this area spans ` +
+      `${response.coverage.coverageMinutes.toFixed(1)} of the requested ${response.timeWindow} minutes${since}. ` +
+      `An absence of strikes in this report does not confirm an absence of lightning. ` +
+      `Re-check in a few minutes or consult official weather services before making safety decisions.`
+    );
+    lines.push('');
+  }
 
   // Recommendations
   if (response.safety.recommendations.length > 0) {
@@ -255,6 +296,10 @@ export function formatLightningActivityResponse(response: LightningActivityRespo
   lines.push('## 📊 Lightning Statistics');
   lines.push('');
   lines.push(`**Total Strikes:** ${response.statistics.totalStrikes}`);
+  lines.push(
+    `**Monitoring Coverage:** ${response.coverage.coverageMinutes.toFixed(1)} of ${response.timeWindow} minutes` +
+    (response.coverage.isComplete ? '' : ' ⚠️')
+  );
 
   if (response.statistics.totalStrikes > 0) {
     lines.push(`**Cloud-to-Ground:** ${response.statistics.cloudToGroundStrikes}`);

--- a/src/handlers/lightningHandler.ts
+++ b/src/handlers/lightningHandler.ts
@@ -13,9 +13,52 @@ import {
   LightningSafetyLevel
 } from '../types/lightning.js';
 import { blitzortungService } from '../services/blitzortung.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { validateLatitude, validateLongitude } from '../utils/validation.js';
 import { logger, redactCoordinatesForLogging } from '../utils/logger.js';
 import { ValidationError } from '../errors/ApiError.js';
+
+interface LightningActivityArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  city_name?: string;
+  radius?: number;
+  timeWindow?: number;
+}
+
+/**
+ * Tool entry point: resolve the location (coordinates, saved name, or geocoded
+ * city), fetch lightning activity, and format it with a resolved-location header.
+ */
+export async function handleGetLightningActivity(
+  args: unknown,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const typedArgs = (args ?? {}) as LightningActivityArgs;
+  const resolved = await resolveLocationAsync(typedArgs, locationStore, geocodingService);
+
+  const result = await getLightningActivity({
+    latitude: resolved.latitude,
+    longitude: resolved.longitude,
+    radius: typedArgs.radius,
+    timeWindow: typedArgs.timeWindow
+  });
+
+  const formatted = formatLightningActivityResponse(result);
+
+  return prependLocationLine({
+    content: [
+      {
+        type: 'text',
+        text: formatted
+      }
+    ]
+  }, resolved);
+}
 
 /**
  * Validate lightning activity request parameters

--- a/src/handlers/locationHandler.ts
+++ b/src/handlers/locationHandler.ts
@@ -63,7 +63,9 @@ export async function handleSearchLocation(
 
   for (let i = 0; i < results.length; i++) {
     const location = results[i];
-    output += `## ${i + 1}. ${location.name}\n\n`;
+    // Provider-returned strings (name, display_name, admin fields) are escaped
+    // before embedding — external text can otherwise alter Markdown rendering.
+    output += `## ${i + 1}. ${escapeMarkdown(location.name)}\n\n`;
 
     // Build location description
     const parts: string[] = [location.name];
@@ -71,7 +73,7 @@ export async function handleSearchLocation(
     if (location.admin2 && location.admin2 !== location.admin1) parts.push(location.admin2);
     if (location.country) parts.push(location.country);
 
-    output += `**Full Name:** ${location.display_name}\n`;
+    output += `**Full Name:** ${escapeMarkdown(location.display_name)}\n`;
     output += `**Coordinates:** ${location.latitude.toFixed(4)}°, ${location.longitude.toFixed(4)}°\n`;
 
     if (location.country_code) {

--- a/src/handlers/marineConditionsHandler.ts
+++ b/src/handlers/marineConditionsHandler.ts
@@ -330,7 +330,8 @@ function formatOpenMeteoMarineConditions(
     output += `**Next ${daysToShow} days:**\n\n`;
 
     for (let i = 0; i < daysToShow; i++) {
-      const dt = DateTime.fromISO(data.daily.time[i], { setZone: false }).setZone(data.timezone);
+      // Open-Meteo daily dates are location-local; parse in the location timezone
+      const dt = DateTime.fromISO(data.daily.time[i], { zone: data.timezone });
       const dayName = dt.toLocaleString({ weekday: 'short', month: 'short', day: 'numeric' });
 
       output += `**${dayName}:**\n`;

--- a/src/handlers/marineConditionsHandler.ts
+++ b/src/handlers/marineConditionsHandler.ts
@@ -6,7 +6,10 @@
 import { DateTime } from 'luxon';
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
-import { validateCoordinates, validateOptionalBoolean } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateOptionalBoolean } from '../utils/validation.js';
 import {
   formatWaveHeight,
   formatWavePeriod,
@@ -26,16 +29,21 @@ import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js'
 interface MarineConditionsArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   forecast?: boolean;
 }
 
 export async function handleGetMarineConditions(
   args: unknown,
   noaaService: NOAAService,
-  openMeteoService: OpenMeteoService
+  openMeteoService: OpenMeteoService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as MarineConditionsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
   const forecast = validateOptionalBoolean(
     (args as MarineConditionsArgs)?.forecast,
     'forecast',
@@ -86,14 +94,14 @@ export async function handleGetMarineConditions(
           forecast
         );
 
-        return {
+        return prependLocationLine({
           content: [
             {
               type: 'text',
               text: output
             }
           ]
-        };
+        }, resolved);
       } else {
         const redacted2 = redactCoordinatesForLogging(latitude, longitude);
         logger.info('NOAA gridpoint has no marine data, falling back to Open-Meteo', {
@@ -123,14 +131,14 @@ export async function handleGetMarineConditions(
   // Format the marine data for display
   const output = formatOpenMeteoMarineConditions(marineData, latitude, longitude, forecast);
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/handlers/riverConditionsHandler.ts
+++ b/src/handlers/riverConditionsHandler.ts
@@ -3,7 +3,9 @@
  */
 
 import { NOAAService } from '../services/noaa.js';
-import { validateCoordinates } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js';
 import { calculateDistance } from '../utils/distance.js';
 import type { NWPSGauge } from '../types/noaa.js';
@@ -11,15 +13,20 @@ import type { NWPSGauge } from '../types/noaa.js';
 interface RiverConditionsArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   radius?: number; // search radius in km (default: 50)
 }
 
 export async function handleGetRiverConditions(
   args: unknown,
-  noaaService: NOAAService
+  noaaService: NOAAService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as RiverConditionsArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
 
   // Validate radius parameter
   let radius = (args as RiverConditionsArgs)?.radius ?? 50; // default 50 km
@@ -92,14 +99,14 @@ export async function handleGetRiverConditions(
   output += `*Data sources: NOAA National Water Prediction Service (NWPS), USGS Water Services*\n`;
   output += `*River conditions are updated hourly. Always consult official sources for critical decisions.*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/handlers/weatherImageryHandler.ts
+++ b/src/handlers/weatherImageryHandler.ts
@@ -6,9 +6,56 @@
 import { WeatherImageryParams, WeatherImageryResponse, ImageryType } from '../types/imagery.js';
 import { rainViewerService } from '../services/rainviewer.js';
 import { gibsService } from '../services/gibs.js';
-import { validateLatitude, validateLongitude } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
+import { validateLatitude, validateLongitude, validateDetail, DetailLevel } from '../utils/validation.js';
 import { logger, redactCoordinatesForLogging } from '../utils/logger.js';
 import { ValidationError } from '../errors/ApiError.js';
+
+interface WeatherImageryArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  city_name?: string;
+  type?: ImageryType;
+  animated?: boolean;
+  detail?: DetailLevel;
+}
+
+/**
+ * Tool entry point: resolve the location (coordinates, saved name, or geocoded
+ * city), fetch imagery, and format it. Markdown image embeds are opt-in via
+ * detail="full"; the default surfaces direct URLs and metadata (lighter for
+ * text-only agents).
+ */
+export async function handleGetWeatherImagery(
+  args: unknown,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const typedArgs = (args ?? {}) as WeatherImageryArgs;
+  const resolved = await resolveLocationAsync(typedArgs, locationStore, geocodingService);
+  const detail = validateDetail(typedArgs.detail);
+
+  const result = await getWeatherImagery({
+    latitude: resolved.latitude,
+    longitude: resolved.longitude,
+    type: (typedArgs.type ?? 'precipitation') as ImageryType,
+    animated: typedArgs.animated
+  });
+
+  const formatted = formatWeatherImageryResponse(result, detail);
+
+  return prependLocationLine({
+    content: [
+      {
+        type: 'text',
+        text: formatted
+      }
+    ]
+  }, resolved);
+}
 
 /**
  * Validate imagery request parameters
@@ -97,9 +144,30 @@ export async function getWeatherImagery(params: WeatherImageryParams): Promise<W
 }
 
 /**
- * Format weather imagery response for display
+ * Render a single imagery frame line.
+ * At detail="full" the image is embedded as Markdown so rich clients render it;
+ * otherwise the direct URL is shown as text (cheaper, and usable by text-only
+ * agents that would otherwise carry an un-renderable image tag).
  */
-export function formatWeatherImageryResponse(response: WeatherImageryResponse): string {
+function formatFrameLine(
+  frame: { url: string; description?: string },
+  detail: DetailLevel
+): string {
+  if (detail === 'full') {
+    return `![${frame.description || 'Weather imagery'}](${frame.url})`;
+  }
+  return `**Image URL:** ${frame.url}`;
+}
+
+/**
+ * Format weather imagery response for display
+ * @param response - Imagery result to render
+ * @param detail - Verbosity; "full" embeds Markdown images, otherwise URLs are text
+ */
+export function formatWeatherImageryResponse(
+  response: WeatherImageryResponse,
+  detail: DetailLevel = 'standard'
+): string {
   const lines: string[] = [];
 
   lines.push('# Weather Imagery');
@@ -133,7 +201,7 @@ export function formatWeatherImageryResponse(response: WeatherImageryResponse): 
     framesToShow.forEach((frame) => {
       const frameNumber = response.frames.indexOf(frame) + 1;
       lines.push(`### Frame ${frameNumber} - ${frame.timestamp.toISOString()}`);
-      lines.push(`![${frame.description || 'Weather imagery'}](${frame.url})`);
+      lines.push(formatFrameLine(frame, detail));
       lines.push('');
     });
 
@@ -146,7 +214,7 @@ export function formatWeatherImageryResponse(response: WeatherImageryResponse): 
     lines.push('');
     const frame = response.frames[0];
     lines.push(`**Timestamp:** ${frame.timestamp.toISOString()}`);
-    lines.push(`![${frame.description || 'Weather imagery'}](${frame.url})`);
+    lines.push(formatFrameLine(frame, detail));
     lines.push('');
   } else {
     lines.push('## ⚠️ No Imagery Available');

--- a/src/handlers/weatherSummaryHandler.ts
+++ b/src/handlers/weatherSummaryHandler.ts
@@ -1,0 +1,169 @@
+/**
+ * Handler for get_weather_summary tool
+ *
+ * A composite tool that answers broad "what's the weather like?" questions in a
+ * single call by aggregating several specialized tools (current conditions,
+ * forecast, alerts, and optionally air quality and lightning) for one location.
+ * Location is resolved once and the resolved coordinates are passed to each
+ * sub-handler so there is no repeated geocoding.
+ */
+
+import { NOAAService } from '../services/noaa.js';
+import { OpenMeteoService } from '../services/openmeteo.js';
+import { NCEIService } from '../services/ncei.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, formatLocationLine } from '../utils/locationResolver.js';
+import { validateDetail, validateForecastDays, DetailLevel } from '../utils/validation.js';
+import { logger } from '../utils/logger.js';
+import { handleGetCurrentConditions } from './currentConditionsHandler.js';
+import { handleGetForecast } from './forecastHandler.js';
+import { handleGetAlerts } from './alertsHandler.js';
+import { handleGetAirQuality } from './airQualityHandler.js';
+import { handleGetLightningActivity } from './lightningHandler.js';
+
+/**
+ * Sections that can be included in a weather summary.
+ */
+export type SummarySection = 'current' | 'forecast' | 'alerts' | 'air_quality' | 'lightning';
+
+const VALID_SECTIONS: SummarySection[] = ['current', 'forecast', 'alerts', 'air_quality', 'lightning'];
+const DEFAULT_SECTIONS: SummarySection[] = ['current', 'forecast', 'alerts'];
+
+interface WeatherSummaryArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  city_name?: string;
+  include?: unknown;
+  detail?: DetailLevel;
+  days?: number;
+}
+
+/**
+ * Validate and normalize the `include` array.
+ * Defaults to current + forecast + alerts; unknown entries are rejected.
+ */
+function validateInclude(value: unknown): SummarySection[] {
+  if (value === undefined) {
+    return DEFAULT_SECTIONS;
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error('include must be an array of section names');
+  }
+
+  const sections: SummarySection[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || !VALID_SECTIONS.includes(entry as SummarySection)) {
+      throw new Error(
+        `Invalid include entry "${entry}". Valid sections: ${VALID_SECTIONS.join(', ')}.`
+      );
+    }
+    if (!sections.includes(entry as SummarySection)) {
+      sections.push(entry as SummarySection);
+    }
+  }
+
+  // Empty array falls back to the default set rather than producing an empty report
+  return sections.length > 0 ? sections : DEFAULT_SECTIONS;
+}
+
+/**
+ * Extract the text payload from a sub-handler result.
+ */
+function textOf(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content
+    .filter(block => block.type === 'text')
+    .map(block => block.text)
+    .join('\n');
+}
+
+export async function handleGetWeatherSummary(
+  args: unknown,
+  noaaService: NOAAService,
+  openMeteoService: OpenMeteoService,
+  nceiService: NCEIService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const typedArgs = (args ?? {}) as WeatherSummaryArgs;
+
+  // Resolve location once; sub-handlers receive the resolved coordinates so they
+  // never re-geocode (coordinates take precedence in resolveLocationAsync).
+  const resolved = await resolveLocationAsync(typedArgs, locationStore, geocodingService);
+  const include = validateInclude(typedArgs.include);
+  const detail = validateDetail(typedArgs.detail, 'summary');
+  const days = validateForecastDays(typedArgs);
+
+  // Shared args for every sub-handler: resolved coordinates plus pass-through of
+  // unit preferences and detail. Coordinates override any name so no geocoding.
+  const subArgs = {
+    ...(typeof args === 'object' && args !== null ? args : {}),
+    latitude: resolved.latitude,
+    longitude: resolved.longitude,
+    location_name: undefined,
+    city_name: undefined,
+    detail
+  };
+
+  let body = `# Weather Summary\n\n`;
+  const locationLine = formatLocationLine(resolved);
+  if (locationLine) {
+    body += locationLine;
+  } else {
+    body += `**Location:** ${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}\n\n`;
+  }
+  body += `**Includes:** ${include.join(', ')}\n\n`;
+  body += `---\n\n`;
+
+  // Run each requested section. A section failure (e.g. alerts outside the US)
+  // degrades to a note instead of failing the whole summary.
+  for (const section of include) {
+    try {
+      let sectionResult: { content: Array<{ type: string; text: string }> };
+      switch (section) {
+        case 'current':
+          sectionResult = await handleGetCurrentConditions(
+            subArgs, noaaService, openMeteoService, nceiService, locationStore, geocodingService
+          );
+          break;
+        case 'forecast':
+          sectionResult = await handleGetForecast(
+            { ...subArgs, days }, noaaService, openMeteoService, locationStore, geocodingService, nceiService
+          );
+          break;
+        case 'alerts':
+          sectionResult = await handleGetAlerts(subArgs, noaaService, locationStore, geocodingService);
+          break;
+        case 'air_quality':
+          sectionResult = await handleGetAirQuality(subArgs, openMeteoService, locationStore, geocodingService);
+          break;
+        case 'lightning':
+          sectionResult = await handleGetLightningActivity(subArgs, locationStore, geocodingService);
+          break;
+        default:
+          continue;
+      }
+      body += textOf(sectionResult).trim();
+      body += `\n\n---\n\n`;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn('Weather summary section failed', { section, error: message });
+      body += `## ${section} (unavailable)\n\n`;
+      body += `⚠️ Could not retrieve ${section} data for this location: ${message}\n\n`;
+      body += `---\n\n`;
+    }
+  }
+
+  body += `*Composite summary. Use the individual tools (get_forecast, get_current_conditions, get_alerts, ...) for deeper detail.*\n`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: body
+      }
+    ]
+  };
+}

--- a/src/handlers/wildfireHandler.ts
+++ b/src/handlers/wildfireHandler.ts
@@ -3,7 +3,9 @@
  */
 
 import { NIFCService } from '../services/nifc.js';
-import { validateCoordinates } from '../utils/validation.js';
+import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
+import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { guessTimezoneFromCoords } from '../utils/timezone.js';
 import { calculateDistance } from '../utils/distance.js';
 import type { WildfireInfo } from '../types/wildfire.js';
@@ -11,15 +13,20 @@ import type { WildfireInfo } from '../types/wildfire.js';
 interface WildfireArgs {
   latitude?: number;
   longitude?: number;
+  location_name?: string;
+  city_name?: string;
   radius?: number; // search radius in km (default: 100)
 }
 
 export async function handleGetWildfireInfo(
   args: unknown,
-  nifcService: NIFCService
+  nifcService: NIFCService,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
-  // Validate input parameters with runtime checks
-  const { latitude, longitude } = validateCoordinates(args);
+  // Resolve location from coordinates, a saved location name, or a geocoded city name
+  const resolved = await resolveLocationAsync(args as WildfireArgs, locationStore, geocodingService);
+  const { latitude, longitude } = resolved;
 
   // Validate radius parameter
   let radius = (args as WildfireArgs)?.radius ?? 100; // default 100 km
@@ -172,14 +179,14 @@ export async function handleGetWildfireInfo(
   output += `*Wildfire data is updated throughout the day. Always consult official sources for evacuation orders and emergency information.*\n`;
   output += `*For active incidents and evacuation orders, visit: https://inciweb.nwcg.gov/*\n`;
 
-  return {
+  return prependLocationLine({
     content: [
       {
         type: 'text',
         text: output
       }
     ]
-  };
+  }, resolved);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,10 +33,11 @@ import { handleCheckServiceStatus } from './handlers/statusHandler.js';
 import { handleSearchLocation } from './handlers/locationHandler.js';
 import { handleGetAirQuality } from './handlers/airQualityHandler.js';
 import { handleGetMarineConditions } from './handlers/marineConditionsHandler.js';
-import { getWeatherImagery, formatWeatherImageryResponse } from './handlers/weatherImageryHandler.js';
-import { getLightningActivity, formatLightningActivityResponse } from './handlers/lightningHandler.js';
+import { handleGetWeatherImagery } from './handlers/weatherImageryHandler.js';
+import { handleGetLightningActivity } from './handlers/lightningHandler.js';
 import { handleGetRiverConditions } from './handlers/riverConditionsHandler.js';
 import { handleGetWildfireInfo } from './handlers/wildfireHandler.js';
+import { handleGetWeatherSummary } from './handlers/weatherSummaryHandler.js';
 import {
   handleSaveLocation,
   handleListSavedLocations,
@@ -198,6 +199,47 @@ const UNIT_SCHEMA_PROPERTIES = {
 };
 
 /**
+ * Shared location parameters. Spread into every location-based weather tool so
+ * the AI can provide a location in ONE of three consistent ways: coordinates,
+ * a saved location name, or a free-text city name (geocoded on demand). Tools
+ * using this fragment must declare `required: []` — resolveLocationAsync enforces
+ * that at least one usable form is present at call time.
+ */
+const LOCATION_SCHEMA_PROPERTIES = {
+  latitude: {
+    type: 'number' as const,
+    description: 'Latitude of the location (-90 to 90). Not required if location_name or city_name is provided.',
+    minimum: -90,
+    maximum: 90
+  },
+  longitude: {
+    type: 'number' as const,
+    description: 'Longitude of the location (-180 to 180). Not required if location_name or city_name is provided.',
+    minimum: -180,
+    maximum: 180
+  },
+  location_name: {
+    type: 'string' as const,
+    description: 'Name of a saved location (e.g., "home", "cabin"). Use instead of coordinates to reference a saved location. List them with list_saved_locations.'
+  },
+  city_name: {
+    type: 'string' as const,
+    description: 'Free-text place name to geocode (e.g., "Paris, France", "Bend, Oregon"). Use instead of coordinates when you only have a place name and it is not a saved location. Include state/country for disambiguation when possible.'
+  }
+};
+
+/**
+ * Shared output-verbosity parameter for high-volume tools.
+ */
+const DETAIL_SCHEMA_PROPERTY = {
+  detail: {
+    type: 'string' as const,
+    description: 'Output verbosity: "summary" (shortest), "standard" (default, balanced), or "full" (everything the source provides, e.g. full alert descriptions, uncapped hourly forecast, embedded imagery).',
+    enum: ['summary', 'standard', 'full']
+  }
+};
+
+/**
  * Tool definitions - each tool defined separately for conditional registration
  */
 const TOOL_DEFINITIONS = {
@@ -207,26 +249,7 @@ const TOOL_DEFINITIONS = {
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90). Not required if location_name is provided.',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180). Not required if location_name is provided.',
-          minimum: -180,
-          maximum: 180
-        },
-        location_name: {
-          type: 'string' as const,
-          description: 'Name of a saved location (e.g., "home", "cabin"). Use this instead of latitude/longitude to reference a saved location. List saved locations with list_saved_locations.'
-        },
-        city_name: {
-          type: 'string' as const,
-          description: 'Free-text place name to geocode (e.g., "Paris, France", "Bend, Oregon"). Use this instead of latitude/longitude when you only have a place name and it is not a saved location. Include state/country for disambiguation when possible.'
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         days: {
           type: 'number' as const,
           description: 'Number of days to include in forecast (1-16 for global, 1-7 for US NOAA, default: 7)',
@@ -261,6 +284,7 @@ const TOOL_DEFINITIONS = {
           enum: ['auto', 'noaa', 'openmeteo'],
           default: 'auto'
         },
+        ...DETAIL_SCHEMA_PROPERTY,
         ...UNIT_SCHEMA_PROPERTIES
       },
       required: []
@@ -269,22 +293,11 @@ const TOOL_DEFINITIONS = {
 
   get_current_conditions: {
     name: 'get_current_conditions' as const,
-    description: 'Get the most recent weather observation for a location (US only). Use this for current weather or when asking about "today\'s weather", "right now", or recent conditions without a specific historical date range. Returns the latest observation from the nearest weather station. Optionally includes fire weather indices (Haines Index, Grassland Fire Danger, Red Flag Threat) when requested. For specific past dates or date ranges, use get_historical_weather instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
+    description: 'Get the most recent weather observation for a location (US only). Use this for current weather or when asking about "today\'s weather", "right now", or recent conditions without a specific historical date range. Returns the latest observation from the nearest weather station. Optionally includes fire weather indices (Haines Index, Grassland Fire Danger, Red Flag Threat) when requested. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For specific past dates or date ranges, use get_historical_weather instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         include_fire_weather: {
           type: 'boolean' as const,
           description: 'Include fire weather indices (Haines Index, Grassland Fire Danger, Red Flag Threat) in the response (default: false, US only)',
@@ -297,56 +310,35 @@ const TOOL_DEFINITIONS = {
         },
         ...UNIT_SCHEMA_PROPERTIES
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_alerts: {
     name: 'get_alerts' as const,
-    description: 'Get active weather alerts, watches, warnings, and advisories for a location (US only). Use this for safety-critical weather information when asked about "any alerts?", "weather warnings?", "is it safe?", "dangerous weather?", or "weather watches?". Returns severity, urgency, certainty, effective/expiration times, and affected areas. For forecast data, use get_forecast instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
+    description: 'Get active weather alerts, watches, warnings, and advisories for a location (US only). Use this for safety-critical weather information when asked about "any alerts?", "weather warnings?", "is it safe?", "dangerous weather?", or "weather watches?". Returns severity, urgency, certainty, effective/expiration times, and affected areas. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For forecast data, use get_forecast instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         active_only: {
           type: 'boolean' as const,
           description: 'Whether to show only active alerts (default: true)',
           default: true
-        }
+        },
+        ...DETAIL_SCHEMA_PROPERTY
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_historical_weather: {
     name: 'get_historical_weather' as const,
-    description: 'Get historical weather data for a specific date range in the past. Use this when the user asks about weather on specific past dates (e.g., "yesterday", "last week", "November 4, 2024", "30 years ago"). Automatically uses NOAA API for recent dates (last 7 days, US only) or Open-Meteo API for older dates (worldwide, back to 1940). Do NOT use for current conditions - use get_current_conditions instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
+    description: 'Get historical weather data for a specific date range in the past. Use this when the user asks about weather on specific past dates (e.g., "yesterday", "last week", "November 4, 2024", "30 years ago"). Automatically uses NOAA API for recent dates (last 7 days, US only) or Open-Meteo API for older dates (worldwide, back to 1940). Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. Do NOT use for current conditions - use get_current_conditions instead. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         start_date: {
           type: 'string' as const,
           description: 'Start date in ISO format (YYYY-MM-DD or ISO 8601 datetime)',
@@ -364,7 +356,36 @@ const TOOL_DEFINITIONS = {
         },
         ...UNIT_SCHEMA_PROPERTIES
       },
-      required: ['latitude', 'longitude', 'start_date', 'end_date']
+      required: ['start_date', 'end_date']
+    }
+  },
+
+  get_weather_summary: {
+    name: 'get_weather_summary' as const,
+    description: 'Get a combined weather overview for a location in a SINGLE call. Best for broad questions like "What\'s the weather like in Seattle?", "Is it safe to hike today?", or "Give me a weather rundown". Aggregates current conditions, forecast, and active alerts by default, and can also include air quality and lightning. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For a single specific data product (just the forecast, just alerts, etc.), call that specialized tool directly. Sections that are unavailable for a location (e.g. US-only alerts abroad) are noted rather than failing the whole summary.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        ...LOCATION_SCHEMA_PROPERTIES,
+        include: {
+          type: 'array' as const,
+          description: 'Which sections to include (default: ["current", "forecast", "alerts"]). Add "air_quality" and/or "lightning" for a fuller picture.',
+          items: {
+            type: 'string' as const,
+            enum: ['current', 'forecast', 'alerts', 'air_quality', 'lightning']
+          }
+        },
+        days: {
+          type: 'number' as const,
+          description: 'Number of forecast days to include when the forecast section is requested (1-16, default: 7)',
+          minimum: 1,
+          maximum: 16,
+          default: 7
+        },
+        ...DETAIL_SCHEMA_PROPERTY,
+        ...UNIT_SCHEMA_PROPERTIES
+      },
+      required: []
     }
   },
 
@@ -402,78 +423,45 @@ const TOOL_DEFINITIONS = {
 
   get_air_quality: {
     name: 'get_air_quality' as const,
-    description: 'Get air quality data including AQI (Air Quality Index), pollutant concentrations, and UV index for a location (global coverage). Use this when asked about "air quality", "pollution", "AQI", "UV index", "safe to exercise outside", or health-related environmental conditions. Returns current conditions and optional hourly forecast. Shows appropriate AQI scale (US AQI for US locations, European EAQI elsewhere) with health recommendations. Pollutants include PM2.5, PM10, ozone, NO2, SO2, and CO.',
+    description: 'Get air quality data including AQI (Air Quality Index), pollutant concentrations, and UV index for a location (global coverage). Use this when asked about "air quality", "pollution", "AQI", "UV index", "safe to exercise outside", or health-related environmental conditions. Returns current conditions and optional hourly forecast. Shows appropriate AQI scale (US AQI for US locations, European EAQI elsewhere) with health recommendations. Pollutants include PM2.5, PM10, ozone, NO2, SO2, and CO. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         forecast: {
           type: 'boolean' as const,
           description: 'Include hourly air quality forecast for next 5 days (default: false, shows current only)',
           default: false
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_marine_conditions: {
     name: 'get_marine_conditions' as const,
-    description: 'Get marine conditions including wave height, swell, ocean currents, and sea state for a location (global coverage). Use this when asked about "ocean conditions", "wave height", "surf conditions", "safe to boat", "marine forecast", "swell", or "sea state". Returns current conditions and optional daily/hourly forecast. Includes significant wave height, wind waves, swell, wave period, and ocean currents. Shows safety assessment for maritime activities. NOTE: Data has limited accuracy in coastal areas and is NOT suitable for coastal navigation - always consult official marine forecasts.',
+    description: 'Get marine conditions including wave height, swell, ocean currents, and sea state for a location (global coverage). Use this when asked about "ocean conditions", "wave height", "surf conditions", "safe to boat", "marine forecast", "swell", or "sea state". Returns current conditions and optional daily/hourly forecast. Includes significant wave height, wind waves, swell, wave period, and ocean currents. Shows safety assessment for maritime activities. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. NOTE: Data has limited accuracy in coastal areas and is NOT suitable for coastal navigation - always consult official marine forecasts.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         forecast: {
           type: 'boolean' as const,
           description: 'Include marine forecast for next 5 days (default: false, shows current only)',
           default: false
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_weather_imagery: {
     name: 'get_weather_imagery' as const,
-    description: 'Get weather imagery including radar, satellite, and precipitation maps for a location. Use this when asked about "show radar", "satellite image", "precipitation map", "weather map", "animated radar", or "what does radar show". Returns image URLs with timestamps for current or animated weather visualization. Precipitation/radar is global via RainViewer; satellite is GOES GeoColor (Western Hemisphere) via NASA GIBS. Includes disclaimer about data delays and official forecast consultation. For numerical forecast data, use get_forecast instead.',
+    description: 'Get weather imagery including radar, satellite, and precipitation maps for a location. Use this when asked about "show radar", "satellite image", "precipitation map", "weather map", "animated radar", or "what does radar show". Returns image URLs with timestamps for current or animated weather visualization. Precipitation/radar is global via RainViewer; satellite is GOES GeoColor (Western Hemisphere) via NASA GIBS. By default returns direct image URLs; use detail="full" to embed Markdown images. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. For numerical forecast data, use get_forecast instead.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         type: {
           type: 'string' as const,
           description: 'Type of imagery: "radar" or "precipitation" (global, RainViewer) or "satellite" (Western Hemisphere GOES GeoColor, NASA GIBS). Default: "precipitation"',
@@ -484,30 +472,20 @@ const TOOL_DEFINITIONS = {
           type: 'boolean' as const,
           description: 'Return animated frames showing progression over time (default: false)',
           default: false
-        }
+        },
+        ...DETAIL_SCHEMA_PROPERTY
       },
-      required: ['latitude', 'longitude', 'type']
+      required: ['type']
     }
   },
 
   get_lightning_activity: {
     name: 'get_lightning_activity' as const,
-    description: 'Get real-time lightning strike activity and safety assessment for a location (global coverage). Use this when asked about "lightning nearby", "lightning strikes", "thunderstorm activity", "is it safe from lightning", or "lightning danger". Returns recent strikes within specified radius and time window, including distance, polarity, intensity, and critical safety recommendations. Provides 4-level safety assessment (safe/elevated/high/extreme) based on proximity. SAFETY-CRITICAL tool for outdoor activities and severe weather monitoring.',
+    description: 'Get real-time lightning strike activity and safety assessment for a location (global coverage). Use this when asked about "lightning nearby", "lightning strikes", "thunderstorm activity", "is it safe from lightning", or "lightning danger". Returns recent strikes within specified radius and time window, including distance, polarity, intensity, and critical safety recommendations. Provides 4-level safety assessment (safe/elevated/high/extreme) based on proximity. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. SAFETY-CRITICAL tool for outdoor activities and severe weather monitoring.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         radius: {
           type: 'number' as const,
           description: 'Search radius in kilometers (1-500, default: 100)',
@@ -523,28 +501,17 @@ const TOOL_DEFINITIONS = {
           default: 60
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_river_conditions: {
     name: 'get_river_conditions' as const,
-    description: 'Monitor river levels and flood status for a location (US only). Use this when asked about "river flooding", "river level", "flood stage", "streamflow", "safe to kayak", or "river conditions". Returns current river gauge data within specified radius including river stage, flow rate, flood category levels (action/minor/moderate/major), and forecasted conditions. Provides safety assessment based on flood stages. SAFETY-CRITICAL tool for flood-prone areas and water recreation.',
+    description: 'Monitor river levels and flood status for a location (US only). Use this when asked about "river flooding", "river level", "flood stage", "streamflow", "safe to kayak", or "river conditions". Returns current river gauge data within specified radius including river stage, flow rate, flood category levels (action/minor/moderate/major), and forecasted conditions. Provides safety assessment based on flood stages. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. SAFETY-CRITICAL tool for flood-prone areas and water recreation.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         radius: {
           type: 'number' as const,
           description: 'Search radius in kilometers (1-500, default: 50)',
@@ -553,28 +520,17 @@ const TOOL_DEFINITIONS = {
           default: 50
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
   get_wildfire_info: {
     name: 'get_wildfire_info' as const,
-    description: 'Monitor active wildfires and fire perimeters for a location (US focus). Use this when asked about "wildfires nearby", "fire danger", "active fires", "wildfire smoke", "fire perimeters", or "evacuation risk". Returns active wildfire information within specified radius including fire name, size, containment percentage, distance from location, and safety assessment. Provides critical evacuation awareness and air quality impact information. SAFETY-CRITICAL tool for wildfire-prone areas.',
+    description: 'Monitor active wildfires and fire perimeters for a location (US focus). Use this when asked about "wildfires nearby", "fire danger", "active fires", "wildfire smoke", "fire perimeters", or "evacuation risk". Returns active wildfire information within specified radius including fire name, size, containment percentage, distance from location, and safety assessment. Provides critical evacuation awareness and air quality impact information. Provide the location as coordinates (latitude+longitude), a saved location_name, or a free-text city_name. SAFETY-CRITICAL tool for wildfire-prone areas.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        latitude: {
-          type: 'number' as const,
-          description: 'Latitude of the location (-90 to 90)',
-          minimum: -90,
-          maximum: 90
-        },
-        longitude: {
-          type: 'number' as const,
-          description: 'Longitude of the location (-180 to 180)',
-          minimum: -180,
-          maximum: 180
-        },
+        ...LOCATION_SCHEMA_PROPERTIES,
         radius: {
           type: 'number' as const,
           description: 'Search radius in kilometers (1-500, default: 100)',
@@ -583,7 +539,7 @@ const TOOL_DEFINITIONS = {
           default: 100
         }
       },
-      required: ['latitude', 'longitude']
+      required: []
     }
   },
 
@@ -720,17 +676,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'get_current_conditions':
         return await withAnalytics('get_current_conditions', async () =>
-          handleGetCurrentConditions(args, noaaService, openMeteoService, nceiService)
+          handleGetCurrentConditions(args, noaaService, openMeteoService, nceiService, locationStore, geocodingService)
         );
 
       case 'get_alerts':
         return await withAnalytics('get_alerts', async () =>
-          handleGetAlerts(args, noaaService)
+          handleGetAlerts(args, noaaService, locationStore, geocodingService)
         );
 
       case 'get_historical_weather':
         return await withAnalytics('get_historical_weather', async () =>
-          handleGetHistoricalWeather(args, noaaService, openMeteoService)
+          handleGetHistoricalWeather(args, noaaService, openMeteoService, locationStore, geocodingService)
+        );
+
+      case 'get_weather_summary':
+        return await withAnalytics('get_weather_summary', async () =>
+          handleGetWeatherSummary(args, noaaService, openMeteoService, nceiService, locationStore, geocodingService)
         );
 
       case 'check_service_status':
@@ -745,50 +706,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'get_air_quality':
         return await withAnalytics('get_air_quality', async () =>
-          handleGetAirQuality(args, openMeteoService)
+          handleGetAirQuality(args, openMeteoService, locationStore, geocodingService)
         );
 
       case 'get_marine_conditions':
         return await withAnalytics('get_marine_conditions', async () =>
-          handleGetMarineConditions(args, noaaService, openMeteoService)
+          handleGetMarineConditions(args, noaaService, openMeteoService, locationStore, geocodingService)
         );
 
       case 'get_weather_imagery':
-        return await withAnalytics('get_weather_imagery', async () => {
-          const result = await getWeatherImagery(args as any);
-          const formatted = formatWeatherImageryResponse(result);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: formatted
-              }
-            ]
-          };
-        });
+        return await withAnalytics('get_weather_imagery', async () =>
+          handleGetWeatherImagery(args, locationStore, geocodingService)
+        );
 
       case 'get_lightning_activity':
-        return await withAnalytics('get_lightning_activity', async () => {
-          const result = await getLightningActivity(args as any);
-          const formatted = formatLightningActivityResponse(result);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: formatted
-              }
-            ]
-          };
-        });
+        return await withAnalytics('get_lightning_activity', async () =>
+          handleGetLightningActivity(args, locationStore, geocodingService)
+        );
 
       case 'get_river_conditions':
         return await withAnalytics('get_river_conditions', async () =>
-          handleGetRiverConditions(args, noaaService)
+          handleGetRiverConditions(args, noaaService, locationStore, geocodingService)
         );
 
       case 'get_wildfire_info':
         return await withAnalytics('get_wildfire_info', async () =>
-          handleGetWildfireInfo(args, nifcService)
+          handleGetWildfireInfo(args, nifcService, locationStore, geocodingService)
         );
 
       case 'save_location':

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,49 @@ const server = new Server(
 );
 
 /**
+ * Shared unit / localization parameters. Spread into weather tools so the AI can
+ * request output units per call. Omitting them falls back to the server default
+ * (WEATHER_UNITS env, default imperial).
+ */
+const UNIT_SCHEMA_PROPERTIES = {
+  units: {
+    type: 'string' as const,
+    description: 'Unit system for output: "imperial" (°F, mph, inHg) or "metric" (°C, km/h, hPa). Defaults to the server setting (imperial unless configured otherwise). Individual *_unit overrides below take precedence.',
+    enum: ['imperial', 'metric']
+  },
+  temperature_unit: {
+    type: 'string' as const,
+    description: 'Override temperature unit: "F" or "C".',
+    enum: ['F', 'C']
+  },
+  wind_speed_unit: {
+    type: 'string' as const,
+    description: 'Override wind speed unit: "mph", "kmh", "ms", or "kn" (knots).',
+    enum: ['mph', 'kmh', 'ms', 'kn']
+  },
+  precipitation_unit: {
+    type: 'string' as const,
+    description: 'Override precipitation unit: "inch" or "mm".',
+    enum: ['inch', 'mm']
+  },
+  pressure_unit: {
+    type: 'string' as const,
+    description: 'Override pressure unit: "inHg" or "hPa".',
+    enum: ['inHg', 'hPa']
+  },
+  distance_unit: {
+    type: 'string' as const,
+    description: 'Override distance/visibility/elevation unit: "mi" or "km".',
+    enum: ['mi', 'km']
+  },
+  time_format: {
+    type: 'string' as const,
+    description: 'Clock format for times: "12h" or "24h".',
+    enum: ['12h', '24h']
+  }
+};
+
+/**
  * Tool definitions - each tool defined separately for conditional registration
  */
 const TOOL_DEFINITIONS = {
@@ -213,7 +256,8 @@ const TOOL_DEFINITIONS = {
           description: 'Data source: "auto" (default, selects NOAA for US or Open-Meteo for international), "noaa" (US only), or "openmeteo" (global)',
           enum: ['auto', 'noaa', 'openmeteo'],
           default: 'auto'
-        }
+        },
+        ...UNIT_SCHEMA_PROPERTIES
       },
       required: []
     }
@@ -246,7 +290,8 @@ const TOOL_DEFINITIONS = {
           type: 'boolean' as const,
           description: 'Include climate normals (30-year averages) for comparison with current conditions (default: false). Shows normal high/low temperatures and precipitation, with departure from normal.',
           default: false
-        }
+        },
+        ...UNIT_SCHEMA_PROPERTIES
       },
       required: ['latitude', 'longitude']
     }
@@ -312,7 +357,8 @@ const TOOL_DEFINITIONS = {
           minimum: 1,
           maximum: 500,
           default: 168
-        }
+        },
+        ...UNIT_SCHEMA_PROPERTIES
       },
       required: ['latitude', 'longitude', 'start_date', 'end_date']
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ function redactSensitiveFields(args: unknown): unknown {
   const redacted: Record<string, unknown> = {};
   const sensitiveFields = [
     'latitude', 'longitude', 'lat', 'lon',
-    'location', 'city', 'state', 'address', 'query',
+    'location', 'city', 'city_name', 'state', 'address', 'query',
     'zipcode', 'postalCode', 'place', 'coordinates'
   ];
 
@@ -160,7 +160,7 @@ const server = new Server(
 const TOOL_DEFINITIONS = {
   get_forecast: {
     name: 'get_forecast' as const,
-    description: 'Get future weather forecast for a location (global coverage). Use this for upcoming weather predictions (e.g., "tomorrow", "this week", "next 7 days", "hourly forecast"). Returns forecast data including temperature, precipitation, wind, conditions, and sunrise/sunset times. Supports both daily and hourly granularity. Automatically selects best data source: NOAA for US locations (more detailed), Open-Meteo for international locations. For current weather, use get_current_conditions. For past weather, use get_historical_weather. Can use either coordinates OR a saved location name (e.g., location_name="home"). If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
+    description: 'Get future weather forecast for a location (global coverage). Use this for upcoming weather predictions (e.g., "tomorrow", "this week", "next 7 days", "hourly forecast"). Returns forecast data including temperature, precipitation, wind, conditions, and sunrise/sunset times. Supports both daily and hourly granularity. Automatically selects best data source: NOAA for US locations (more detailed), Open-Meteo for international locations. For current weather, use get_current_conditions. For past weather, use get_historical_weather. Provide the location in ONE of three ways: coordinates (latitude+longitude), a saved location name (location_name="home"), or a free-text city name (city_name="Paris, France") which is geocoded automatically. If this tool returns an error, check the error message for status page links and consider using check_service_status to verify API availability.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -179,6 +179,10 @@ const TOOL_DEFINITIONS = {
         location_name: {
           type: 'string' as const,
           description: 'Name of a saved location (e.g., "home", "cabin"). Use this instead of latitude/longitude to reference a saved location. List saved locations with list_saved_locations.'
+        },
+        city_name: {
+          type: 'string' as const,
+          description: 'Free-text place name to geocode (e.g., "Paris, France", "Bend, Oregon"). Use this instead of latitude/longitude when you only have a place name and it is not a saved location. Include state/country for disambiguation when possible.'
         },
         days: {
           type: 'number' as const,
@@ -665,7 +669,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     switch (name) {
       case 'get_forecast':
         return await withAnalytics('get_forecast', async () =>
-          handleGetForecast(args, noaaService, openMeteoService, locationStore, nceiService)
+          handleGetForecast(args, noaaService, openMeteoService, locationStore, geocodingService, nceiService)
         );
 
       case 'get_current_conditions':

--- a/src/services/blitzortung.ts
+++ b/src/services/blitzortung.ts
@@ -74,6 +74,10 @@ export class BlitzortungService {
 
   // Subscription management with LRU tracking
   private subscribedGeohashes: Map<string, number> = new Map(); // geohash -> last access timestamp
+  // Strikes only accumulate for a geohash while it is subscribed, so a query's real
+  // monitoring coverage starts at the newest first-subscription among its geohashes —
+  // not at the requested time window. Tracked so results can disclose limited coverage.
+  private geohashFirstSubscribed: Map<string, number> = new Map(); // geohash -> first subscribed timestamp
   private readonly maxSubscriptions = 50; // Limit concurrent subscriptions to prevent unbounded growth
   private isConnecting = false;
   private isConnected = false;
@@ -299,6 +303,7 @@ export class BlitzortungService {
         const geohashPath = geohash.split('').join('/');
         const topic = `${this.topicPrefix}/${geohashPath}/#`;
         subscriptions.push(topic);
+        this.geohashFirstSubscribed.set(geohash, now);
       }
       // Update access time for all geohashes in this request (LRU tracking)
       this.subscribedGeohashes.set(geohash, now);
@@ -371,6 +376,7 @@ export class BlitzortungService {
     // Remove from tracking map
     for (const [geohash] of toEvict) {
       this.subscribedGeohashes.delete(geohash);
+      this.geohashFirstSubscribed.delete(geohash);
     }
 
     logger.debug('Eviction complete', {
@@ -424,6 +430,7 @@ export class BlitzortungService {
         // Remove from tracking
         for (const geohash of staleGeohashes) {
           this.subscribedGeohashes.delete(geohash);
+          this.geohashFirstSubscribed.delete(geohash);
         }
 
         logger.debug('Pruning complete', {
@@ -479,6 +486,33 @@ export class BlitzortungService {
       // Return empty array on error to allow graceful degradation
       return [];
     }
+  }
+
+  /**
+   * Get the moment from which the entire queried area has been continuously
+   * monitored, or null if any part of it is not currently subscribed (or the
+   * broker is disconnected). Callers use this to detect that a "0 strikes"
+   * result covers less than the requested time window.
+   */
+  getCoverageStart(latitude: number, longitude: number, radiusKm: number): Date | null {
+    if (!this.isConnected) {
+      return null;
+    }
+
+    const geohashes = calculateGeohashSubscriptions(latitude, longitude, radiusKm);
+    let coverageStart = 0;
+
+    for (const geohash of geohashes) {
+      const firstSubscribed = this.geohashFirstSubscribed.get(geohash);
+      if (firstSubscribed === undefined) {
+        return null;
+      }
+      if (firstSubscribed > coverageStart) {
+        coverageStart = firstSubscribed;
+      }
+    }
+
+    return coverageStart > 0 ? new Date(coverageStart) : null;
   }
 
   /**
@@ -570,6 +604,7 @@ export class BlitzortungService {
         this.client!.end(false, {}, () => {
           this.isConnected = false;
           this.subscribedGeohashes.clear();
+          this.geohashFirstSubscribed.clear();
           logger.info('Disconnected from Blitzortung MQTT broker');
           resolve();
         });

--- a/src/services/noaa.ts
+++ b/src/services/noaa.ts
@@ -308,16 +308,17 @@ export class NOAAService {
   /**
    * Get forecast for a location using grid coordinates
    */
-  async getForecast(office: string, gridX: number, gridY: number): Promise<ForecastResponse> {
-    // Check cache first (if enabled)
+  async getForecast(office: string, gridX: number, gridY: number, units: 'us' | 'si' = 'us'): Promise<ForecastResponse> {
+    const url = `/gridpoints/${office}/${gridX},${gridY}/forecast?units=${units}`;
+
+    // Check cache first (if enabled; units in the key keeps us/si distinct)
     if (CacheConfig.enabled) {
-      const cacheKey = Cache.generateKey('forecast', office, gridX, gridY);
+      const cacheKey = Cache.generateKey('forecast', office, gridX, gridY, units);
       const cached = this.cache.get(cacheKey);
       if (cached) {
         return cached as ForecastResponse;
       }
 
-      const url = `/gridpoints/${office}/${gridX},${gridY}/forecast`;
       const result = await this.makeRequest<ForecastResponse>(url);
 
       // Cache with forecast TTL (2 hours)
@@ -325,23 +326,23 @@ export class NOAAService {
       return result;
     }
 
-    const url = `/gridpoints/${office}/${gridX},${gridY}/forecast`;
     return this.makeRequest<ForecastResponse>(url);
   }
 
   /**
    * Get hourly forecast for a location using grid coordinates
    */
-  async getHourlyForecast(office: string, gridX: number, gridY: number): Promise<ForecastResponse> {
-    // Check cache first (if enabled)
+  async getHourlyForecast(office: string, gridX: number, gridY: number, units: 'us' | 'si' = 'us'): Promise<ForecastResponse> {
+    const url = `/gridpoints/${office}/${gridX},${gridY}/forecast/hourly?units=${units}`;
+
+    // Check cache first (if enabled; units in the key keeps us/si distinct)
     if (CacheConfig.enabled) {
-      const cacheKey = Cache.generateKey('hourly-forecast', office, gridX, gridY);
+      const cacheKey = Cache.generateKey('hourly-forecast', office, gridX, gridY, units);
       const cached = this.cache.get(cacheKey);
       if (cached) {
         return cached as ForecastResponse;
       }
 
-      const url = `/gridpoints/${office}/${gridX},${gridY}/forecast/hourly`;
       const result = await this.makeRequest<ForecastResponse>(url);
 
       // Cache with forecast TTL (2 hours) - hourly forecasts update at same rate as daily
@@ -349,7 +350,6 @@ export class NOAAService {
       return result;
     }
 
-    const url = `/gridpoints/${office}/${gridX},${gridY}/forecast/hourly`;
     return this.makeRequest<ForecastResponse>(url);
   }
 
@@ -357,20 +357,20 @@ export class NOAAService {
    * Get forecast for a location using lat/lon (convenience method)
    * This combines getPointData and getForecast
    */
-  async getForecastByCoordinates(latitude: number, longitude: number): Promise<ForecastResponse> {
+  async getForecastByCoordinates(latitude: number, longitude: number, units: 'us' | 'si' = 'us'): Promise<ForecastResponse> {
     const pointData = await this.getPointData(latitude, longitude);
     const { gridId, gridX, gridY } = pointData.properties;
-    return this.getForecast(gridId, gridX, gridY);
+    return this.getForecast(gridId, gridX, gridY, units);
   }
 
   /**
    * Get hourly forecast for a location using lat/lon (convenience method)
    * This combines getPointData and getHourlyForecast
    */
-  async getHourlyForecastByCoordinates(latitude: number, longitude: number): Promise<ForecastResponse> {
+  async getHourlyForecastByCoordinates(latitude: number, longitude: number, units: 'us' | 'si' = 'us'): Promise<ForecastResponse> {
     const pointData = await this.getPointData(latitude, longitude);
     const { gridId, gridX, gridY } = pointData.properties;
-    return this.getHourlyForecast(gridId, gridX, gridY);
+    return this.getHourlyForecast(gridId, gridX, gridY, units);
   }
 
   /**

--- a/src/services/openmeteo.ts
+++ b/src/services/openmeteo.ts
@@ -24,6 +24,8 @@ import { validateLatitude, validateLongitude } from '../utils/validation.js';
 import { logger, redactCoordinatesForLogging } from '../utils/logger.js';
 import { computeNormalsFrom30YearData, getNormalsCacheKey } from '../utils/normals.js';
 import { getUserAgent } from '../utils/version.js';
+import { UnitPreferences, IMPERIAL_PREFERENCES } from '../config/units.js';
+import { openMeteoUnitParams } from '../utils/unitFormat.js';
 import {
   RateLimitError,
   ServiceUnavailableError,
@@ -31,6 +33,14 @@ import {
   DataNotFoundError,
   ApiError
 } from '../errors/ApiError.js';
+
+/**
+ * Compact signature of the unit preferences that affect an Open-Meteo request,
+ * used to keep cache entries for different unit systems distinct.
+ */
+function unitSignature(prefs: UnitPreferences): string {
+  return `${prefs.temperature}-${prefs.windSpeed}-${prefs.precipitation}`;
+}
 
 export interface OpenMeteoServiceConfig {
   baseURL?: string;
@@ -353,18 +363,19 @@ export class OpenMeteoService {
     longitude: number,
     startDate: string,
     endDate: string,
-    useHourly: boolean = true
+    useHourly: boolean = true,
+    prefs: UnitPreferences = IMPERIAL_PREFERENCES
   ): Promise<OpenMeteoHistoricalResponse> {
     // Validate coordinates (checks for NaN, Infinity, and range)
     validateLatitude(latitude);
     validateLongitude(longitude);
 
     // Build parameters once
-    const params = this.buildHistoricalParams(latitude, longitude, startDate, endDate, useHourly);
+    const params = this.buildHistoricalParams(latitude, longitude, startDate, endDate, useHourly, prefs);
 
-    // Check cache first (if enabled)
+    // Check cache first (if enabled; unit signature keeps imperial/metric distinct)
     if (CacheConfig.enabled) {
-      const cacheKey = Cache.generateKey('openmeteo-historical', latitude, longitude, startDate, endDate, useHourly);
+      const cacheKey = Cache.generateKey('openmeteo-historical', latitude, longitude, startDate, endDate, useHourly, unitSignature(prefs));
       const cached = this.cache.get(cacheKey);
       if (cached) {
         return cached as OpenMeteoHistoricalResponse;
@@ -395,16 +406,15 @@ export class OpenMeteoService {
     longitude: number,
     startDate: string,
     endDate: string,
-    useHourly: boolean
+    useHourly: boolean,
+    prefs: UnitPreferences = IMPERIAL_PREFERENCES
   ): Record<string, string | number> {
     const params: Record<string, string | number> = {
       latitude,
       longitude,
       start_date: startDate,
       end_date: endDate,
-      temperature_unit: 'fahrenheit',
-      wind_speed_unit: 'mph',
-      precipitation_unit: 'inch',
+      ...openMeteoUnitParams(prefs),
       timezone: 'auto'
     };
 
@@ -599,7 +609,8 @@ export class OpenMeteoService {
     latitude: number,
     longitude: number,
     days: number = 7,
-    hourly: boolean = false
+    hourly: boolean = false,
+    prefs: UnitPreferences = IMPERIAL_PREFERENCES
   ): Promise<OpenMeteoForecastResponse> {
     // Validate coordinates
     validateLatitude(latitude);
@@ -614,11 +625,11 @@ export class OpenMeteoService {
     }
 
     // Build parameters
-    const params = this.buildForecastParams(latitude, longitude, days, hourly);
+    const params = this.buildForecastParams(latitude, longitude, days, hourly, prefs);
 
-    // Check cache first
+    // Check cache first (unit signature keeps imperial/metric responses distinct)
     if (CacheConfig.enabled) {
-      const cacheKey = Cache.generateKey('openmeteo-forecast', latitude, longitude, days, hourly);
+      const cacheKey = Cache.generateKey('openmeteo-forecast', latitude, longitude, days, hourly, unitSignature(prefs));
       const cached = this.cache.get(cacheKey);
       if (cached) {
         return cached as OpenMeteoForecastResponse;
@@ -647,15 +658,14 @@ export class OpenMeteoService {
     latitude: number,
     longitude: number,
     days: number,
-    hourly: boolean
+    hourly: boolean,
+    prefs: UnitPreferences = IMPERIAL_PREFERENCES
   ): Record<string, string | number> {
     const params: Record<string, string | number> = {
       latitude,
       longitude,
       forecast_days: days,
-      temperature_unit: 'fahrenheit',
-      wind_speed_unit: 'mph',
-      precipitation_unit: 'inch',
+      ...openMeteoUnitParams(prefs),
       timezone: 'auto'
     };
 

--- a/src/types/lightning.ts
+++ b/src/types/lightning.ts
@@ -57,6 +57,18 @@ export interface LightningSafetyAssessment {
 }
 
 /**
+ * How much of the requested time window is actually backed by live monitoring.
+ * Strikes are collected into a rolling buffer that only fills while the area's
+ * MQTT subscriptions are active, so a fresh server (or a first query for an
+ * area) may cover far less history than the requested window.
+ */
+export interface LightningMonitoringCoverage {
+  monitoringSince: Date | null; // When live coverage of the queried area began (null = unknown/none)
+  coverageMinutes: number;      // Minutes of the requested window actually monitored
+  isComplete: boolean;          // True when coverage spans the full requested window
+}
+
+/**
  * Lightning activity response
  */
 export interface LightningActivityResponse {
@@ -73,6 +85,7 @@ export interface LightningActivityResponse {
   strikes: LightningStrike[];
   statistics: LightningStatistics;
   safety: LightningSafetyAssessment;
+  coverage: LightningMonitoringCoverage;
   source: string;
   generatedAt: Date;
   disclaimer?: string;

--- a/src/utils/locationResolver.ts
+++ b/src/utils/locationResolver.ts
@@ -3,19 +3,52 @@
  */
 
 import { LocationStore } from '../services/locationStore.js';
+import { GeocodingService } from '../services/geocoding.js';
 import { validateLatitude, validateLongitude } from './validation.js';
+import { Cache } from './cache.js';
+import { CacheConfig } from '../config/cache.js';
 
 export interface LocationInput {
   latitude?: number;
   longitude?: number;
   location_name?: string;
+  city_name?: string;
 }
 
 export interface ResolvedLocation {
   latitude: number;
   longitude: number;
-  source: 'coordinates' | 'saved_location';
+  source: 'coordinates' | 'saved_location' | 'geocoded';
   location_name?: string;
+}
+
+/**
+ * Cached geocode result for a free-text city name.
+ * City coordinates are effectively static, so these are cached with an
+ * Infinity TTL (see CacheConfig.ttl.geocoding).
+ */
+interface CachedCityGeocode {
+  latitude: number;
+  longitude: number;
+  display_name: string;
+}
+
+// Module-level cache for city_name -> coordinates lookups.
+const cityGeocodeCache = new Cache<CachedCityGeocode>(CacheConfig.maxSize);
+
+/**
+ * Build the cache key for a city geocode lookup.
+ */
+function cityGeocodeKey(cityName: string): string {
+  return `city-geocode:${cityName.toLowerCase().trim()}`;
+}
+
+/**
+ * Clear the module-level city geocode cache.
+ * Exposed primarily for tests to guarantee a clean slate.
+ */
+export function clearCityGeocodeCache(): void {
+  cityGeocodeCache.clear();
 }
 
 /**
@@ -99,6 +132,107 @@ export function resolveLocation(
     'Examples:\n' +
     '  - Using coordinates: latitude=47.6062, longitude=-122.3321\n' +
     '  - Using saved location: location_name="home"\n\n' +
+    'Use save_location to save frequently used locations.'
+  );
+}
+
+/**
+ * Resolve location coordinates from direct coordinates, a saved location name,
+ * or a free-text city name that is geocoded on demand.
+ *
+ * Resolution precedence: coordinates > location_name (saved) > city_name (geocoded).
+ * Geocoded city lookups are cached (see cityGeocodeCache) so repeated requests for
+ * the same place do not re-hit the geocoding providers.
+ *
+ * @param args - Arguments containing coordinates, a saved location_name, or a city_name
+ * @param locationStore - Location store instance (for saved locations)
+ * @param geocodingService - Geocoding service (for city_name lookups)
+ * @returns Resolved coordinates and metadata
+ * @throws Error if nothing usable is provided, validation fails, or geocoding finds no match
+ */
+export async function resolveLocationAsync(
+  args: LocationInput,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<ResolvedLocation> {
+  // 1. Explicit coordinates take precedence
+  if (typeof args.latitude === 'number' && typeof args.longitude === 'number') {
+    validateLatitude(args.latitude);
+    validateLongitude(args.longitude);
+
+    return {
+      latitude: args.latitude,
+      longitude: args.longitude,
+      source: 'coordinates'
+    };
+  }
+
+  // 2. Saved location by name (reuse the synchronous resolver's matching logic)
+  if (args.location_name && typeof args.location_name === 'string') {
+    return resolveLocation({ location_name: args.location_name }, locationStore);
+  }
+
+  // 3. Free-text city name -> geocode on demand
+  if (args.city_name && typeof args.city_name === 'string') {
+    const cityName = args.city_name.trim();
+
+    if (cityName.length === 0) {
+      throw new Error('city_name cannot be empty');
+    }
+
+    const cacheKey = cityGeocodeKey(cityName);
+
+    if (CacheConfig.enabled) {
+      const cached = cityGeocodeCache.get(cacheKey);
+      if (cached) {
+        return {
+          latitude: cached.latitude,
+          longitude: cached.longitude,
+          source: 'geocoded',
+          location_name: cached.display_name
+        };
+      }
+    }
+
+    const results = await geocodingService.geocode(cityName, 1);
+
+    if (!results || results.length === 0) {
+      throw new Error(
+        `Could not find a location matching "${cityName}".\n\n` +
+        'Try a more specific name (e.g. "Paris, France" or "Bend, Oregon"), ' +
+        'or use search_location to look up coordinates.'
+      );
+    }
+
+    const best = results[0];
+
+    if (CacheConfig.enabled) {
+      cityGeocodeCache.set(
+        cacheKey,
+        {
+          latitude: best.latitude,
+          longitude: best.longitude,
+          display_name: best.display_name
+        },
+        CacheConfig.ttl.geocoding
+      );
+    }
+
+    return {
+      latitude: best.latitude,
+      longitude: best.longitude,
+      source: 'geocoded',
+      location_name: best.display_name
+    };
+  }
+
+  // Nothing usable provided
+  throw new Error(
+    'Provide one of: coordinates (latitude + longitude), a saved location_name, or a city_name.\n\n' +
+    'Examples:\n' +
+    '  - Using coordinates: latitude=47.6062, longitude=-122.3321\n' +
+    '  - Using saved location: location_name="home"\n' +
+    '  - Using a city name: city_name="Paris, France"\n\n' +
     'Use save_location to save frequently used locations.'
   );
 }

--- a/src/utils/locationResolver.ts
+++ b/src/utils/locationResolver.ts
@@ -23,6 +23,47 @@ export interface ResolvedLocation {
 }
 
 /**
+ * Build a header line describing how a location name was resolved.
+ *
+ * Returns an empty string for direct-coordinate requests (nothing to disclose),
+ * otherwise a Markdown line showing the matched name and coordinates so an
+ * ambiguous saved/geocoded lookup is transparent to the user. Shared across all
+ * weather handlers so location disclosure is consistent.
+ *
+ * @param resolved - Result from resolveLocation/resolveLocationAsync
+ * @returns Markdown line (with trailing blank line) or '' for coordinate input
+ */
+export function formatLocationLine(resolved: ResolvedLocation): string {
+  if (resolved.source === 'coordinates' || !resolved.location_name) {
+    return '';
+  }
+
+  const coords = `${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}`;
+  return `**Location:** ${resolved.location_name} (${coords})\n\n`;
+}
+
+/**
+ * Prepend the resolved-location header to a handler's text content, if any.
+ *
+ * Mutates the first text block of a standard `{ content: [...] }` handler result
+ * so name-based lookups (saved location or geocoded city) surface what matched.
+ * A no-op for direct-coordinate requests.
+ *
+ * @param result - Handler result whose first text block will be prefixed
+ * @param resolved - Result from resolveLocationAsync
+ * @returns The same result object (for convenient chaining)
+ */
+export function prependLocationLine<
+  T extends { content: Array<{ type: string; text: string }> }
+>(result: T, resolved: ResolvedLocation): T {
+  const locationLine = formatLocationLine(resolved);
+  if (locationLine && result.content.length > 0 && result.content[0]?.type === 'text') {
+    result.content[0].text = locationLine + result.content[0].text;
+  }
+  return result;
+}
+
+/**
  * Cached geocode result for a free-text city name.
  * City coordinates are effectively static, so these are cached with an
  * Infinity TTL (see CacheConfig.ttl.geocoding).

--- a/src/utils/normals.ts
+++ b/src/utils/normals.ts
@@ -11,9 +11,25 @@
 
 import type { OpenMeteoHistoricalResponse, ClimateNormals } from '../types/openmeteo.js';
 import { celsiusToFahrenheit } from './units.js';
+import { UnitPreferences, IMPERIAL_PREFERENCES } from '../config/units.js';
+import { temperatureLabel, precipitationLabel } from './unitFormat.js';
 import type { OpenMeteoService } from '../services/openmeteo.js';
 import type { NCEIService } from '../services/ncei.js';
 import { logger } from './logger.js';
+
+/**
+ * Climate normals are stored canonically in imperial units (°F, inches).
+ * These helpers convert them to the caller's preferred units for display.
+ */
+function normalTempToPref(fahrenheit: number, prefs: UnitPreferences): number {
+  return prefs.temperature === 'C' ? Math.round(((fahrenheit - 32) * 5) / 9) : Math.round(fahrenheit);
+}
+
+function normalPrecipToPref(inches: number, prefs: UnitPreferences): number {
+  return prefs.precipitation === 'mm'
+    ? Math.round(inches * 25.4 * 10) / 10
+    : inches;
+}
 
 /**
  * Convert millimeters to inches
@@ -132,17 +148,24 @@ export function calculateDeparture(actual: number, normal: number): string {
  */
 export function formatNormals(
   normals: ClimateNormals,
-  currentTemp?: { high?: number; low?: number }
+  currentTemp?: { high?: number; low?: number },
+  prefs: UnitPreferences = IMPERIAL_PREFERENCES
 ): string {
+  // currentTemp values arrive already in the caller's units; convert the
+  // stored (imperial) normals into the same units for a like-for-like display.
+  const tempU = temperatureLabel(prefs);
+  const normalHigh = normalTempToPref(normals.tempHigh, prefs);
+  const normalLow = normalTempToPref(normals.tempLow, prefs);
+
   let output = `\n## 📊 Climate Context\n\n`;
-  output += `**Normal High:** ${normals.tempHigh}°F\n`;
-  output += `**Normal Low:** ${normals.tempLow}°F\n`;
-  output += `**Normal Precipitation:** ${normals.precipitation}" \n`;
+  output += `**Normal High:** ${normalHigh}${tempU}\n`;
+  output += `**Normal Low:** ${normalLow}${tempU}\n`;
+  output += `**Normal Precipitation:** ${normalPrecipToPref(normals.precipitation, prefs)} ${precipitationLabel(prefs)}\n`;
 
   if (currentTemp) {
     if (currentTemp.high !== undefined) {
-      const departure = calculateDeparture(currentTemp.high, normals.tempHigh);
-      output += `**High Departure:** ${departure}°F`;
+      const departure = calculateDeparture(currentTemp.high, normalHigh);
+      output += `**High Departure:** ${departure}${tempU}`;
       if (departure.startsWith('+')) {
         output += ` (warmer than normal)`;
       } else if (departure.startsWith('-')) {
@@ -152,8 +175,8 @@ export function formatNormals(
     }
 
     if (currentTemp.low !== undefined) {
-      const departure = calculateDeparture(currentTemp.low, normals.tempLow);
-      output += `**Low Departure:** ${departure}°F`;
+      const departure = calculateDeparture(currentTemp.low, normalLow);
+      output += `**Low Departure:** ${departure}${tempU}`;
       if (departure.startsWith('+')) {
         output += ` (warmer than normal)`;
       } else if (departure.startsWith('-')) {

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -20,14 +20,16 @@ export function formatInTimezone(
   format: 'full' | 'long' | 'medium' | 'short' = 'medium'
 ): string {
   try {
-    const dt = DateTime.fromISO(isoString, { setZone: false });
+    // Timezone-naive strings (e.g. Open-Meteo's "2026-07-07T04:32") are already
+    // location-local, so they must be interpreted in the target zone — parsing them
+    // in the server's zone and converting would apply the offset twice. Strings with
+    // an explicit offset keep their instant and are converted for display.
+    const zonedDt = DateTime.fromISO(isoString, { zone: timezone });
 
-    if (!dt.isValid) {
+    if (!zonedDt.isValid) {
       // Fallback to JavaScript Date if Luxon can't parse
       return new Date(isoString).toLocaleString('en-US', { timeZone: timezone });
     }
-
-    const zonedDt = dt.setZone(timezone);
 
     // Format based on requested style
     switch (format) {
@@ -55,13 +57,13 @@ export function formatInTimezone(
  */
 export function formatDateInTimezone(isoString: string, timezone: string): string {
   try {
-    const dt = DateTime.fromISO(isoString, { setZone: false });
+    // See formatInTimezone: naive strings are location-local, parse in target zone
+    const zonedDt = DateTime.fromISO(isoString, { zone: timezone });
 
-    if (!dt.isValid) {
+    if (!zonedDt.isValid) {
       return new Date(isoString).toLocaleDateString('en-US', { timeZone: timezone });
     }
 
-    const zonedDt = dt.setZone(timezone);
     return zonedDt.toLocaleString(DateTime.DATE_MED);
   } catch (error) {
     return new Date(isoString).toLocaleDateString('en-US', { timeZone: timezone });
@@ -76,16 +78,16 @@ export function formatDateInTimezone(isoString: string, timezone: string): strin
  */
 export function formatTimeInTimezone(isoString: string, timezone: string): string {
   try {
-    const dt = DateTime.fromISO(isoString, { setZone: false });
+    // See formatInTimezone: naive strings are location-local, parse in target zone
+    const zonedDt = DateTime.fromISO(isoString, { zone: timezone });
 
-    if (!dt.isValid) {
+    if (!zonedDt.isValid) {
       return new Date(isoString).toLocaleTimeString('en-US', {
         timeZone: timezone,
         timeZoneName: 'short'
       });
     }
 
-    const zonedDt = dt.setZone(timezone);
     return zonedDt.toLocaleString(DateTime.TIME_WITH_SHORT_OFFSET);
   } catch (error) {
     return new Date(isoString).toLocaleTimeString('en-US', {
@@ -158,8 +160,8 @@ export function formatTimeRangeInTimezone(
   timezone: string
 ): string {
   try {
-    const start = DateTime.fromISO(startTime, { setZone: false }).setZone(timezone);
-    const end = DateTime.fromISO(endTime, { setZone: false }).setZone(timezone);
+    const start = DateTime.fromISO(startTime, { zone: timezone });
+    const end = DateTime.fromISO(endTime, { zone: timezone });
 
     if (!start.isValid || !end.isValid) {
       return `${formatInTimezone(startTime, timezone, 'short')} - ${formatInTimezone(endTime, timezone, 'short')}`;

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -17,7 +17,8 @@ import { logger } from './logger.js';
 export function formatInTimezone(
   isoString: string,
   timezone: string,
-  format: 'full' | 'long' | 'medium' | 'short' = 'medium'
+  format: 'full' | 'long' | 'medium' | 'short' = 'medium',
+  timeFormat: '12h' | '24h' = '12h'
 ): string {
   try {
     // Timezone-naive strings (e.g. Open-Meteo's "2026-07-07T04:32") are already
@@ -31,17 +32,21 @@ export function formatInTimezone(
       return new Date(isoString).toLocaleString('en-US', { timeZone: timezone });
     }
 
+    // hour12 override lets callers honor a 24-hour preference; undefined keeps
+    // the locale default (12-hour for en-US).
+    const hourOpt = timeFormat === '24h' ? { hour12: false } : {};
+
     // Format based on requested style
     switch (format) {
       case 'full':
-        return zonedDt.toLocaleString(DateTime.DATETIME_FULL);
+        return zonedDt.toLocaleString({ ...DateTime.DATETIME_FULL, ...hourOpt });
       case 'long':
-        return zonedDt.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+        return zonedDt.toLocaleString({ ...DateTime.DATETIME_MED_WITH_SECONDS, ...hourOpt });
       case 'short':
-        return zonedDt.toLocaleString(DateTime.DATETIME_SHORT);
+        return zonedDt.toLocaleString({ ...DateTime.DATETIME_SHORT, ...hourOpt });
       case 'medium':
       default:
-        return zonedDt.toLocaleString(DateTime.DATETIME_MED);
+        return zonedDt.toLocaleString({ ...DateTime.DATETIME_MED, ...hourOpt });
     }
   } catch (error) {
     // Fallback to standard Date formatting if anything goes wrong

--- a/src/utils/unitFormat.ts
+++ b/src/utils/unitFormat.ts
@@ -1,0 +1,261 @@
+/**
+ * Units-aware formatting.
+ *
+ * Every weather output path funnels through these helpers so that a single
+ * `UnitPreferences` object controls how temperature, wind, pressure,
+ * precipitation, distance/visibility, and clock times are rendered.
+ *
+ * Two families of helpers exist:
+ *   - `format*From*` take a value in a known canonical/SI source unit and
+ *     convert + label it (used for the NOAA path, where values arrive in SI).
+ *   - `*Label` + `withLabel` just attach the correct label to a value that is
+ *     already in the target unit (used for the Open-Meteo path, where the API
+ *     is asked to return values in the requested unit — no re-conversion).
+ */
+
+import { UnitPreferences } from '../config/units.js';
+import { QuantitativeValue } from '../types/noaa.js';
+import { DateTime } from 'luxon';
+import {
+  celsiusToFahrenheit,
+  mpsToMph,
+  metersToMiles,
+  metersToFeet,
+  pascalsToInHg,
+  extractValue,
+} from './units.js';
+import { kmToMiles } from './distance.js';
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+export function temperatureLabel(prefs: UnitPreferences): string {
+  return `°${prefs.temperature}`;
+}
+
+export function windSpeedLabel(prefs: UnitPreferences): string {
+  switch (prefs.windSpeed) {
+    case 'kmh': return 'km/h';
+    case 'ms': return 'm/s';
+    case 'kn': return 'kn';
+    default: return 'mph';
+  }
+}
+
+export function precipitationLabel(prefs: UnitPreferences): string {
+  return prefs.precipitation === 'mm' ? 'mm' : 'in';
+}
+
+export function pressureLabel(prefs: UnitPreferences): string {
+  return prefs.pressure === 'hPa' ? 'hPa' : 'inHg';
+}
+
+export function distanceLabel(prefs: UnitPreferences): string {
+  return prefs.distance === 'km' ? 'km' : 'mi';
+}
+
+/** The Open-Meteo request tokens matching the current preferences. */
+export function openMeteoUnitParams(prefs: UnitPreferences): {
+  temperature_unit: 'celsius' | 'fahrenheit';
+  wind_speed_unit: 'mph' | 'kmh' | 'ms' | 'kn';
+  precipitation_unit: 'inch' | 'mm';
+} {
+  return {
+    temperature_unit: prefs.temperature === 'C' ? 'celsius' : 'fahrenheit',
+    wind_speed_unit: prefs.windSpeed,
+    precipitation_unit: prefs.precipitation === 'mm' ? 'mm' : 'inch',
+  };
+}
+
+/** NOAA forecast endpoint units token (`us` = imperial, `si` = metric). */
+export function noaaUnitsParam(prefs: UnitPreferences): 'us' | 'si' {
+  return prefs.temperature === 'C' ? 'si' : 'us';
+}
+
+// ---------------------------------------------------------------------------
+// Decimal-place conventions per unit
+// ---------------------------------------------------------------------------
+
+function windDecimals(prefs: UnitPreferences): number {
+  // Sub-unit resolution matters most for m/s; whole numbers elsewhere read cleaner.
+  return prefs.windSpeed === 'ms' ? 1 : 0;
+}
+
+function pressureDecimals(prefs: UnitPreferences): number {
+  return prefs.pressure === 'hPa' ? 0 : 2;
+}
+
+function precipDecimals(prefs: UnitPreferences): number {
+  return prefs.precipitation === 'mm' ? 1 : 2;
+}
+
+// ---------------------------------------------------------------------------
+// Conversions from canonical/SI source units
+// ---------------------------------------------------------------------------
+
+export function convertTemperatureFromC(celsius: number, prefs: UnitPreferences): number {
+  return prefs.temperature === 'F' ? celsiusToFahrenheit(celsius) : celsius;
+}
+
+export function convertWindFromMps(mps: number, prefs: UnitPreferences): number {
+  switch (prefs.windSpeed) {
+    case 'kmh': return mps * 3.6;
+    case 'ms': return mps;
+    case 'kn': return mps * 1.943844;
+    default: return mpsToMph(mps);
+  }
+}
+
+export function convertPressureFromPa(pa: number, prefs: UnitPreferences): number {
+  return prefs.pressure === 'hPa' ? pa / 100 : pascalsToInHg(pa);
+}
+
+export function convertPrecipFromMm(mm: number, prefs: UnitPreferences): number {
+  return prefs.precipitation === 'mm' ? mm : mm * 0.0393701;
+}
+
+export function convertDistanceFromKm(km: number, prefs: UnitPreferences): number {
+  return prefs.distance === 'km' ? km : kmToMiles(km);
+}
+
+// ---------------------------------------------------------------------------
+// Value formatters (raw numeric source → labeled string)
+// ---------------------------------------------------------------------------
+
+/** Format a value that is ALREADY in the target unit, attaching the label. */
+export function withLabel(value: number, label: string, decimals = 0): string {
+  return `${value.toFixed(decimals)} ${label}`;
+}
+
+export function formatTemperatureFromC(celsius: number, prefs: UnitPreferences): string {
+  return `${Math.round(convertTemperatureFromC(celsius, prefs))}${temperatureLabel(prefs)}`;
+}
+
+export function formatWindFromMps(mps: number, prefs: UnitPreferences): string {
+  const value = convertWindFromMps(mps, prefs);
+  return withLabel(value, windSpeedLabel(prefs), windDecimals(prefs));
+}
+
+export function formatPressureFromPa(pa: number, prefs: UnitPreferences): string {
+  const value = convertPressureFromPa(pa, prefs);
+  return withLabel(value, pressureLabel(prefs), pressureDecimals(prefs));
+}
+
+export function formatPrecipFromMm(mm: number, prefs: UnitPreferences): string {
+  const value = convertPrecipFromMm(mm, prefs);
+  return withLabel(value, precipitationLabel(prefs), precipDecimals(prefs));
+}
+
+export function formatVisibilityFromM(meters: number, prefs: UnitPreferences): string {
+  const value = prefs.distance === 'km' ? meters / 1000 : metersToMiles(meters);
+  return withLabel(value, prefs.distance === 'km' ? 'km' : 'miles', 1);
+}
+
+export function formatDistanceFromKm(km: number, prefs: UnitPreferences): string {
+  const value = convertDistanceFromKm(km, prefs);
+  return withLabel(value, distanceLabel(prefs), 1);
+}
+
+/** Elevation/height from a metres source: feet for imperial, metres for metric. */
+export function formatElevationFromM(meters: number, prefs: UnitPreferences): string {
+  if (prefs.distance === 'km') {
+    return `${Math.round(meters)}m`;
+  }
+  return `${Math.round(metersToFeet(meters))}ft`;
+}
+
+/** Height from a feet source (e.g. cloud base, mixing height). */
+export function formatHeightFromFt(feet: number, prefs: UnitPreferences): string {
+  if (prefs.distance === 'km') {
+    return `${Math.round(feet / 3.28084)}m`;
+  }
+  return `${Math.round(feet)}ft`;
+}
+
+// ---------------------------------------------------------------------------
+// NOAA QuantitativeValue formatters (unitCode-aware SI → target)
+// ---------------------------------------------------------------------------
+
+/** Normalize a NOAA temperature QuantitativeValue to Celsius. */
+function qvToCelsius(qv: QuantitativeValue | undefined): number | null {
+  const value = extractValue(qv);
+  if (value === null) return null;
+  return qv?.unitCode?.includes('degF') ? ((value - 32) * 5) / 9 : value;
+}
+
+/** Normalize a NOAA wind QuantitativeValue to metres per second. */
+function qvToMps(qv: QuantitativeValue | undefined): number | null {
+  const value = extractValue(qv);
+  if (value === null) return null;
+  if (qv?.unitCode?.includes('km_h')) return value / 3.6;
+  if (qv?.unitCode?.includes('mi_h') || qv?.unitCode?.includes('mph')) return value / 2.23694;
+  // Default and explicit m_s
+  return value;
+}
+
+export function formatTemperatureQV(
+  qv: QuantitativeValue | undefined,
+  prefs: UnitPreferences
+): string {
+  const celsius = qvToCelsius(qv);
+  if (celsius === null) return 'N/A';
+  return formatTemperatureFromC(celsius, prefs);
+}
+
+export function formatWindSpeedQV(
+  qv: QuantitativeValue | undefined,
+  prefs: UnitPreferences
+): string {
+  const mps = qvToMps(qv);
+  if (mps === null) return 'Calm';
+  return formatWindFromMps(mps, prefs);
+}
+
+export function formatVisibilityQV(
+  qv: QuantitativeValue | undefined,
+  prefs: UnitPreferences
+): string {
+  const meters = extractValue(qv);
+  if (meters === null) return 'N/A';
+  return formatVisibilityFromM(meters, prefs);
+}
+
+export function formatPressureQV(
+  qv: QuantitativeValue | undefined,
+  prefs: UnitPreferences
+): string {
+  const pa = extractValue(qv);
+  if (pa === null) return 'N/A';
+  return formatPressureFromPa(pa, prefs);
+}
+
+// ---------------------------------------------------------------------------
+// Clock time
+// ---------------------------------------------------------------------------
+
+/**
+ * Format the time-of-day portion of a Date according to the preferred clock
+ * format (12h vs 24h), optionally in a specific IANA timezone.
+ */
+export function formatClockTime(
+  date: Date,
+  prefs: UnitPreferences,
+  timeZone?: string
+): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: prefs.timeFormat === '12h',
+    ...(timeZone ? { timeZone } : {}),
+  });
+}
+
+/**
+ * Format a Luxon DateTime's time-of-day honoring the 12h/24h preference.
+ * Used for sunrise/sunset lines that are parsed with an explicit zone.
+ */
+export function formatLuxonTime(dt: DateTime, prefs: UnitPreferences): string {
+  const hourOpt = prefs.timeFormat === '24h' ? { hour12: false } : {};
+  return dt.toLocaleString({ ...DateTime.TIME_SIMPLE, ...hourOpt });
+}

--- a/src/utils/unitPreferences.ts
+++ b/src/utils/unitPreferences.ts
@@ -1,0 +1,90 @@
+/**
+ * Resolve per-request unit preferences from tool arguments.
+ *
+ * Precedence (highest first):
+ *   1. per-call individual overrides (temperature_unit, wind_speed_unit, ...)
+ *   2. per-call system preset (units: "imperial" | "metric")
+ *   3. the server-wide default (from the environment)
+ */
+
+import {
+  UnitPreferences,
+  systemPreferences,
+  normalizeUnit,
+  defaultUnitPreferences,
+} from '../config/units.js';
+
+/**
+ * Unit-related arguments accepted by weather tools. All optional; when a tool
+ * omits a given knob from its schema, callers simply never set it.
+ */
+export interface UnitArgs {
+  units?: string;
+  temperature_unit?: string;
+  wind_speed_unit?: string;
+  precipitation_unit?: string;
+  pressure_unit?: string;
+  distance_unit?: string;
+  time_format?: string;
+}
+
+/**
+ * Normalize one field or throw a helpful error listing the accepted values.
+ */
+function coerce<K extends Parameters<typeof normalizeUnit>[0]>(
+  kind: K,
+  raw: string | undefined,
+  paramName: string,
+  accepted: string
+): ReturnType<typeof normalizeUnit<K>> | undefined {
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return undefined;
+  }
+  const normalized = normalizeUnit(kind, raw);
+  if (normalized === undefined) {
+    throw new Error(`Invalid ${paramName}: "${raw}". Accepted values: ${accepted}.`);
+  }
+  return normalized;
+}
+
+/**
+ * Resolve the effective unit preferences for a single tool invocation.
+ *
+ * @param args - The tool arguments (may contain units/*_unit/time_format)
+ * @param base - Base preferences to build on (defaults to the env-configured default)
+ * @returns Fully-resolved preferences
+ * @throws Error if any provided unit value is unrecognized
+ */
+export function resolveUnitPreferences(
+  args: UnitArgs | undefined | null,
+  base: UnitPreferences = defaultUnitPreferences
+): UnitPreferences {
+  // Start from the system preset if one is given, else the base default.
+  let prefs: UnitPreferences = { ...base };
+
+  const system = coerce('system', args?.units, 'units', 'imperial, metric');
+  if (system !== undefined) {
+    prefs = systemPreferences(system);
+  }
+
+  // Individual overrides win over the preset.
+  const temperature = coerce('temperature', args?.temperature_unit, 'temperature_unit', 'F, C');
+  if (temperature !== undefined) prefs.temperature = temperature;
+
+  const windSpeed = coerce('windSpeed', args?.wind_speed_unit, 'wind_speed_unit', 'mph, kmh, ms, kn');
+  if (windSpeed !== undefined) prefs.windSpeed = windSpeed;
+
+  const precipitation = coerce('precipitation', args?.precipitation_unit, 'precipitation_unit', 'inch, mm');
+  if (precipitation !== undefined) prefs.precipitation = precipitation;
+
+  const pressure = coerce('pressure', args?.pressure_unit, 'pressure_unit', 'inHg, hPa');
+  if (pressure !== undefined) prefs.pressure = pressure;
+
+  const distance = coerce('distance', args?.distance_unit, 'distance_unit', 'mi, km');
+  if (distance !== undefined) prefs.distance = distance;
+
+  const timeFormat = coerce('timeFormat', args?.time_format, 'time_format', '12h, 24h');
+  if (timeFormat !== undefined) prefs.timeFormat = timeFormat;
+
+  return prefs;
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -157,6 +157,40 @@ export function validateGranularity(value: unknown): 'daily' | 'hourly' {
 }
 
 /**
+ * Output verbosity levels for high-volume weather tools.
+ * - summary: shortest useful answer (fewest entries, headline-only)
+ * - standard: sensible default balancing detail and token cost
+ * - full: everything the source provides (long descriptions, all entries)
+ */
+export type DetailLevel = 'summary' | 'standard' | 'full';
+
+/**
+ * Validate the shared `detail` output-control parameter.
+ * @param value - Value to validate (from tool args)
+ * @param defaultValue - Level to use when omitted (defaults to 'standard')
+ * @returns Validated detail level
+ * @throws {Error} If value is present but not a valid level
+ */
+export function validateDetail(
+  value: unknown,
+  defaultValue: DetailLevel = 'standard'
+): DetailLevel {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid detail: must be a string, received ${typeof value}`);
+  }
+
+  if (value !== 'summary' && value !== 'standard' && value !== 'full') {
+    throw new Error(`Invalid detail: "${value}". Must be one of "summary", "standard", or "full".`);
+  }
+
+  return value;
+}
+
+/**
  * Validate optional boolean with default
  * @param value - Value to validate
  * @param name - Parameter name for error messages

--- a/tests/unit/alerts-detail.test.ts
+++ b/tests/unit/alerts-detail.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the get_alerts `detail` output control and location resolution.
+ *
+ * A minimal NOAAService stub returns one alert with a long description and
+ * instruction so we can assert what each verbosity level includes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleGetAlerts } from '../../src/handlers/alertsHandler.js';
+import type { NOAAService } from '../../src/services/noaa.js';
+import type { LocationStore } from '../../src/services/locationStore.js';
+import type { GeocodingService } from '../../src/services/geocoding.js';
+
+const DESCRIPTION = 'A very long National Weather Service description that is expensive to include.';
+const INSTRUCTION = 'Move to higher ground immediately.';
+
+function makeNoaaStub(): NOAAService {
+  return {
+    getStations: vi.fn(async () => ({ features: [] })),
+    getAlerts: vi.fn(async () => ({
+      updated: '2026-07-13T12:00:00Z',
+      features: [
+        {
+          properties: {
+            event: 'Flood Warning',
+            severity: 'Severe',
+            urgency: 'Immediate',
+            certainty: 'Likely',
+            headline: 'Flood Warning in effect',
+            description: DESCRIPTION,
+            areaDesc: 'Test County',
+            effective: '2026-07-13T12:00:00Z',
+            expires: '2026-07-13T18:00:00Z',
+            response: 'Avoid',
+            senderName: 'NWS',
+            instruction: INSTRUCTION,
+          },
+        },
+      ],
+    })),
+  } as unknown as NOAAService;
+}
+
+const store = {} as unknown as LocationStore;
+const geocoding = {} as unknown as GeocodingService;
+
+async function getAlertsText(args: Record<string, unknown>): Promise<string> {
+  const result = await handleGetAlerts(args, makeNoaaStub(), store, geocoding);
+  return result.content[0].text;
+}
+
+describe('get_alerts detail control', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('standard (default) includes instructions but omits the full description', async () => {
+    const text = await getAlertsText({ latitude: 40, longitude: -100 });
+    expect(text).toContain('Flood Warning');
+    expect(text).toContain(INSTRUCTION);
+    expect(text).not.toContain(DESCRIPTION);
+    expect(text).toContain('detail="full"');
+  });
+
+  it('summary omits both description and instructions', async () => {
+    const text = await getAlertsText({ latitude: 40, longitude: -100, detail: 'summary' });
+    expect(text).toContain('Flood Warning');
+    expect(text).not.toContain(DESCRIPTION);
+    expect(text).not.toContain(INSTRUCTION);
+  });
+
+  it('full includes the complete description and instructions', async () => {
+    const text = await getAlertsText({ latitude: 40, longitude: -100, detail: 'full' });
+    expect(text).toContain(DESCRIPTION);
+    expect(text).toContain(INSTRUCTION);
+    expect(text).not.toContain('detail="full"');
+  });
+
+  it('rejects an invalid detail level', async () => {
+    await expect(
+      getAlertsText({ latitude: 40, longitude: -100, detail: 'loud' })
+    ).rejects.toThrow(/detail/i);
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -22,6 +22,7 @@ describe('Cache Configuration', () => {
 
     it('should have proper TTL values', () => {
       expect(CacheConfig.ttl.gridCoordinates).toBe(Infinity);
+      expect(CacheConfig.ttl.geocoding).toBe(Infinity);
       expect(CacheConfig.ttl.stations).toBeGreaterThan(0);
       expect(CacheConfig.ttl.forecast).toBeGreaterThan(0);
       expect(CacheConfig.ttl.currentConditions).toBeGreaterThan(0);

--- a/tests/unit/imagery-handler.test.ts
+++ b/tests/unit/imagery-handler.test.ts
@@ -280,7 +280,13 @@ describe('Weather Imagery Handler', () => {
 
       expect(formatted).toContain('## 📸 Current Imagery');
       expect(formatted).toContain('**Timestamp:** 2024-01-01T12:00:00.000Z');
-      expect(formatted).toContain('![Precipitation radar](https://example.com/frame.png)');
+      // Default (standard) surfaces the direct URL as text, not an embedded image
+      expect(formatted).toContain('**Image URL:** https://example.com/frame.png');
+      expect(formatted).not.toContain('![Precipitation radar]');
+
+      // detail="full" embeds the image as Markdown for rich clients
+      const full = formatWeatherImageryResponse(response, 'full');
+      expect(full).toContain('![Precipitation radar](https://example.com/frame.png)');
     });
 
     it('should format response with multiple frames (animated)', () => {

--- a/tests/unit/lightning-handler.test.ts
+++ b/tests/unit/lightning-handler.test.ts
@@ -11,16 +11,22 @@ import * as blitzortungModule from '../../src/services/blitzortung.js';
 // Mock the blitzortung service
 vi.mock('../../src/services/blitzortung.js', () => ({
   blitzortungService: {
-    getLightningStrikes: vi.fn()
+    getLightningStrikes: vi.fn(),
+    getCoverageStart: vi.fn()
   }
 }));
 
 describe('Lightning Activity Handler', () => {
   let mockGetLightningStrikes: Mock;
+  let mockGetCoverageStart: Mock;
 
   beforeEach(() => {
     mockGetLightningStrikes = blitzortungModule.blitzortungService.getLightningStrikes as Mock;
     mockGetLightningStrikes.mockReset();
+    mockGetCoverageStart = blitzortungModule.blitzortungService.getCoverageStart as Mock;
+    mockGetCoverageStart.mockReset();
+    // Default: area has been monitored for 3 hours, so any window <= 120 min is fully covered
+    mockGetCoverageStart.mockReturnValue(new Date(Date.now() - 3 * 60 * 60 * 1000));
   });
 
   describe('Parameter Validation', () => {
@@ -450,6 +456,9 @@ describe('Lightning Activity Handler', () => {
       expect(result.strikes).toEqual([]);
       expect(result.statistics).toBeDefined();
       expect(result.safety).toBeDefined();
+      expect(result.coverage).toBeDefined();
+      expect(result.coverage.isComplete).toBe(true);
+      expect(result.coverage.coverageMinutes).toBe(60);
       expect(result.source).toBe('Blitzortung.org');
       expect(result.generatedAt).toBeInstanceOf(Date);
       expect(result.disclaimer).toBeDefined();
@@ -524,6 +533,11 @@ describe('Lightning Activity Handler', () => {
           nearestStrikeTime: null,
           isActiveThunderstorm: false
         },
+        coverage: {
+          monitoringSince: new Date('2024-01-01T10:00:00Z'),
+          coverageMinutes: 60,
+          isComplete: true
+        },
         source: 'Blitzortung.org',
         generatedAt: new Date('2024-01-01T13:00:00Z'),
         disclaimer: 'Lightning data from Blitzortung.org community network.'
@@ -577,6 +591,11 @@ describe('Lightning Activity Handler', () => {
           nearestStrikeDistance: 12.3,
           nearestStrikeTime: new Date('2024-01-01T12:45:00Z'),
           isActiveThunderstorm: true
+        },
+        coverage: {
+          monitoringSince: new Date('2024-01-01T10:00:00Z'),
+          coverageMinutes: 60,
+          isComplete: true
         },
         source: 'Blitzortung.org',
         generatedAt: new Date('2024-01-01T13:00:00Z'),
@@ -633,7 +652,12 @@ describe('Lightning Activity Handler', () => {
             nearestStrikeTime: null,
             isActiveThunderstorm: false
           },
-          source: 'Blitzortung.org',
+          coverage: {
+          monitoringSince: new Date('2024-01-01T10:00:00Z'),
+          coverageMinutes: 60,
+          isComplete: true
+        },
+        source: 'Blitzortung.org',
           generatedAt: new Date()
         };
 
@@ -678,6 +702,11 @@ describe('Lightning Activity Handler', () => {
           nearestStrikeDistance: 1,
           nearestStrikeTime: new Date(),
           isActiveThunderstorm: false
+        },
+        coverage: {
+          monitoringSince: new Date('2024-01-01T10:00:00Z'),
+          coverageMinutes: 60,
+          isComplete: true
         },
         source: 'Blitzortung.org',
         generatedAt: new Date()
@@ -730,6 +759,109 @@ describe('Lightning Activity Handler', () => {
 
       expect(result.searchRadius).toBe(500);
       expect(result.timeWindow).toBe(120);
+    });
+  });
+
+  describe('Monitoring Coverage (cold-buffer safety)', () => {
+    it('should mark coverage incomplete when monitoring started mid-window', async () => {
+      mockGetLightningStrikes.mockResolvedValue([]);
+      // Monitoring for this area began 2 minutes ago; window is 60 minutes
+      mockGetCoverageStart.mockReturnValue(new Date(Date.now() - 2 * 60 * 1000));
+
+      const result = await getLightningActivity({
+        latitude: 40.7128,
+        longitude: -74.006,
+        timeWindow: 60
+      });
+
+      expect(result.coverage.isComplete).toBe(false);
+      expect(result.coverage.coverageMinutes).toBeGreaterThan(1.9);
+      expect(result.coverage.coverageMinutes).toBeLessThan(2.5);
+      expect(result.coverage.monitoringSince).toBeInstanceOf(Date);
+    });
+
+    it('should make a safe verdict inconclusive under incomplete coverage', async () => {
+      mockGetLightningStrikes.mockResolvedValue([]);
+      mockGetCoverageStart.mockReturnValue(new Date(Date.now() - 2 * 60 * 1000));
+
+      const result = await getLightningActivity({
+        latitude: 40.7128,
+        longitude: -74.006,
+        timeWindow: 60
+      });
+
+      expect(result.safety.level).toBe('safe');
+      expect(result.safety.message).toContain('does NOT confirm');
+      expect(result.safety.recommendations[0]).toContain('inconclusive');
+    });
+
+    it('should report zero coverage when the area is not monitored at all', async () => {
+      mockGetLightningStrikes.mockResolvedValue([]);
+      mockGetCoverageStart.mockReturnValue(null);
+
+      const result = await getLightningActivity({
+        latitude: 40.7128,
+        longitude: -74.006
+      });
+
+      expect(result.coverage.monitoringSince).toBeNull();
+      expect(result.coverage.coverageMinutes).toBe(0);
+      expect(result.coverage.isComplete).toBe(false);
+      expect(result.safety.message).toContain('does NOT confirm');
+    });
+
+    it('should not alter non-safe verdicts under incomplete coverage', async () => {
+      const strikes: LightningStrike[] = [
+        {
+          timestamp: new Date(Date.now() - 1 * 60 * 1000),
+          latitude: 40.72,
+          longitude: -74.0,
+          polarity: -1,
+          amplitude: 50,
+          distance: 5
+        }
+      ];
+      mockGetLightningStrikes.mockResolvedValue(strikes);
+      mockGetCoverageStart.mockReturnValue(new Date(Date.now() - 2 * 60 * 1000));
+
+      const result = await getLightningActivity({
+        latitude: 40.7128,
+        longitude: -74.006
+      });
+
+      expect(result.safety.level).toBe('extreme');
+      expect(result.safety.message).toContain('EXTREME DANGER');
+    });
+
+    it('should render LIMITED DATA warning in formatted output', async () => {
+      mockGetLightningStrikes.mockResolvedValue([]);
+      mockGetCoverageStart.mockReturnValue(new Date(Date.now() - 2 * 60 * 1000));
+
+      const result = await getLightningActivity({
+        latitude: 40.7128,
+        longitude: -74.006,
+        timeWindow: 60
+      });
+      const formatted = formatLightningActivityResponse(result);
+
+      expect(formatted).toContain('SAFE (LIMITED DATA)');
+      expect(formatted).toContain('Limited monitoring coverage');
+      expect(formatted).toMatch(/\*\*Monitoring Coverage:\*\* \d+\.\d of 60 minutes ⚠️/);
+    });
+
+    it('should render full coverage without warnings', async () => {
+      mockGetLightningStrikes.mockResolvedValue([]);
+
+      const result = await getLightningActivity({
+        latitude: 40.7128,
+        longitude: -74.006,
+        timeWindow: 60
+      });
+      const formatted = formatLightningActivityResponse(result);
+
+      expect(formatted).not.toContain('LIMITED DATA');
+      expect(formatted).not.toContain('Limited monitoring coverage');
+      expect(formatted).toContain('**Monitoring Coverage:** 60.0 of 60 minutes');
     });
   });
 });

--- a/tests/unit/locationResolver.test.ts
+++ b/tests/unit/locationResolver.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for locationResolver
+ *
+ * Focuses on resolveLocationAsync, which resolves a location from direct
+ * coordinates, a saved location name, or a free-text city name (geocoded).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  resolveLocationAsync,
+  clearCityGeocodeCache,
+} from '../../src/utils/locationResolver.js';
+import type { LocationStore } from '../../src/services/locationStore.js';
+import type { GeocodingService, GeocodingResult } from '../../src/services/geocoding.js';
+import type { SavedLocation } from '../../src/types/savedLocations.js';
+
+/**
+ * Build a minimal LocationStore stub with the two methods the resolver uses.
+ */
+function makeLocationStore(locations: Record<string, SavedLocation> = {}): LocationStore {
+  return {
+    get: (alias: string) => locations[alias.toLowerCase().trim()],
+    getAll: () => locations,
+  } as unknown as LocationStore;
+}
+
+/**
+ * Build a GeocodingService stub whose geocode() returns the supplied results.
+ */
+function makeGeocodingService(results: GeocodingResult[]): {
+  service: GeocodingService;
+  geocode: ReturnType<typeof vi.fn>;
+} {
+  const geocode = vi.fn(async () => results);
+  return {
+    service: { geocode } as unknown as GeocodingService,
+    geocode,
+  };
+}
+
+function makeGeocodingResult(overrides: Partial<GeocodingResult> = {}): GeocodingResult {
+  return {
+    name: 'Paris',
+    display_name: 'Paris, Île-de-France, France',
+    latitude: 48.8566,
+    longitude: 2.3522,
+    confidence: 'high',
+    source: 'openmeteo',
+    ...overrides,
+  };
+}
+
+function makeSavedLocation(overrides: Partial<SavedLocation> = {}): SavedLocation {
+  return {
+    name: 'Seattle, WA',
+    latitude: 47.6062,
+    longitude: -122.3321,
+    saved_at: '2025-01-15T10:30:00.000Z',
+    updated_at: '2025-01-15T10:30:00.000Z',
+    ...overrides,
+  } as SavedLocation;
+}
+
+describe('resolveLocationAsync', () => {
+  beforeEach(() => {
+    clearCityGeocodeCache();
+  });
+
+  describe('coordinates', () => {
+    it('resolves direct coordinates', async () => {
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([]);
+
+      const resolved = await resolveLocationAsync(
+        { latitude: 40.7128, longitude: -74.006 },
+        store,
+        service
+      );
+
+      expect(resolved).toEqual({
+        latitude: 40.7128,
+        longitude: -74.006,
+        source: 'coordinates',
+      });
+    });
+
+    it('rejects invalid coordinates', async () => {
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([]);
+
+      await expect(
+        resolveLocationAsync({ latitude: 999, longitude: 0 }, store, service)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('precedence', () => {
+    it('prefers coordinates over location_name and city_name', async () => {
+      const store = makeLocationStore({ home: makeSavedLocation() });
+      const { service, geocode } = makeGeocodingService([makeGeocodingResult()]);
+
+      const resolved = await resolveLocationAsync(
+        { latitude: 10, longitude: 20, location_name: 'home', city_name: 'Paris' },
+        store,
+        service
+      );
+
+      expect(resolved.source).toBe('coordinates');
+      expect(resolved.latitude).toBe(10);
+      expect(geocode).not.toHaveBeenCalled();
+    });
+
+    it('prefers a saved location_name over city_name', async () => {
+      const store = makeLocationStore({ home: makeSavedLocation() });
+      const { service, geocode } = makeGeocodingService([makeGeocodingResult()]);
+
+      const resolved = await resolveLocationAsync(
+        { location_name: 'home', city_name: 'Paris' },
+        store,
+        service
+      );
+
+      expect(resolved.source).toBe('saved_location');
+      expect(resolved.latitude).toBe(47.6062);
+      expect(geocode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('location_name', () => {
+    it('resolves a saved location', async () => {
+      const store = makeLocationStore({ home: makeSavedLocation() });
+      const { service } = makeGeocodingService([]);
+
+      const resolved = await resolveLocationAsync({ location_name: 'home' }, store, service);
+
+      expect(resolved).toEqual({
+        latitude: 47.6062,
+        longitude: -122.3321,
+        source: 'saved_location',
+        location_name: 'home',
+      });
+    });
+
+    it('throws a helpful error for an unknown saved location', async () => {
+      const store = makeLocationStore({ home: makeSavedLocation() });
+      const { service } = makeGeocodingService([]);
+
+      await expect(
+        resolveLocationAsync({ location_name: 'nowhere' }, store, service)
+      ).rejects.toThrow(/not found/i);
+    });
+  });
+
+  describe('city_name (geocoding)', () => {
+    it('geocodes a free-text city name', async () => {
+      const store = makeLocationStore();
+      const { service, geocode } = makeGeocodingService([makeGeocodingResult()]);
+
+      const resolved = await resolveLocationAsync({ city_name: 'Paris, France' }, store, service);
+
+      expect(resolved).toEqual({
+        latitude: 48.8566,
+        longitude: 2.3522,
+        source: 'geocoded',
+        location_name: 'Paris, Île-de-France, France',
+      });
+      expect(geocode).toHaveBeenCalledWith('Paris, France', 1);
+    });
+
+    it('passes through the geocoder display_name as location_name', async () => {
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([
+        makeGeocodingResult({ display_name: 'Bend, Deschutes County, Oregon, United States' }),
+      ]);
+
+      const resolved = await resolveLocationAsync({ city_name: 'Bend, Oregon' }, store, service);
+
+      expect(resolved.location_name).toBe('Bend, Deschutes County, Oregon, United States');
+    });
+
+    it('caches results so a repeated lookup does not re-hit the geocoder', async () => {
+      const store = makeLocationStore();
+      const { service, geocode } = makeGeocodingService([makeGeocodingResult()]);
+
+      const first = await resolveLocationAsync({ city_name: 'Paris' }, store, service);
+      const second = await resolveLocationAsync({ city_name: 'Paris' }, store, service);
+
+      expect(second).toEqual(first);
+      expect(geocode).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats the cache key case-insensitively', async () => {
+      const store = makeLocationStore();
+      const { service, geocode } = makeGeocodingService([makeGeocodingResult()]);
+
+      await resolveLocationAsync({ city_name: 'Paris' }, store, service);
+      await resolveLocationAsync({ city_name: '  PARIS  ' }, store, service);
+
+      expect(geocode).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when the city name is empty', async () => {
+      const store = makeLocationStore();
+      const { service, geocode } = makeGeocodingService([]);
+
+      await expect(
+        resolveLocationAsync({ city_name: '   ' }, store, service)
+      ).rejects.toThrow(/empty/i);
+      expect(geocode).not.toHaveBeenCalled();
+    });
+
+    it('throws a helpful error when geocoding finds nothing', async () => {
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([]);
+
+      await expect(
+        resolveLocationAsync({ city_name: 'Nonexistentville' }, store, service)
+      ).rejects.toThrow(/could not find/i);
+    });
+  });
+
+  describe('no input', () => {
+    it('throws when nothing usable is provided', async () => {
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([]);
+
+      await expect(resolveLocationAsync({}, store, service)).rejects.toThrow(
+        /coordinates|location_name|city_name/i
+      );
+    });
+  });
+});

--- a/tests/unit/locationResolver.test.ts
+++ b/tests/unit/locationResolver.test.ts
@@ -9,7 +9,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   resolveLocationAsync,
   clearCityGeocodeCache,
+  formatLocationLine,
+  prependLocationLine,
 } from '../../src/utils/locationResolver.js';
+import type { ResolvedLocation } from '../../src/utils/locationResolver.js';
 import type { LocationStore } from '../../src/services/locationStore.js';
 import type { GeocodingService, GeocodingResult } from '../../src/services/geocoding.js';
 import type { SavedLocation } from '../../src/types/savedLocations.js';
@@ -228,5 +231,66 @@ describe('resolveLocationAsync', () => {
         /coordinates|location_name|city_name/i
       );
     });
+  });
+});
+
+describe('formatLocationLine', () => {
+  it('returns an empty string for direct coordinate input', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      source: 'coordinates',
+    };
+    expect(formatLocationLine(resolved)).toBe('');
+  });
+
+  it('discloses the matched name and coordinates for a saved location', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 47.6062,
+      longitude: -122.3321,
+      source: 'saved_location',
+      location_name: 'home',
+    };
+    expect(formatLocationLine(resolved)).toBe('**Location:** home (47.6062, -122.3321)\n\n');
+  });
+
+  it('discloses the geocoder display name for a city lookup', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 48.8566,
+      longitude: 2.3522,
+      source: 'geocoded',
+      location_name: 'Paris, Île-de-France, France',
+    };
+    expect(formatLocationLine(resolved)).toContain('Paris, Île-de-France, France');
+    expect(formatLocationLine(resolved)).toContain('48.8566, 2.3522');
+  });
+});
+
+describe('prependLocationLine', () => {
+  it('prepends the location line to the first text block for a name lookup', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 47.6062,
+      longitude: -122.3321,
+      source: 'saved_location',
+      location_name: 'home',
+    };
+    const result = { content: [{ type: 'text', text: '# Forecast\n' }] };
+
+    const out = prependLocationLine(result, resolved);
+
+    expect(out.content[0].text).toBe('**Location:** home (47.6062, -122.3321)\n\n# Forecast\n');
+  });
+
+  it('is a no-op for direct coordinate input', () => {
+    const resolved: ResolvedLocation = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      source: 'coordinates',
+    };
+    const result = { content: [{ type: 'text', text: '# Forecast\n' }] };
+
+    prependLocationLine(result, resolved);
+
+    expect(result.content[0].text).toBe('# Forecast\n');
   });
 });

--- a/tests/unit/normals.test.ts
+++ b/tests/unit/normals.test.ts
@@ -188,7 +188,7 @@ describe('Climate Normals Utilities', () => {
       expect(output).toContain('## 📊 Climate Context');
       expect(output).toContain('**Normal High:** 65°F');
       expect(output).toContain('**Normal Low:** 45°F');
-      expect(output).toContain('**Normal Precipitation:** 0.12"');
+      expect(output).toContain('**Normal Precipitation:** 0.12 in');
       expect(output).toContain('*Climate normals based on 1991-2020 data*');
       expect(output).toContain('*Source: Open-Meteo*');
       expect(output).not.toContain('Departure');

--- a/tests/unit/timezone.test.ts
+++ b/tests/unit/timezone.test.ts
@@ -75,6 +75,29 @@ describe('Timezone Utilities', () => {
       expect(result).toContain('Nov 7, 2025');
       expect(result).toMatch(/2:30\s*PM/); // Handle non-breaking space
     });
+
+    // Open-Meteo returns timezone-naive strings that are already local to the
+    // requested location. They must render verbatim in that timezone — not be
+    // parsed in the server's zone and shifted (the v1.8.2 sunrise/sunset bug).
+    it('should treat timezone-naive strings as location-local (no double shift)', () => {
+      const tokyoSunrise = formatInTimezone('2026-07-07T04:32', 'Asia/Tokyo', 'short');
+      expect(tokyoSunrise).toMatch(/4:32\s*AM/);
+      expect(tokyoSunrise).toContain('7/7/2026');
+
+      const fijiSunrise = formatInTimezone('2026-07-07T06:29', 'Pacific/Fiji', 'short');
+      expect(fijiSunrise).toMatch(/6:29\s*AM/);
+
+      const utcNoon = formatInTimezone('2026-07-07T12:00', 'Etc/GMT', 'short');
+      expect(utcNoon).toMatch(/12:00\s*PM/);
+    });
+
+    it('should treat naive strings as location-local in date/time/range formatters', () => {
+      expect(formatDateInTimezone('2026-07-07T01:00', 'Pacific/Honolulu')).toContain('Jul 7, 2026');
+      expect(formatTimeInTimezone('2026-07-07T04:32', 'Asia/Tokyo')).toMatch(/4:32:00\s*AM/);
+      expect(
+        formatTimeRangeInTimezone('2026-07-07T14:00', '2026-07-07T17:00', 'Asia/Tokyo')
+      ).toMatch(/2:00\s*PM.*5:00\s*PM/);
+    });
   });
 
   describe('formatDateInTimezone', () => {

--- a/tests/unit/tool-config.test.ts
+++ b/tests/unit/tool-config.test.ts
@@ -65,6 +65,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig(undefined);
 
       const enabled = toolConfig.getEnabledTools();
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
@@ -79,50 +80,68 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('basic');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(9); // Updated for v1.7.0: added 4 saved-location tools
+      // v1.11.0 "summary-first" default: 6 tools led by get_weather_summary
+      expect(enabled).toHaveLength(6);
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
       expect(enabled).toContain('search_location');
       expect(enabled).toContain('check_service_status');
+      // Personalization, history, and specialized tools are promoted out of basic
+      expect(enabled).not.toContain('save_location');
+      expect(enabled).not.toContain('get_historical_weather');
+      expect(enabled).not.toContain('get_air_quality');
     });
 
     it('should load "standard" preset', async () => {
       const toolConfig = await createToolConfig('standard');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(10); // Updated for v1.7.0: added 4 saved-location tools
+      // v1.11.0: basic + historical, air_quality, and saved-location CRUD
+      expect(enabled).toHaveLength(12);
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
       expect(enabled).toContain('get_historical_weather');
+      expect(enabled).toContain('get_air_quality');
       expect(enabled).toContain('search_location');
       expect(enabled).toContain('check_service_status');
+      expect(enabled).toContain('save_location');
+      // Specialized safety tools are still full-only
+      expect(enabled).not.toContain('get_marine_conditions');
+      expect(enabled).not.toContain('get_wildfire_info');
     });
 
     it('should load "full" preset', async () => {
       const toolConfig = await createToolConfig('full');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(11); // Updated for v1.7.0: added 4 saved-location tools
-      expect(enabled).toContain('get_forecast');
-      expect(enabled).toContain('get_current_conditions');
-      expect(enabled).toContain('get_alerts');
+      // v1.11.0: full is the complete set (17 tools, same membership as "all")
+      expect(enabled).toHaveLength(17);
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('get_historical_weather');
-      expect(enabled).toContain('search_location');
-      expect(enabled).toContain('check_service_status');
       expect(enabled).toContain('get_air_quality');
+      expect(enabled).toContain('get_marine_conditions');
+      expect(enabled).toContain('get_weather_imagery');
+      expect(enabled).toContain('get_lightning_activity');
+      expect(enabled).toContain('get_river_conditions');
+      expect(enabled).toContain('get_wildfire_info');
+      expect(enabled).toContain('save_location');
     });
 
     it('should load "all" preset', async () => {
       const toolConfig = await createToolConfig('all');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(16); // Updated for v1.7.0: added 4 saved-location tools
+      // v1.11.0: 16 previous tools + get_weather_summary = 17
+      expect(enabled).toHaveLength(17);
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_current_conditions');
       expect(enabled).toContain('get_alerts');
       expect(enabled).toContain('get_historical_weather');
+      expect(enabled).toContain('get_weather_summary');
       expect(enabled).toContain('check_service_status');
       expect(enabled).toContain('search_location');
       expect(enabled).toContain('get_air_quality');
@@ -207,7 +226,7 @@ describe('Tool Configuration', () => {
       const toolConfig = await createToolConfig('all,-get_marine_conditions');
 
       const enabled = toolConfig.getEnabledTools();
-      expect(enabled).toHaveLength(15); // Updated for v1.7.0: 16 total tools - 1 removed = 15
+      expect(enabled).toHaveLength(16); // v1.11.0: 17 total tools - 1 removed = 16
       expect(enabled).not.toContain('get_marine_conditions');
       expect(enabled).toContain('get_forecast');
       expect(enabled).toContain('get_air_quality');

--- a/tests/unit/units-localization.test.ts
+++ b/tests/unit/units-localization.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Unit tests for the units / localization layer:
+ * config presets + normalization, per-call resolver precedence, and the
+ * units-aware formatters.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  IMPERIAL_PREFERENCES,
+  METRIC_PREFERENCES,
+  systemPreferences,
+  normalizeUnit,
+  defaultUnitPreferences,
+  UnitPreferences,
+} from '../../src/config/units.js';
+import { resolveUnitPreferences } from '../../src/utils/unitPreferences.js';
+import {
+  temperatureLabel,
+  windSpeedLabel,
+  pressureLabel,
+  precipitationLabel,
+  distanceLabel,
+  openMeteoUnitParams,
+  noaaUnitsParam,
+  formatTemperatureFromC,
+  formatWindFromMps,
+  formatPressureFromPa,
+  formatPrecipFromMm,
+  formatVisibilityFromM,
+  formatDistanceFromKm,
+  formatTemperatureQV,
+  formatWindSpeedQV,
+  formatPressureQV,
+  formatVisibilityQV,
+  formatClockTime,
+} from '../../src/utils/unitFormat.js';
+
+describe('units config', () => {
+  it('defaults to imperial', () => {
+    expect(defaultUnitPreferences.temperature).toBe('F');
+    expect(defaultUnitPreferences.windSpeed).toBe('mph');
+  });
+
+  it('exposes distinct imperial and metric presets', () => {
+    expect(systemPreferences('imperial')).toEqual(IMPERIAL_PREFERENCES);
+    expect(systemPreferences('metric')).toEqual(METRIC_PREFERENCES);
+    expect(METRIC_PREFERENCES.temperature).toBe('C');
+    expect(METRIC_PREFERENCES.pressure).toBe('hPa');
+  });
+
+  it('returns fresh copies (no shared mutable state)', () => {
+    const a = systemPreferences('metric');
+    a.temperature = 'F';
+    expect(systemPreferences('metric').temperature).toBe('C');
+  });
+
+  it('normalizes unit spellings', () => {
+    expect(normalizeUnit('temperature', 'Celsius')).toBe('C');
+    expect(normalizeUnit('temperature', '°F')).toBe('F');
+    expect(normalizeUnit('windSpeed', 'km/h')).toBe('kmh');
+    expect(normalizeUnit('windSpeed', 'knots')).toBe('kn');
+    expect(normalizeUnit('pressure', 'mb')).toBe('hPa');
+    expect(normalizeUnit('system', 'SI')).toBe('metric');
+    expect(normalizeUnit('timeFormat', '24')).toBe('24h');
+  });
+
+  it('returns undefined for unknown values', () => {
+    expect(normalizeUnit('temperature', 'kelvin')).toBeUndefined();
+    expect(normalizeUnit('windSpeed', 'furlongs/fortnight')).toBeUndefined();
+  });
+});
+
+describe('resolveUnitPreferences', () => {
+  const base = IMPERIAL_PREFERENCES;
+
+  it('returns the base when no args are given', () => {
+    expect(resolveUnitPreferences(undefined, base)).toEqual(base);
+    expect(resolveUnitPreferences({}, base)).toEqual(base);
+  });
+
+  it('applies a system preset', () => {
+    expect(resolveUnitPreferences({ units: 'metric' }, base)).toEqual(METRIC_PREFERENCES);
+  });
+
+  it('lets an individual override win over the preset', () => {
+    const prefs = resolveUnitPreferences({ units: 'imperial', temperature_unit: 'C' }, base);
+    expect(prefs.temperature).toBe('C');
+    expect(prefs.windSpeed).toBe('mph'); // untouched by the override
+  });
+
+  it('supports per-unit overrides on top of the env base (knots, hPa)', () => {
+    const prefs = resolveUnitPreferences({ wind_speed_unit: 'kn', pressure_unit: 'hPa' }, base);
+    expect(prefs.windSpeed).toBe('kn');
+    expect(prefs.pressure).toBe('hPa');
+    expect(prefs.temperature).toBe('F'); // still imperial base
+  });
+
+  it('applies time_format independently', () => {
+    expect(resolveUnitPreferences({ time_format: '24h' }, base).timeFormat).toBe('24h');
+  });
+
+  it('throws a helpful error on an invalid value', () => {
+    expect(() => resolveUnitPreferences({ units: 'freedom' }, base)).toThrow(/Invalid units/);
+    expect(() => resolveUnitPreferences({ temperature_unit: 'kelvin' }, base)).toThrow(/temperature_unit/);
+  });
+});
+
+describe('unit labels and API params', () => {
+  it('produces correct labels per system', () => {
+    expect(temperatureLabel(METRIC_PREFERENCES)).toBe('°C');
+    expect(temperatureLabel(IMPERIAL_PREFERENCES)).toBe('°F');
+    expect(windSpeedLabel(METRIC_PREFERENCES)).toBe('km/h');
+    expect(windSpeedLabel({ ...IMPERIAL_PREFERENCES, windSpeed: 'kn' })).toBe('kn');
+    expect(pressureLabel(METRIC_PREFERENCES)).toBe('hPa');
+    expect(precipitationLabel(METRIC_PREFERENCES)).toBe('mm');
+    expect(distanceLabel(METRIC_PREFERENCES)).toBe('km');
+  });
+
+  it('maps preferences to Open-Meteo request tokens', () => {
+    expect(openMeteoUnitParams(IMPERIAL_PREFERENCES)).toEqual({
+      temperature_unit: 'fahrenheit',
+      wind_speed_unit: 'mph',
+      precipitation_unit: 'inch',
+    });
+    expect(openMeteoUnitParams(METRIC_PREFERENCES)).toEqual({
+      temperature_unit: 'celsius',
+      wind_speed_unit: 'kmh',
+      precipitation_unit: 'mm',
+    });
+  });
+
+  it('maps preferences to NOAA units token', () => {
+    expect(noaaUnitsParam(IMPERIAL_PREFERENCES)).toBe('us');
+    expect(noaaUnitsParam(METRIC_PREFERENCES)).toBe('si');
+  });
+});
+
+describe('formatters from SI/canonical', () => {
+  it('formats temperature', () => {
+    expect(formatTemperatureFromC(0, IMPERIAL_PREFERENCES)).toBe('32°F');
+    expect(formatTemperatureFromC(0, METRIC_PREFERENCES)).toBe('0°C');
+    expect(formatTemperatureFromC(100, METRIC_PREFERENCES)).toBe('100°C');
+  });
+
+  it('formats wind across all four units', () => {
+    expect(formatWindFromMps(10, IMPERIAL_PREFERENCES)).toBe('22 mph');
+    expect(formatWindFromMps(10, METRIC_PREFERENCES)).toBe('36 km/h');
+    expect(formatWindFromMps(10, { ...METRIC_PREFERENCES, windSpeed: 'ms' })).toBe('10.0 m/s');
+    expect(formatWindFromMps(10, { ...IMPERIAL_PREFERENCES, windSpeed: 'kn' })).toBe('19 kn');
+  });
+
+  it('formats pressure', () => {
+    expect(formatPressureFromPa(101325, IMPERIAL_PREFERENCES)).toBe('29.92 inHg');
+    expect(formatPressureFromPa(101325, METRIC_PREFERENCES)).toBe('1013 hPa');
+  });
+
+  it('formats precipitation', () => {
+    expect(formatPrecipFromMm(25.4, IMPERIAL_PREFERENCES)).toBe('1.00 in');
+    expect(formatPrecipFromMm(25.4, METRIC_PREFERENCES)).toBe('25.4 mm');
+  });
+
+  it('formats visibility and distance', () => {
+    expect(formatVisibilityFromM(1609.34, IMPERIAL_PREFERENCES)).toBe('1.0 miles');
+    expect(formatVisibilityFromM(1000, METRIC_PREFERENCES)).toBe('1.0 km');
+    expect(formatDistanceFromKm(1, IMPERIAL_PREFERENCES)).toBe('0.6 mi');
+    expect(formatDistanceFromKm(1, METRIC_PREFERENCES)).toBe('1.0 km');
+  });
+});
+
+describe('NOAA QuantitativeValue formatters', () => {
+  it('converts degC observations to the target unit', () => {
+    const qv = { value: 20, unitCode: 'wmoUnit:degC' };
+    expect(formatTemperatureQV(qv, IMPERIAL_PREFERENCES)).toBe('68°F');
+    expect(formatTemperatureQV(qv, METRIC_PREFERENCES)).toBe('20°C');
+  });
+
+  it('handles null and returns sensible placeholders', () => {
+    expect(formatTemperatureQV({ value: null, unitCode: 'wmoUnit:degC' }, METRIC_PREFERENCES)).toBe('N/A');
+    expect(formatWindSpeedQV({ value: null, unitCode: 'wmoUnit:km_h-1' }, METRIC_PREFERENCES)).toBe('Calm');
+    expect(formatPressureQV(undefined, IMPERIAL_PREFERENCES)).toBe('N/A');
+    expect(formatVisibilityQV(undefined, METRIC_PREFERENCES)).toBe('N/A');
+  });
+
+  it('converts wind observations from m/s and km/h sources', () => {
+    expect(formatWindSpeedQV({ value: 10, unitCode: 'wmoUnit:m_s-1' }, IMPERIAL_PREFERENCES)).toBe('22 mph');
+    expect(formatWindSpeedQV({ value: 36, unitCode: 'wmoUnit:km_h-1' }, METRIC_PREFERENCES)).toBe('36 km/h');
+  });
+
+  it('converts pressure observations from pascals', () => {
+    expect(formatPressureQV({ value: 101325, unitCode: 'wmoUnit:Pa' }, METRIC_PREFERENCES)).toBe('1013 hPa');
+  });
+});
+
+describe('clock time formatting', () => {
+  // A fixed UTC instant: 14:05 UTC.
+  const d = new Date('2026-07-13T14:05:00Z');
+
+  it('respects 12h vs 24h in UTC', () => {
+    const prefs12: UnitPreferences = { ...IMPERIAL_PREFERENCES, timeFormat: '12h' };
+    const prefs24: UnitPreferences = { ...METRIC_PREFERENCES, timeFormat: '24h' };
+    expect(formatClockTime(d, prefs12, 'UTC')).toBe('2:05 PM');
+    expect(formatClockTime(d, prefs24, 'UTC')).toBe('14:05');
+  });
+});

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -10,6 +10,7 @@ import {
   validateGranularity,
   validateOptionalBoolean,
   validateHistoricalWeatherParams,
+  validateDetail,
 } from '../../src/utils/validation.js';
 
 describe('Validation Utilities', () => {
@@ -374,6 +375,30 @@ describe('Validation Utilities', () => {
       expect(() => validateLatitude(Number.MAX_VALUE)).toThrow();
       expect(() => validateLatitude(Number.MIN_VALUE)).not.toThrow();
       expect(() => validateLatitude(-0)).not.toThrow();
+    });
+  });
+
+  describe('validateDetail', () => {
+    it('defaults to "standard" when undefined', () => {
+      expect(validateDetail(undefined)).toBe('standard');
+    });
+
+    it('honors a custom default when undefined', () => {
+      expect(validateDetail(undefined, 'summary')).toBe('summary');
+    });
+
+    it('accepts each valid level', () => {
+      expect(validateDetail('summary')).toBe('summary');
+      expect(validateDetail('standard')).toBe('standard');
+      expect(validateDetail('full')).toBe('full');
+    });
+
+    it('rejects an unknown level', () => {
+      expect(() => validateDetail('verbose')).toThrow(/detail/i);
+    });
+
+    it('rejects a non-string value', () => {
+      expect(() => validateDetail(3 as unknown)).toThrow(/string/i);
     });
   });
 });

--- a/tests/unit/weather-summary-handler.test.ts
+++ b/tests/unit/weather-summary-handler.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the get_weather_summary composite handler.
+ *
+ * The sub-handlers are mocked so these tests focus on the summary handler's own
+ * behavior: section selection, aggregation, single location resolution, and
+ * graceful degradation when a section fails.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const currentMock = vi.fn();
+const forecastMock = vi.fn();
+const alertsMock = vi.fn();
+const airQualityMock = vi.fn();
+const lightningMock = vi.fn();
+
+vi.mock('../../src/handlers/currentConditionsHandler.js', () => ({
+  handleGetCurrentConditions: (...args: unknown[]) => currentMock(...args),
+}));
+vi.mock('../../src/handlers/forecastHandler.js', () => ({
+  handleGetForecast: (...args: unknown[]) => forecastMock(...args),
+}));
+vi.mock('../../src/handlers/alertsHandler.js', () => ({
+  handleGetAlerts: (...args: unknown[]) => alertsMock(...args),
+}));
+vi.mock('../../src/handlers/airQualityHandler.js', () => ({
+  handleGetAirQuality: (...args: unknown[]) => airQualityMock(...args),
+}));
+vi.mock('../../src/handlers/lightningHandler.js', () => ({
+  handleGetLightningActivity: (...args: unknown[]) => lightningMock(...args),
+}));
+
+import { handleGetWeatherSummary } from '../../src/handlers/weatherSummaryHandler.js';
+
+function textResult(text: string) {
+  return { content: [{ type: 'text', text }] };
+}
+
+const services = {
+  noaa: {} as any,
+  openMeteo: {} as any,
+  ncei: {} as any,
+  // Coordinate input means resolveLocationAsync never touches these
+  locationStore: {} as any,
+  geocoding: {} as any,
+};
+
+function callSummary(args: Record<string, unknown>) {
+  return handleGetWeatherSummary(
+    args,
+    services.noaa,
+    services.openMeteo,
+    services.ncei,
+    services.locationStore,
+    services.geocoding
+  );
+}
+
+describe('handleGetWeatherSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentMock.mockResolvedValue(textResult('# Current Weather Conditions\nSunny'));
+    forecastMock.mockResolvedValue(textResult('# Weather Forecast (Daily)\nWarm'));
+    alertsMock.mockResolvedValue(textResult('# Weather Alerts\nNone'));
+    airQualityMock.mockResolvedValue(textResult('# Air Quality Report\nGood'));
+    lightningMock.mockResolvedValue(textResult('# Lightning Activity Report\nSafe'));
+  });
+
+  it('includes current, forecast, and alerts by default', async () => {
+    const result = await callSummary({ latitude: 47.6, longitude: -122.3 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('# Weather Summary');
+    expect(text).toContain('**Includes:** current, forecast, alerts');
+    expect(text).toContain('Current Weather Conditions');
+    expect(text).toContain('Weather Forecast');
+    expect(text).toContain('Weather Alerts');
+
+    expect(currentMock).toHaveBeenCalledTimes(1);
+    expect(forecastMock).toHaveBeenCalledTimes(1);
+    expect(alertsMock).toHaveBeenCalledTimes(1);
+    expect(airQualityMock).not.toHaveBeenCalled();
+    expect(lightningMock).not.toHaveBeenCalled();
+  });
+
+  it('honors an explicit include list', async () => {
+    const result = await callSummary({
+      latitude: 47.6,
+      longitude: -122.3,
+      include: ['forecast', 'air_quality'],
+    });
+    const text = result.content[0].text;
+
+    expect(text).toContain('**Includes:** forecast, air_quality');
+    expect(forecastMock).toHaveBeenCalledTimes(1);
+    expect(airQualityMock).toHaveBeenCalledTimes(1);
+    expect(currentMock).not.toHaveBeenCalled();
+    expect(alertsMock).not.toHaveBeenCalled();
+  });
+
+  it('passes resolved coordinates (not a name) to every sub-handler', async () => {
+    await callSummary({ latitude: 47.6, longitude: -122.3 });
+
+    const firstCallArgs = forecastMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(firstCallArgs.latitude).toBe(47.6);
+    expect(firstCallArgs.longitude).toBe(-122.3);
+    // location_name/city_name stripped so no sub-handler re-geocodes
+    expect(firstCallArgs.location_name).toBeUndefined();
+    expect(firstCallArgs.city_name).toBeUndefined();
+  });
+
+  it('degrades gracefully when a section fails', async () => {
+    alertsMock.mockRejectedValue(new Error('alerts unavailable outside the US'));
+
+    const result = await callSummary({ latitude: 48.85, longitude: 2.35 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('alerts (unavailable)');
+    expect(text).toContain('alerts unavailable outside the US');
+    // Other sections still render
+    expect(text).toContain('Current Weather Conditions');
+    expect(text).toContain('Weather Forecast');
+  });
+
+  it('rejects an invalid include entry', async () => {
+    await expect(
+      callSummary({ latitude: 47.6, longitude: -122.3, include: ['forecast', 'bogus'] })
+    ).rejects.toThrow(/invalid include/i);
+  });
+
+  it('falls back to defaults for an empty include array', async () => {
+    await callSummary({ latitude: 47.6, longitude: -122.3, include: [] });
+
+    expect(currentMock).toHaveBeenCalledTimes(1);
+    expect(forecastMock).toHaveBeenCalledTimes(1);
+    expect(alertsMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Brings `main` up to date with the `release/features-1.10.0` line. This is the accumulated release work that was staged on the release branch:

- **v1.8.3** — get_historical_weather header date-shift + observation-count fix
- **v1.9.0** — `city_name` parameter for `get_forecast` (geocode-on-demand)
- **v1.10.0** — imperial/metric unit localization (`WEATHER_UNITS`, per-call `units`)
- **v1.11.0** — universal location resolution across all tools, new `get_weather_summary` composite tool, `detail` output control, summary-first preset ladder, NOAA point/grid reuse, `search_location` Markdown escaping

Clean fast-forward of `main` (main is a strict ancestor). Full details in [CHANGELOG.md](https://github.com/weather-mcp/weather-mcp/blob/release/features-1.10.0/CHANGELOG.md).

**17 MCP tools · 1,149 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)