### PR TITLE
Release 1.11.1: geocoding, river sentinel & lightning pre-warm fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Startup pre-warming of lightning monitoring for saved locations** - Blitzortung strikes are only buffered for an area once it has been subscribed, so the first `get_lightning_activity` query for a location previously reported ~zero monitoring coverage. The server now subscribes each saved location's geohashes at startup (best-effort and non-blocking) so their coverage accumulates before the first query. Disable with `WEATHER_LIGHTNING_PREWARM=false` (also skipped automatically when the lightning tool is not enabled). The limited-coverage notice now explains *why* coverage can be low on a first lookup and that historical strikes cannot be backfilled.
+
+### Fixed
+- **`city_name` and low-limit `search_location` geocoding failed for valid US places** - The geocoding client serialized query spaces as `+` instead of RFC 3986 `%20`, and Nominatim returns zero matches for such `+`-encoded queries when only one result is requested. Because the on-demand `city_name` resolver requests a single result, every `city_name` lookup (e.g. `city_name="Clare, MI"`) — and any `search_location(..., limit=1)` — failed with "No locations found" even though the place exists. Query parameters are now percent-encoded (`%20`), and the geocoding service requests a small result floor internally before slicing to the caller's limit, so single-result lookups are no longer at the fragile boundary. (`src/services/geocoding.ts`)
+- **River forecast rendered NWPS placeholder sentinels literally** - `get_river_conditions` printed `-999.00 ft` / `-999.00 kcfs` and a year-0001 "Dec 31, 1" valid time for gauges whose forecast is not current. Missing-data sentinels (values `<= -900`) and implausible timestamps (year `< 2000`) are now detected: the `### Forecast` block is shown only when it carries at least one real value and a plausible time, and is otherwise suppressed. The same guard is applied to observed stage/flow. (`src/handlers/riverConditionsHandler.ts`)
+
 ## [1.11.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-07-13
+
 ### Added
 - **Startup pre-warming of lightning monitoring for saved locations** - Blitzortung strikes are only buffered for an area once it has been subscribed, so the first `get_lightning_activity` query for a location previously reported ~zero monitoring coverage. The server now subscribes each saved location's geohashes at startup (best-effort and non-blocking) so their coverage accumulates before the first query. Disable with `WEATHER_LIGHTNING_PREWARM=false` (also skipped automatically when the lightning tool is not enabled). The limited-coverage notice now explains *why* coverage can be low on a first lookup and that historical strikes cannot be backfilled.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This document provides context and guidelines for AI assistants (Claude, etc.) w
 **Weather MCP Server** is a Model Context Protocol (MCP) server providing weather data from NOAA and Open-Meteo APIs. It enables AI assistants to fetch real-time weather forecasts, current conditions, historical data, air quality, marine conditions, and severe weather alerts.
 
 - **Language:** TypeScript (Node.js)
-- **Version:** 1.11.0 (Production Ready)
+- **Version:** 1.11.1 (Production Ready)
 - **License:** MIT
 - **MCP SDK:** @modelcontextprotocol/sdk v1.21.0
 
@@ -551,13 +551,14 @@ npm audit             # No critical vulnerabilities
 
 ## Project Status
 
-- **Version:** 1.11.0
+- **Version:** 1.11.1
 - **Status:** Production Ready ✅
+- **New in v1.11.1:** Geocoding fix — `city_name`/`search_location` lookups no longer fail at low result limits (RFC 3986 `%20` encoding + result floor); river forecast no longer prints NWPS `-999`/year-0001 placeholder sentinels; lightning monitoring is pre-warmed for saved locations at startup (`WEATHER_LIGHTNING_PREWARM`)
 - **New in v1.11.0:** Universal location resolution (`location_name`/`city_name` on every location-based tool), `get_weather_summary` composite tool, `detail` output control (forecast/alerts/imagery), and a "summary-first" 6-tool default `basic` preset led by `get_weather_summary` (history, air quality, saved-location CRUD, and specialized tools live in `standard`/`full`)
 - **New in v1.10.0:** Unit localization — imperial/metric (plus per-unit overrides and 12h/24h) via `WEATHER_UNITS` env or a per-call `units` parameter on forecast/current/historical tools
 - **New in v1.9.0:** `city_name` parameter for `get_forecast` — request a forecast by free-text place name (geocoded on demand, with caching)
 - **Security Rating:** A- (Excellent, 93/100)
-- **Test Coverage:** 1,149 tests, 100% pass rate
+- **Test Coverage:** 1,165 tests, 100% pass rate
 - **Code Quality:** A+ (Excellent, 97.5/100)
 
 ## Useful References
@@ -580,6 +581,6 @@ npm audit             # No critical vulnerabilities
 
 ---
 
-**Last Updated:** 2026-07-13 (v1.11.0)
+**Last Updated:** 2026-07-13 (v1.11.1)
 
 This document should be updated whenever major architectural changes are made or new patterns are introduced.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,12 @@ CACHE_MAX_SIZE=1000            # Max cache entries (100-10000, default: 1000)
 # API Configuration
 API_TIMEOUT_MS=30000           # API timeout in milliseconds (5000-120000, default: 30000)
 
