### PR TITLE
ci: Bump checkout & setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
       contents: read
       id-token: write # npm provenance attestation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
The v1.11.1 publish run flagged a deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`.

Bumps both to `@v5`, which target the Node 24 runtime natively, clearing the warning.

## Changes
- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`

No behavior change: `setup-node` keeps `node-version: 22`, the npm registry URL, and the OIDC/provenance publishing config. `publish.yml` is the only workflow and these were its only Node-20 actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)