+# Lightning
+WEATHER_LIGHTNING_PREWARM=true # Subscribe saved locations at startup so lightning
+                               # coverage accumulates before the first query (default: true).
+                               # Set false to skip the startup MQTT connection. No effect
+                               # when get_lightning_activity is disabled.
+
 # Units / Localization (v1.10.0)
 WEATHER_UNITS=imperial         # imperial | metric (default: imperial)
 # Optional per-unit overrides (follow WEATHER_UNITS if unset):

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Supported on `get_forecast`, `get_current_conditions`, and `get_historical_weath
 | `CACHE_ENABLED` | `true` | Enable/disable response caching |
 | `CACHE_MAX_SIZE` | `1000` | Max cache entries (100–10000) |
 | `API_TIMEOUT_MS` | `30000` | Upstream API timeout (5000–120000) |
+| `WEATHER_LIGHTNING_PREWARM` | `true` | Subscribe saved locations' geohashes at startup so `get_lightning_activity` has coverage before the first query. Set `false` to skip this and avoid the persistent MQTT connection at startup. No effect when the lightning tool is disabled. |
 | `LOG_LEVEL` | `1` | 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR (logs go to stderr) |
 | `NCEI_API_TOKEN` | — | Optional [free NCEI token](https://www.ncdc.noaa.gov/cdo-web/token) for official NOAA climate normals (US); falls back to Open-Meteo automatically |
 

--- a/docs/development/BUG_REPORT_2026-07-13.md
+++ b/docs/development/BUG_REPORT_2026-07-13.md
@@ -1,0 +1,182 @@
+# Bug Report — Full-Tool Test Session (2026-07-13)
+
+**Server version:** 1.11.0
+**Branch:** `release/features-1.10.0`
+**Method:** Exercised all 17 MCP tools against live APIs, home base **Clare, MI**
+(43.8195, -84.7686), using off-location coordinates for marine / wildfire / lightning.
+
+**Summary:** 3 issues found, all addressed — 1 significant bug (city_name geocoding, fixed),
+1 display bug (river sentinels, fixed), 1 inherent data-availability limitation (lightning
+first-query coverage, mitigated via startup pre-warm + clearer messaging). All 17 tools
+return correct data on the coordinate and saved-`location_name` paths.
+
+**Status:** BUG-1 ✅ fixed · BUG-2 ✅ fixed · BUG-3 ✅ mitigated · 1,165 tests pass ·
+`dist/` rebuilt (restart to load).
+
+---
+
+## BUG-1 — `city_name` geocoding fails for US queries (limit=1) — ✅ FIXED
+
+**Severity:** High — the v1.11.0 "universal location resolution" `city_name` feature was
+fully non-functional for US places. Every `get_*` call using `city_name` failed.
+
+### Symptom
+```
+get_forecast(city_name="Clare, MI")      -> "No locations found matching "Clare, MI"."
+get_weather_summary(city_name="Detroit, Michigan") -> same error
+search_location(query="Clare, MI", limit=1)        -> same error   (limit=1 reproduces it)
+search_location(query="Clare, MI")                 -> OK           (default limit=5 masks it)
+```
+Error text: `Tried 3 provider(s): Census.gov: No results found; Nominatim: No results found; Open-Meteo: No results found`
+
+### Root cause
+Two interacting defects in `src/services/geocoding.ts`:
+
+1. **Space encoding.** Axios's default param serializer encodes spaces as `+`
+   (`q=Clare,+MI`) rather than RFC-3986 `%20` (`q=Clare%2C%20MI`).
+2. **Nominatim `+` / limit=1 quirk.** For a `+`-encoded query, Nominatim returns
+   **0 results at `limit=1`** but 2 results at `limit>=2`. With proper `%20` encoding,
+   `limit=1` correctly returns 1 result.
+
+The on-demand resolver hard-codes `geocode(cityName, 1)`
+(`src/utils/locationResolver.ts:238`), so `city_name` lookups always hit both landmines.
+`search_location`'s default `limit=5` accidentally avoided the second one, which is why
+that tool appeared to work while `city_name` did not — same underlying `GeocodingService`
+singleton (`src/index.ts:141`).
+
+### Ground truth captured during diagnosis
+```
+# Direct Nominatim, "+"-encoded query:
+q=Clare,+MI     limit=1 -> 0 results
+q=Clare,+MI     limit=2 -> 2 results
+# Direct Nominatim, %20-encoded query:
+q=Clare%2C%20MI limit=1 -> 1 result     <-- what the fix produces
+```
+
+### Fix (`src/services/geocoding.ts`)
+1. Added `rfc3986ParamsSerializer()` (spaces -> `%20`) and applied it as
+   `paramsSerializer` on all three provider axios clients (Census, Nominatim, Open-Meteo).
+   This is the true root-cause fix.
+2. Added a defensive result floor: `GeocodingService.geocode()` now requests
+   `Math.max(limit, PROVIDER_RESULT_FLOOR /* 5 */)` from providers and slices the result
+   down to the caller's `limit`, so no lookup is ever at the fragile upstream `limit=1`
+   boundary.
+
+### Verification
+- `GeocodingService.geocode("Clare, MI", 1)` -> Clare County (was: error) — against **live
+  Nominatim**.
+- `resolveLocationAsync({city_name:"Clare, MI"})` -> resolves + emits correct
+  `**Location:** Clare County, Michigan, United States (43.9689, -84.8505)` header.
+- Added `tests/unit/geocoding.test.ts` (6 tests: `%20` encoding, undefined/null omission,
+  limit=1 regression, floor=5 request, slice-to-limit, caller-limit > floor).
+- Full suite: **1,155 passed** (was 1,149). `npm run build` clean.
+
+### Post-fix note
+All four MCP instances launch from `.../weather-mcp/dist/index.js` (see workspace
+`.mcp.json`), so **restarting the Claude Code session relaunches them with the rebuilt,
+fixed code** — no npm publish required to test.
+
+---
+
+## BUG-2 — River forecast renders no-data sentinels literally — ✅ FIXED
+
+**Severity:** Low — cosmetic; current observations are correct, only the "no active
+forecast" case was ugly.
+
+**Symptom** (`get_river_conditions`, Clare 75 km radius): gauges with no current forecast
+printed raw sentinels instead of omitting the forecast:
+```
+### Forecast
+**Valid Time:** Dec 31, 1, 6:27 PM
+**Forecasted Stage:** -999.00 ft
+**Forecasted Flow:** -999.00 kcfs
+**Forecasted Category:** ⚪ FCST NOT CURRENT
+```
+`-999.00` is NWPS's missing-value sentinel and `Dec 31, 1` is a year-0001 placeholder
+timestamp. The handler's `!== null` guards let `-999` through and formatted the placeholder
+date literally.
+
+**Fix** (`src/handlers/riverConditionsHandler.ts`):
+- `isRealValue()` — treats `null`/`undefined`/non-finite and values `<= -900` (the NWPS
+  `-999`/`-999999` sentinels) as "no data". Replaces the `!== null` checks on both observed
+  and forecast stage/flow, and the flood-stage percentage calc.
+- `hasPlausibleValidTime()` — rejects unparseable times and any year `< 2000` (kills the
+  year-0001 placeholder).
+- `isUsableForecast()` — a forecast is rendered only if it has at least one real value AND a
+  plausible timestamp; otherwise the whole `### Forecast` block is suppressed.
+
+**Verification:** `tests/unit/riverConditions.test.ts` (8 tests covering sentinel values,
+year-0001 times, unparseable times, and the "one real value is enough" case). Full suite
+green.
+
+---
+
+## BUG-3 — Lightning reports 0.0-min live coverage on first query — ✅ MITIGATED
+
+**Severity:** Low / inherent limitation — output was already honest; the gap was missing
+coverage on first use and unclear "why".
+
+**Symptom** (`get_lightning_activity`, tried Clare and a Tampa FL summer afternoon):
+```
+## 🟢 Safety Status: SAFE (LIMITED DATA)
+**Monitoring Coverage:** 0.0 of N minutes ⚠️
+```
+
+**Root nature:** NOT a code defect. Blitzortung is a **real-time MQTT feed with no
+historical backfill** (`src/services/blitzortung.ts`). Strikes only buffer for an area
+*after* it is first subscribed (lazily, on first query), so a location's first lookup can
+never show more than the ~10 s post-subscribe wait — reported as 0.0-min coverage. Strikes
+cannot be retroactively fetched.
+
+**Mitigation applied (pre-warm + clearer messaging):**
+- `BlitzortungService.prewarmLocation()` — subscribes an area (no wait/read), best-effort,
+  swallows its own errors.
+- `prewarmLightningMonitoring()` in `src/index.ts` subscribes all **saved locations'**
+  geohashes at startup (non-blocking), so their coverage accumulates before the user asks.
+  Gated on the lightning tool being enabled; opt out with `WEATHER_LIGHTNING_PREWARM=false`.
+  Trade-off: keeps a persistent MQTT connection open from boot.
+- Handler now appends a "*Why:*" explainer making clear that near-zero coverage is expected
+  on a first query, that saved locations are pre-warmed, and that history cannot be
+  backfilled.
+
+**Still true after the fix:** a brand-new (non-saved) location's *first* query — and the
+first query immediately after a restart, before coverage accrues — will still show low/zero
+coverage. This is fundamental to the live feed. Verified via startup smoke test (server
+logs "Pre-warming lightning monitoring for saved locations" → connects → subscribes;
+stdout stays clean). Messaging locked by `tests/unit/lightningMessaging.test.ts`.
+
+**New env var:** `WEATHER_LIGHTNING_PREWARM` (default on) — set `false` to disable startup
+pre-warming and its always-on MQTT connection.
+
+---
+
+## Tools verified healthy (coordinate / `location_name` paths)
+
+`check_service_status`, `search_location` (limit>=2), `get_forecast`,
+`get_current_conditions` (+fire weather, +normals), `get_alerts` (live Heat Advisory),
+`get_weather_summary` (all 5 sections), `get_historical_weather`, `get_air_quality`,
+`get_marine_conditions`, `get_weather_imagery` (radar frames + GOES satellite),
+`get_river_conditions` (16 gauges; see BUG-2), `get_wildfire_info` (8 active CA fires),
+`save_location`, `list_saved_locations`, `get_saved_location`, `remove_saved_location`.
+After BUG-1's fix, all of these also work via `city_name`.
+
+---
+
+## How to verify after restarting the session
+All fixes ship in `dist/` (rebuilt); the four MCP instances relaunch `node dist/index.js`
+on restart.
+
+- **BUG-1 (city_name):** `get_forecast(city_name="Clare, MI")` → forecast with a
+  `**Location:** Clare County, Michigan, United States (...)` header, not an error. Also try
+  `get_weather_summary(city_name="Detroit, Michigan")` and `get_forecast(city_name="Paris, France")`.
+- **BUG-2 (river sentinels):** `get_river_conditions(location_name="home")` → gauges with no
+  real forecast should simply omit the `### Forecast` block; no `-999.00` or `Dec 31, 1`
+  anywhere.
+- **BUG-3 (lightning):** `get_lightning_activity(location_name="home")` → still expect
+  "LIMITED DATA" right after restart, but now with a "*Why:*" explainer. Coverage for saved
+  locations should climb on repeat queries a few minutes apart (pre-warm). Set
+  `WEATHER_LIGHTNING_PREWARM=false` to disable startup pre-warming.
+
+## Test suite
+1,165 tests pass (was 1,149; +16: geocoding 6, river 8, lightning messaging 2). `npm run
+build` clean.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dangahagan/weather-mcp",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "MCP server giving AI assistants 16 weather tools with zero API keys: global forecasts, current conditions, alerts, air quality, marine conditions, lightning detection, radar imagery, river levels, wildfire tracking, and historical weather back to 1940. Built entirely on free public APIs (NOAA, Open-Meteo, USGS, NIFC).",
   "mcpName": "io.github.dgahagan/weather-mcp",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.dgahagan/weather-mcp",
   "title": "Weather Data MCP Server",
   "description": "17 weather tools, no API keys: a one-call weather summary plus forecasts, alerts, air quality, marine, radar, lightning, wildfires.",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@dangahagan/weather-mcp",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/handlers/lightningHandler.ts
+++ b/src/handlers/lightningHandler.ts
@@ -323,6 +323,15 @@ export function formatLightningActivityResponse(response: LightningActivityRespo
       `Re-check in a few minutes or consult official weather services before making safety decisions.`
     );
     lines.push('');
+    // Explain WHY coverage is limited so a fresh/near-zero reading is not mistaken for
+    // verified calm — this is expected on a first query, not an error.
+    lines.push(
+      '*Why: lightning is monitored via a live feed that only begins buffering strikes once ' +
+      'an area is first queried, so a location’s first lookup starts near zero coverage and ' +
+      'builds over the following minutes. Saved locations are pre-warmed at startup. Historical ' +
+      'strikes cannot be backfilled.*'
+    );
+    lines.push('');
   }
 
   // Recommendations

--- a/src/handlers/riverConditionsHandler.ts
+++ b/src/handlers/riverConditionsHandler.ts
@@ -8,7 +8,42 @@ import { GeocodingService } from '../services/geocoding.js';
 import { resolveLocationAsync, prependLocationLine } from '../utils/locationResolver.js';
 import { formatInTimezone, guessTimezoneFromCoords } from '../utils/timezone.js';
 import { calculateDistance } from '../utils/distance.js';
-import type { NWPSGauge } from '../types/noaa.js';
+import type { NWPSGauge, GaugeStatus } from '../types/noaa.js';
+
+/**
+ * NWPS emits large negative sentinels (e.g. -999, -999999) for missing stage/flow
+ * values. Any real river stage or flow is well above this threshold, so treat values
+ * at or below it as "no data".
+ */
+const NWPS_SENTINEL_THRESHOLD = -900;
+
+/**
+ * True only for a real, present numeric reading (not null, not a missing-data sentinel).
+ */
+export function isRealValue(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > NWPS_SENTINEL_THRESHOLD;
+}
+
+/**
+ * True when a gauge's validTime is a real, plausible timestamp. NWPS uses a year-0001
+ * placeholder (renders as "Dec 31, 1") for stale/absent forecasts, so reject anything
+ * that fails to parse or predates 2000.
+ */
+function hasPlausibleValidTime(validTime: string | undefined): boolean {
+  if (!validTime) return false;
+  const parsed = Date.parse(validTime);
+  if (Number.isNaN(parsed)) return false;
+  return new Date(parsed).getUTCFullYear() >= 2000;
+}
+
+/**
+ * A forecast is worth displaying only if it carries at least one real value AND a
+ * plausible timestamp. Otherwise NWPS is returning a placeholder (-999 values, year-0001
+ * time, "fcst_not_current" category) that should be suppressed rather than rendered raw.
+ */
+export function isUsableForecast(status: GaugeStatus): boolean {
+  return (isRealValue(status.primary) || isRealValue(status.secondary)) && hasPlausibleValidTime(status.validTime);
+}
 
 interface RiverConditionsArgs {
   latitude?: number;
@@ -128,11 +163,11 @@ function formatGaugeDetails(gauge: NWPSGauge, distance: number, timezone: string
     output += `### Current Conditions\n`;
     output += `**Observed:** ${formatInTimezone(obs.validTime, timezone)}\n`;
 
-    if (obs.primary !== null) {
+    if (isRealValue(obs.primary)) {
       output += `**River Stage:** ${obs.primary.toFixed(2)} ft\n`;
     }
 
-    if (obs.secondary !== null) {
+    if (isRealValue(obs.secondary)) {
       output += `**Flow Rate:** ${obs.secondary.toFixed(2)} kcfs (${(obs.secondary * 1000).toFixed(0)} cfs)\n`;
     }
 
@@ -155,24 +190,25 @@ function formatGaugeDetails(gauge: NWPSGauge, distance: number, timezone: string
     output += `**Major Flood:** ${cat.major.toFixed(1)} ft\n\n`;
 
     // Show stage relative to flood levels if we have current stage
-    if (gauge.status.observed?.primary !== null && gauge.status.observed?.primary !== undefined) {
+    if (isRealValue(gauge.status.observed?.primary)) {
       const currentStage = gauge.status.observed.primary;
       const pctToAction = ((currentStage / cat.action) * 100).toFixed(0);
       output += `**Current stage is ${pctToAction}% of action stage**\n\n`;
     }
   }
 
-  // Forecast (if available)
-  if (gauge.status.forecast) {
+  // Forecast (only when NWPS returns a real, current forecast — placeholder rows with
+  // -999 values and a year-0001 validTime are suppressed rather than rendered raw).
+  if (gauge.status.forecast && isUsableForecast(gauge.status.forecast)) {
     const forecast = gauge.status.forecast;
     output += `### Forecast\n`;
     output += `**Valid Time:** ${formatInTimezone(forecast.validTime, timezone)}\n`;
 
-    if (forecast.primary !== null) {
+    if (isRealValue(forecast.primary)) {
       output += `**Forecasted Stage:** ${forecast.primary.toFixed(2)} ft\n`;
     }
 
-    if (forecast.secondary !== null) {
+    if (isRealValue(forecast.secondary)) {
       output += `**Forecasted Flow:** ${forecast.secondary.toFixed(2)} kcfs\n`;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { NCEIService } from './services/ncei.js';
 import { NIFCService } from './services/nifc.js';
 import { GeocodingService } from './services/geocoding.js';
 import { LocationStore } from './services/locationStore.js';
+import { blitzortungService } from './services/blitzortung.js';
 import { CacheConfig } from './config/cache.js';
 import { toolConfig } from './config/tools.js';
 import { logger } from './utils/logger.js';
@@ -784,6 +785,39 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 /**
  * Start the server
  */
+/**
+ * Pre-warm live lightning monitoring for saved locations at startup.
+ *
+ * The Blitzortung feed only buffers strikes for an area once it is subscribed, so the
+ * first query to a location otherwise reports zero monitoring coverage. Subscribing
+ * saved locations at startup lets their coverage accumulate before the user asks.
+ * Best-effort and fully non-blocking: it opens a persistent MQTT connection, so it is
+ * skipped when the lightning tool is disabled or when WEATHER_LIGHTNING_PREWARM=false.
+ */
+function prewarmLightningMonitoring(): void {
+  if (process.env.WEATHER_LIGHTNING_PREWARM === 'false') {
+    return;
+  }
+  if (!toolConfig.isEnabled('get_lightning_activity')) {
+    return;
+  }
+
+  const savedLocations = Object.values(locationStore.getAll());
+  if (savedLocations.length === 0) {
+    return;
+  }
+
+  logger.info('Pre-warming lightning monitoring for saved locations', {
+    count: savedLocations.length
+  });
+
+  // Fire-and-forget: prewarmLocation swallows its own errors and must never block
+  // startup or the stdio transport.
+  for (const location of savedLocations) {
+    void blitzortungService.prewarmLocation(location.latitude, location.longitude);
+  }
+}
+
 async function main() {
   const transport = new StdioServerTransport();
 
@@ -824,6 +858,10 @@ async function main() {
       enabledTools: toolConfig.getEnabledTools().length,
       toolList: toolConfig.getEnabledTools().join(', ')
     });
+
+    // Begin buffering lightning strikes for saved locations so their coverage
+    // accumulates before the first query (non-blocking, best-effort).
+    prewarmLightningMonitoring();
 
     // Inform users about version and upgrade options
     logger.info('Version check', {

--- a/src/services/blitzortung.ts
+++ b/src/services/blitzortung.ts
@@ -489,6 +489,34 @@ export class BlitzortungService {
   }
 
   /**
+   * Begin buffering strikes for a location without waiting for or returning results.
+   *
+   * Subscribes the area's geohashes so the rolling buffer starts filling immediately.
+   * Intended for startup pre-warming of known locations (e.g. saved locations) so that
+   * later queries have real monitoring coverage instead of starting from zero. Best-effort:
+   * failures are swallowed and must never block or crash startup.
+   */
+  async prewarmLocation(
+    latitude: number,
+    longitude: number,
+    radiusKm: number = 100
+  ): Promise<void> {
+    try {
+      await this.subscribeToLocation(latitude, longitude, radiusKm);
+      const redacted = redactCoordinatesForLogging(latitude, longitude);
+      logger.info('Pre-warmed lightning monitoring for location', {
+        latitude: redacted.lat,
+        longitude: redacted.lon,
+        radiusKm
+      });
+    } catch (error) {
+      logger.warn('Failed to pre-warm lightning monitoring for location', {
+        error: (error as Error).message
+      });
+    }
+  }
+
+  /**
    * Get the moment from which the entire queried area has been continuously
    * monitored, or null if any part of it is not currently subscribed (or the
    * broker is disconnected). Callers use this to detect that a "0 strikes"

--- a/src/services/geocoding.ts
+++ b/src/services/geocoding.ts
@@ -9,6 +9,31 @@ import { DataNotFoundError, RateLimitError, ServiceUnavailableError } from '../e
 import { logger } from '../utils/logger.js';
 
 /**
+ * Serialize query parameters using RFC 3986 percent-encoding (spaces -> %20).
+ *
+ * Axios's default serializer encodes spaces as "+" (application/x-www-form-urlencoded
+ * style). Nominatim treats such "+"-encoded queries inconsistently — notably it can
+ * return ZERO matches at limit=1 for a query that returns matches with %20 encoding
+ * (e.g. "Clare, MI"). Forcing %20 keeps geocoding results stable across providers and
+ * result limits. Shared by every provider client below.
+ */
+export function rfc3986ParamsSerializer(params: Record<string, unknown>): string {
+  return Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join('&');
+}
+
+/**
+ * Minimum number of results requested from an upstream provider, regardless of the
+ * caller's requested limit. Some providers (Nominatim in particular) rank or de-duplicate
+ * unreliably when asked for a single result, so we always request a small floor and then
+ * slice down to the caller's limit. Prevents fragile limit=1 lookups (e.g. the on-demand
+ * city_name resolver) from spuriously returning "no results".
+ */
+const PROVIDER_RESULT_FLOOR = 5;
+
+/**
  * Geocoding result with standardized format across all providers
  */
 export interface GeocodingResult {
@@ -77,7 +102,8 @@ class CensusGovProvider implements GeocodingProvider {
       timeout: 10000,
       headers: {
         'Accept': 'application/json'
-      }
+      },
+      paramsSerializer: { serialize: rfc3986ParamsSerializer }
     });
 
     // Rate limit to 5 requests/second to be respectful
@@ -167,7 +193,8 @@ class NominatimProvider implements GeocodingProvider {
       headers: {
         'User-Agent': '(weather-mcp, github.com/weather-mcp/weather-mcp)',
         'Accept': 'application/json'
-      }
+      },
+      paramsSerializer: { serialize: rfc3986ParamsSerializer }
     });
 
     // Strict 1 request/second rate limit as per Nominatim usage policy
@@ -273,7 +300,8 @@ class OpenMeteoProvider implements GeocodingProvider {
       timeout: 10000,
       headers: {
         'Accept': 'application/json'
-      }
+      },
+      paramsSerializer: { serialize: rfc3986ParamsSerializer }
     });
   }
 
@@ -426,15 +454,19 @@ export class GeocodingService {
 
     const errors: string[] = [];
 
+    // Always request at least PROVIDER_RESULT_FLOOR from upstream (providers rank
+    // unreliably at limit=1), then slice to the caller's requested limit.
+    const providerLimit = Math.max(limit, PROVIDER_RESULT_FLOOR);
+
     // Try each provider in order
     for (const provider of providers) {
       try {
         logger.debug(`Trying provider: ${provider.name}`);
-        const results = await provider.geocode(query, limit);
+        const results = await provider.geocode(query, providerLimit);
 
         if (results.length > 0) {
           logger.info(`Geocoding successful via ${provider.name}: ${results.length} result(s)`);
-          return results;
+          return results.slice(0, limit);
         }
 
         logger.debug(`${provider.name}: No results found`);

--- a/tests/unit/geocoding.test.ts
+++ b/tests/unit/geocoding.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the multi-service GeocodingService.
+ *
+ * Regression coverage for the limit=1 geocoding failure: axios encoded spaces as
+ * "+", and Nominatim returned zero matches for such "+"-encoded queries at limit=1
+ * (e.g. "Clare, MI"). Every city_name lookup (which requests limit=1) therefore
+ * failed. The fix forces RFC 3986 (%20) encoding AND requests a result floor from
+ * upstream providers before slicing to the caller's limit.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted so the vi.mock factory can reference it safely.
+const { getMock } = vi.hoisted(() => ({ getMock: vi.fn() }));
+
+vi.mock('axios', () => {
+  // Each created client routes .get() through the shared mock, tagged with its
+  // baseURL so a test can tell the three providers apart.
+  const create = vi.fn((config: { baseURL?: string }) => ({
+    get: (path: string, opts: unknown) => getMock(config?.baseURL, path, opts),
+  }));
+  return {
+    default: { create, isAxiosError: () => false },
+    isAxiosError: () => false,
+  };
+});
+
+import { GeocodingService, rfc3986ParamsSerializer } from '../../src/services/geocoding.js';
+
+/** Build N Nominatim-shaped rows. */
+function nominatimRows(n: number): unknown[] {
+  return Array.from({ length: n }, (_, i) => ({
+    place_id: i,
+    lat: `43.${i}`,
+    lon: `-84.${i}`,
+    name: `Result ${i}`,
+    display_name: `Result ${i}, Michigan, United States`,
+    importance: 0.5,
+    type: 'administrative',
+    address: {},
+  }));
+}
+
+/**
+ * Route provider requests by baseURL: Census returns empty, Nominatim returns
+ * `nominatimCount` rows, Open-Meteo returns empty. Mirrors a US query where
+ * Nominatim is the winning provider.
+ */
+function routeProviders(nominatimCount: number): void {
+  getMock.mockImplementation(async (baseURL: string, _path: string) => {
+    if (baseURL.includes('census')) return { data: { result: { addressMatches: [] } } };
+    if (baseURL.includes('nominatim')) return { data: nominatimRows(nominatimCount) };
+    if (baseURL.includes('open-meteo')) return { data: { results: [] } };
+    return { data: [] };
+  });
+}
+
+describe('rfc3986ParamsSerializer', () => {
+  it('encodes spaces as %20 (not +) and commas as %2C', () => {
+    // The exact bug: axios default "+" encoding made Nominatim drop limit=1 matches.
+    expect(rfc3986ParamsSerializer({ q: 'Clare, MI' })).toBe('q=Clare%2C%20MI');
+  });
+
+  it('serializes multiple params and omits undefined/null values', () => {
+    const out = rfc3986ParamsSerializer({ q: 'Bend, OR', limit: 5, extra: undefined, other: null });
+    expect(out).toBe('q=Bend%2C%20OR&limit=5');
+  });
+});
+
+describe('GeocodingService.geocode', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('returns a result for a limit=1 US query (regression: city_name lookups)', async () => {
+    routeProviders(2);
+    const service = new GeocodingService();
+
+    const results = await service.geocode('Clare, MI', 1);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.source).toBe('nominatim');
+  });
+
+  it('requests a result floor of 5 from providers even when the caller asks for 1', async () => {
+    routeProviders(2);
+    const service = new GeocodingService();
+
+    await service.geocode('Clare, MI', 1);
+
+    const nominatimCall = getMock.mock.calls.find((c) => String(c[0]).includes('nominatim'));
+    expect(nominatimCall).toBeDefined();
+    expect((nominatimCall?.[2] as { params: { limit: number } }).params.limit).toBe(5);
+  });
+
+  it('slices provider results down to the caller-requested limit', async () => {
+    routeProviders(5);
+    const service = new GeocodingService();
+
+    const results = await service.geocode('Clare, MI', 2);
+
+    expect(results).toHaveLength(2);
+  });
+
+  it('honors a caller limit larger than the floor', async () => {
+    routeProviders(9);
+    const service = new GeocodingService();
+
+    const results = await service.geocode('Clare, MI', 8);
+
+    const nominatimCall = getMock.mock.calls.find((c) => String(c[0]).includes('nominatim'));
+    expect((nominatimCall?.[2] as { params: { limit: number } }).params.limit).toBe(8);
+    expect(results).toHaveLength(8);
+  });
+});

--- a/tests/unit/lightningMessaging.test.ts
+++ b/tests/unit/lightningMessaging.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for lightning limited-coverage messaging (BUG-3, 2026-07-13).
+ *
+ * A first query to a fresh area reports near-zero monitoring coverage because the live
+ * Blitzortung feed only buffers strikes after subscription. The output must clearly flag
+ * this ("LIMITED DATA") and explain why, so a near-zero reading is not mistaken for
+ * verified calm.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatLightningActivityResponse } from '../../src/handlers/lightningHandler.js';
+import type { LightningActivityResponse } from '../../src/types/lightning.js';
+
+function baseResponse(overrides: Partial<LightningActivityResponse> = {}): LightningActivityResponse {
+  const now = new Date('2026-07-13T15:30:00Z');
+  return {
+    location: { latitude: 43.8195, longitude: -84.7686 },
+    searchRadius: 100,
+    timeWindow: 60,
+    searchPeriod: { start: new Date(now.getTime() - 60 * 60 * 1000), end: now },
+    strikes: [],
+    statistics: {
+      totalStrikes: 0,
+      cloudToGroundStrikes: 0,
+      intraCloudStrikes: 0,
+      averageDistance: 0,
+      nearestDistance: 0,
+      strikesPerMinute: 0,
+      densityPerSqKm: 0,
+    },
+    safety: {
+      level: 'safe',
+      message:
+        'No lightning strikes observed during the limited monitoring period. ' +
+        'This does NOT confirm the absence of lightning activity.',
+      recommendations: [],
+      nearestStrikeDistance: null,
+      nearestStrikeTime: null,
+      isActiveThunderstorm: false,
+    },
+    coverage: { monitoringSince: null, coverageMinutes: 0, isComplete: false },
+    source: 'Blitzortung.org',
+    generatedAt: now,
+    disclaimer: 'test disclaimer',
+    ...overrides,
+  };
+}
+
+describe('formatLightningActivityResponse — limited-coverage messaging', () => {
+  it('flags LIMITED DATA and explains why on incomplete coverage', () => {
+    const out = formatLightningActivityResponse(baseResponse());
+
+    expect(out).toContain('(LIMITED DATA)');
+    expect(out).toContain('Limited monitoring coverage');
+    expect(out).toContain('Why:');
+    expect(out).toContain('pre-warmed at startup');
+    expect(out).toContain('cannot be backfilled');
+  });
+
+  it('omits the limited-data explainer when coverage is complete', () => {
+    const out = formatLightningActivityResponse(
+      baseResponse({
+        coverage: {
+          monitoringSince: new Date('2026-07-13T14:00:00Z'),
+          coverageMinutes: 60,
+          isComplete: true,
+        },
+      }),
+    );
+
+    expect(out).not.toContain('(LIMITED DATA)');
+    expect(out).not.toContain('Limited monitoring coverage');
+    expect(out).not.toContain('Why:');
+  });
+});

--- a/tests/unit/riverConditions.test.ts
+++ b/tests/unit/riverConditions.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for river-conditions sentinel handling.
+ *
+ * Regression coverage for BUG-2 (2026-07-13): NWPS returns placeholder forecast rows
+ * with -999 stage/flow values and a year-0001 validTime (rendered as "Dec 31, 1"),
+ * and a "fcst_not_current" category. These must be suppressed, not printed raw.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isRealValue, isUsableForecast } from '../../src/handlers/riverConditionsHandler.js';
+import type { GaugeStatus } from '../../src/types/noaa.js';
+
+function status(overrides: Partial<GaugeStatus> = {}): GaugeStatus {
+  return {
+    primary: 4.2,
+    secondary: 0.05,
+    floodCategory: 'no_flooding',
+    validTime: '2026-07-13T14:15:00Z',
+    ...overrides,
+  };
+}
+
+describe('isRealValue', () => {
+  it('accepts real numeric readings', () => {
+    expect(isRealValue(4.2)).toBe(true);
+    expect(isRealValue(0)).toBe(true);
+    expect(isRealValue(-5)).toBe(true); // plausible low stage, not a sentinel
+  });
+
+  it('rejects null/undefined and NWPS missing-data sentinels', () => {
+    expect(isRealValue(null)).toBe(false);
+    expect(isRealValue(undefined)).toBe(false);
+    expect(isRealValue(-999)).toBe(false);
+    expect(isRealValue(-999999)).toBe(false);
+    expect(isRealValue(NaN)).toBe(false);
+    expect(isRealValue(Infinity)).toBe(false);
+  });
+});
+
+describe('isUsableForecast', () => {
+  it('accepts a forecast with real values and a current timestamp', () => {
+    expect(isUsableForecast(status())).toBe(true);
+  });
+
+  it('rejects the NWPS placeholder forecast (-999 values + year-0001 time)', () => {
+    expect(
+      isUsableForecast(status({ primary: -999, secondary: -999, validTime: '0001-12-31T18:27:00Z' })),
+    ).toBe(false);
+  });
+
+  it('rejects a forecast whose values are real but timestamp is a year-0001 placeholder', () => {
+    expect(isUsableForecast(status({ validTime: '0001-12-31T18:27:00Z' }))).toBe(false);
+  });
+
+  it('rejects a forecast with a valid time but only sentinel values', () => {
+    expect(isUsableForecast(status({ primary: -999, secondary: -999 }))).toBe(false);
+  });
+
+  it('rejects an unparseable validTime', () => {
+    expect(isUsableForecast(status({ validTime: 'not-a-date' }))).toBe(false);
+  });
+
+  it('accepts when at least one of stage/flow is real', () => {
+    expect(isUsableForecast(status({ primary: -999, secondary: 0.17 }))).toBe(true);
+  });
+});


### PR DESCRIPTION
Bug-fix patch release cutting **1.11.1**. Found via a full 17-tool test session (home base Clare, MI); details in `docs/development/BUG_REPORT_2026-07-13.md`.

## Fixes
- **Geocoding failed for valid US places at low result limits** (`fix`). The client encoded query spaces as `+` instead of RFC 3986 `%20`, and Nominatim returns zero matches for such queries when only one result is requested — so every on-demand `city_name` lookup and any `search_location(..., limit=1)` failed with "No locations found" (e.g. `city_name="Clare, MI"`). Now percent-encodes params (`%20`) and requests a small result floor before slicing to the caller's limit. (`src/services/geocoding.ts`)
- **River forecast printed NWPS placeholder sentinels** (`fix`). `get_river_conditions` rendered `-999.00 ft` / `-999.00 kcfs` and a year-0001 "Dec 31, 1" time for gauges without a current forecast. Sentinels (`<= -900`) and implausible timestamps (year `< 2000`) are now detected; the Forecast block is shown only with a real value + plausible time, else suppressed. (`src/handlers/riverConditionsHandler.ts`)
- **Lightning reported ~zero coverage on first query** (`feat`). Strikes only buffer once an area is subscribed. Saved locations' geohashes are now pre-warmed at startup (best-effort, non-blocking) so coverage accumulates before the first query; opt out with `WEATHER_LIGHTNING_PREWARM=false`. The limited-coverage notice now explains why coverage can be low and that history can't be backfilled. (`src/index.ts`, `src/services/blitzortung.ts`, `src/handlers/lightningHandler.ts`)

## Release prep
- `package.json` + `server.json` (server + npm package) bumped to **1.11.1**, kept in sync for the publish workflow's version check.
- CHANGELOG `[1.11.1]`; README + CLAUDE.md document `WEATHER_LIGHTNING_PREWARM`.

## Verification
- **1,165 tests pass** (+16: geocoding 6, river 8, lightning messaging 2), build clean.
- All three fixes confirmed live against the running MCP server after a session restart, including the exact original repro `search_location("Clare, MI", limit=1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)