### PR TITLE
fix: correct NAM grid lookup and Central US timezone mis-bucketing

### DIFF
--- a/docs/APPLICATION_FLOW.md
+++ b/docs/APPLICATION_FLOW.md
@@ -1,0 +1,264 @@
+# Application Flow
+
+This document explains how the Weather MCP Server works internally, from startup through request execution and graceful shutdown.
+
+## 1. High-Level Overview
+
+The server is a Model Context Protocol (MCP) application that exposes weather tools over stdio transport.
+
+At runtime, the flow is:
+
+1. Initialize services and configuration.
+2. Register enabled tools and request handlers with MCP SDK.
+3. Receive tool calls from an MCP client.
+4. Route to a specific handler.
+5. Call one or more services (NOAA, Open-Meteo, Nominatim, etc.).
+6. Format a text response and return it through MCP.
+7. Track analytics and log structured events.
+
+Primary entrypoint: `src/index.ts`.
+
+## 2. Startup Sequence
+
+On process start, `src/index.ts` performs the following:
+
+1. Loads environment variables via `dotenv/config`.
+2. Reads package version from `package.json`.
+3. Instantiates core services:
+   - `NOAAService`
+   - `OpenMeteoService`
+   - `NOMADSService`
+   - `ModelComparisonService`
+   - `NominatimService`
+   - `NCEIService`
+   - `NIFCService`
+   - `GeocodingService`
+   - `LocationStore`
+4. Creates MCP server instance via `new Server(...)`.
+5. Defines all tool schemas in `TOOL_DEFINITIONS`.
+6. Registers `ListToolsRequestSchema` and `CallToolRequestSchema` handlers.
+7. Connects the server to `StdioServerTransport`.
+
+## 3. Tool Exposure and Configuration
+
+Tool exposure is dynamic and controlled by `ENABLED_TOOLS` in `src/config/tools.ts`.
+
+- Default preset: `basic`
+- Presets: `basic`, `standard`, `full`, `all`
+- Supports explicit include/exclude syntax (for example: `basic,+air_quality,-alerts`)
+- Supports short aliases (`forecast`, `current`, `aqi`, `marine`, etc.)
+
+At list-tools time, only enabled tool definitions are returned to the client.
+
+## 4. Request Lifecycle
+
+Every MCP tool call follows the same pipeline.
+
+1. MCP client sends a `CallTool` request.
+2. `src/index.ts` receives request in `server.setRequestHandler(CallToolRequestSchema, ...)`.
+3. `name` and `arguments` are extracted.
+4. `switch (name)` routes to the matching tool case.
+5. The tool execution is wrapped in `withAnalytics(...)` from `src/analytics/middleware.ts`.
+6. A handler is called (for example `handleGetForecast(...)`).
+7. Handler validates input, resolves location, calls downstream services, and formats output text.
+8. Handler returns MCP response payload:
+   - `content: [{ type: 'text', text: '...' }]`
+9. If an exception occurs:
+   - arguments are redacted for logs
+   - error is logged with structured metadata
+   - `formatErrorForUser(...)` creates user-safe message
+   - response is returned with `isError: true`
+
+## 5. Architecture Layers
+
+## 5.1 MCP Server Layer
+
+Location: `src/index.ts`
+
+Responsibilities:
+
+- Define tool schemas (`TOOL_DEFINITIONS`)
+- Return enabled tools (`ListToolsRequestSchema`)
+- Route calls to handlers (`CallToolRequestSchema`)
+- Wrap calls with analytics
+- Perform graceful shutdown
+
+## 5.2 Handler Layer
+
+Location: `src/handlers/`
+
+Responsibilities:
+
+- Parse and validate tool arguments
+- Orchestrate service calls
+- Apply formatting and display rules
+- Return MCP text content
+
+Pattern: one handler per MCP tool.
+
+## 5.3 Service Layer
+
+Location: `src/services/`
+
+Responsibilities:
+
+- External API communication
+- Retry/backoff and timeout behavior
+- Service-specific error mapping
+- Caching of API results where appropriate
+
+Examples:
+
+- `NOAAService` for US forecasts, alerts, current conditions, and river data.
+- `OpenMeteoService` for global forecast/historical/marine/air quality data.
+- `NOMADSService` for GFS and NAM deterministic model-run forecasts.
+- `ModelComparisonService` for side-by-side GFS/NAM/ECMWF-proxy daily alignment.
+- `NominatimService` and `GeocodingService` for location search.
+- `LocationStore` for saved-location persistence.
+
+## 5.4 Utilities and Error Model
+
+Locations:
+
+- `src/utils/`
+- `src/errors/ApiError.ts`
+
+Responsibilities:
+
+- Coordinate and argument validation
+- Unit conversions and formatting helpers
+- Caching infrastructure and TTL policy
+- Typed error hierarchy and sanitization
+
+## 5.5 Analytics Layer
+
+Location: `src/analytics/`
+
+`withAnalytics(...)` wraps each tool call and records:
+
+- success or error status
+- response time
+- categorized error type (validation, not_found, rate_limit, timeout, etc.)
+
+Analytics failure does not replace tool behavior; handler errors are still re-thrown and processed by normal error handling.
+
+## 6. Data Source Selection
+
+Some handlers choose services dynamically.
+
+Example: `get_forecast` in `src/handlers/forecastHandler.ts`:
+
+- If `source=auto`, it checks if coordinates are in US bounds.
+- US coordinates use NOAA.
+- Non-US coordinates use Open-Meteo.
+- Explicit `source=noaa|openmeteo` overrides auto mode.
+
+This keeps one tool interface while optimizing regional data quality.
+
+## 7. Saved Locations Flow
+
+Saved locations are persisted to:
+
+- `~/.weather-mcp/locations.json`
+
+Key components:
+
+- Storage service: `src/services/locationStore.ts`
+- Resolver utility: `src/utils/locationResolver.ts`
+
+Resolution behavior:
+
+1. If `location_name` is provided, resolve alias (and alternate names).
+2. Otherwise, require valid `latitude` and `longitude`.
+3. Return normalized coordinates to the handler.
+
+`LocationStore` uses in-memory cache plus synchronous file I/O for deterministic persistence behavior.
+
+## 8. Caching and Performance
+
+Cache policy is defined in `src/config/cache.ts` and implemented by `src/utils/cache.ts`.
+
+Highlights:
+
+- LRU cache with configurable max size.
+- TTL values based on data volatility:
+  - Forecast: 2 hours
+  - Current conditions: 15 minutes
+  - Alerts: 5 minutes
+  - Grid coordinates: Infinity
+  - Historical older data: Infinity
+- `CACHE_ENABLED` can disable caching globally.
+- `API_TIMEOUT_MS` and `CACHE_MAX_SIZE` are validated with bounds.
+
+## 9. Error Handling and Reliability
+
+Errors are modeled through typed classes in `src/errors/ApiError.ts`:
+
+- `RateLimitError`
+- `ServiceUnavailableError`
+- `InvalidLocationError`
+- `DataNotFoundError`
+- `ValidationError`
+
+Response behavior:
+
+1. Service/handler throws typed error.
+2. Top-level request handler catches it.
+3. Sensitive fields in args are redacted for logs.
+4. `formatErrorForUser(...)` sanitizes output.
+5. MCP response returns safe text with `isError: true`.
+
+Retry behavior is implemented in service clients (for example `NOAAService.makeRequest(...)`) using exponential backoff with jitter.
+
+## 10. Logging and Observability
+
+Structured logging is centralized in `src/utils/logger.ts`.
+
+Important MCP rule:
+
+- Logs must go to stderr (`console.error`) so stdout remains reserved for MCP protocol traffic.
+
+Logs include timestamp, level, message, optional context, error details, and metadata.
+
+## 11. Graceful Shutdown
+
+`src/index.ts` registers signal handlers for:
+
+- `SIGTERM`
+- `SIGINT`
+
+Shutdown order:
+
+1. Flush analytics (`analytics.shutdown()`).
+2. Clear service caches.
+3. Close MCP server.
+4. Exit process.
+
+This minimizes lost analytics events and leaves resources in a clean state.
+
+## 12. End-to-End Example (Forecast)
+
+A typical `get_forecast` request path:
+
+1. Client calls `get_forecast` with `location_name` or coordinates.
+2. `CallToolRequestSchema` routes to `handleGetForecast(...)` under `withAnalytics(...)`.
+3. Handler resolves location via `resolveLocation(...)`.
+4. Handler validates options (`days`, `granularity`, booleans).
+5. Handler selects NOAA or Open-Meteo path.
+6. Service call returns raw weather data.
+7. Handler formats weather into readable markdown-style text.
+8. MCP returns `content` with one text block.
+9. Analytics records response time and outcome.
+
+## 13. Contributor Quick Trace
+
+To trace behavior quickly:
+
+1. Start at `src/index.ts` (`ListToolsRequestSchema`, `CallToolRequestSchema`).
+2. Follow a single tool case to its handler in `src/handlers/`.
+3. Follow service calls in `src/services/`.
+4. Check utilities used by that handler in `src/utils/`.
+5. Review error classes in `src/errors/ApiError.ts`.
+6. Review analytics wrapper in `src/analytics/middleware.ts`.
+
+This path is the fastest way to understand any tool end to end.

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ This directory contains comprehensive documentation for the Weather MCP Server p
 - **[MCP_BEST_PRACTICES.md](./MCP_BEST_PRACTICES.md)** - Guide for service status communication
 
 ### 📁 Technical Documentation
+- **[APPLICATION_FLOW.md](./APPLICATION_FLOW.md)** - End-to-end runtime architecture and request lifecycle
 - **[NOAA_API_RESEARCH.md](./NOAA_API_RESEARCH.md)** - NOAA API research and integration details
 - **[HISTORICAL_DATA_PLAN.md](./HISTORICAL_DATA_PLAN.md)** - Historical weather data implementation plan
 - **[PROJECT_STATUS.md](./PROJECT_STATUS.md)** - Current project status
@@ -70,6 +71,7 @@ This directory contains comprehensive documentation for the Weather MCP Server p
 
 ### For Contributors
 - [Contributing Guidelines](../CONTRIBUTING.md)
+- [Application Flow](./APPLICATION_FLOW.md)
 - [Code Review](./development/CODE_REVIEW.md)
 - [Security Policy](../SECURITY.md)
 - [Development Plan](./planning/IMPLEMENTATION_PLAN.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
+        "@mattnucc/gribberish": "^0.30.1",
         "@modelcontextprotocol/sdk": "^1.21.1",
         "axios": "^1.13.1",
         "dotenv": "^17.2.3",
@@ -99,6 +100,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -571,6 +582,102 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mattnucc/gribberish": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mattnucc/gribberish/-/gribberish-0.30.1.tgz",
+      "integrity": "sha512-JR1vLdTOC3615p3YJUbdGCFpgZDTyU1dXW2oSzi4Qz4wdXpGYhb2SZqJI/SRjAuPO0EBTtDKEmi6/6NXJFE/EA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      },
+      "optionalDependencies": {
+        "@mattnucc/gribberish-darwin-arm64": "0.30.1",
+        "@mattnucc/gribberish-darwin-x64": "0.30.1",
+        "@mattnucc/gribberish-linux-x64-gnu": "0.30.1",
+        "@mattnucc/gribberish-wasm32-wasi": "0.30.1",
+        "@mattnucc/gribberish-win32-x64-msvc": "0.30.1"
+      }
+    },
+    "node_modules/@mattnucc/gribberish-darwin-arm64": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mattnucc/gribberish-darwin-arm64/-/gribberish-darwin-arm64-0.30.1.tgz",
+      "integrity": "sha512-9W9LFC01gsFYqsrWtF2dYk0uUwwMHyZFCBj6qQCx2XbP1LMI4Ie7EXgz5L702vYAR/TWFZvTZFdFpCc9UWpi1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@mattnucc/gribberish-darwin-x64": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mattnucc/gribberish-darwin-x64/-/gribberish-darwin-x64-0.30.1.tgz",
+      "integrity": "sha512-AmJEeXQSddAft+f6Vi8zpaeJQhDZPZ1nMmpyZ1HAzI8aIuHZDIAlU0OvNrZCo3R0DuVPHItXxOYkP6Y5FKAR0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@mattnucc/gribberish-linux-x64-gnu": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mattnucc/gribberish-linux-x64-gnu/-/gribberish-linux-x64-gnu-0.30.1.tgz",
+      "integrity": "sha512-oO1ab5ab+1Uv4BkfK6UHpTG0gZHVesOQhOhQiXOcfmxjiokpn1tDpRjVUyYhGAI82RO4twCNboJ6ncV8U1h6jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@mattnucc/gribberish-wasm32-wasi": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mattnucc/gribberish-wasm32-wasi/-/gribberish-wasm32-wasi-0.30.1.tgz",
+      "integrity": "sha512-tlGEGw+QU6MOQ38mUmaNyKMmKZMB5295/di9mo3QmMOjV5hf9ocfAXDnKuQ+bCBdlHIw81TiCdGD2bJrSIwcbQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@mattnucc/gribberish-win32-x64-msvc": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mattnucc/gribberish-win32-x64-msvc/-/gribberish-win32-x64-msvc-0.30.1.tgz",
+      "integrity": "sha512-uzrW+Cz27yPHqZ99OfAy70LLIA6+4E0xGKcHD5GmiC2nilZPGspqBg53e5UlrhtlxAvNbZV80sODJ+CqcCJGCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.21.1.tgz",
@@ -601,6 +708,24 @@
         "@cfworker/json-schema": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -917,6 +1042,16 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1728,6 +1863,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2542,6 +2678,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3107,6 +3244,7 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -3191,6 +3329,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3266,6 +3405,7 @@
       "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.8",
         "@vitest/mocker": "4.0.8",
@@ -3449,6 +3589,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "url": "https://github.com/weather-mcp/weather-mcp/issues"
   },
   "dependencies": {
+    "@mattnucc/gribberish": "^0.30.1",
     "@modelcontextprotocol/sdk": "^1.21.1",
     "axios": "^1.13.1",
     "dotenv": "^17.2.3",

--- a/src/config/tools.ts
+++ b/src/config/tools.ts
@@ -16,6 +16,8 @@
  */
 export type ToolName =
   | 'get_forecast'
+  | 'get_forecast_nomads'
+  | 'get_model_comparison_forecast'
   | 'get_current_conditions'
   | 'get_alerts'
   | 'get_historical_weather'
@@ -81,6 +83,8 @@ const TOOL_PRESETS: Record<string, ToolName[]> = {
   // All available tools
   all: [
     'get_forecast',
+    'get_forecast_nomads',
+    'get_model_comparison_forecast',
     'get_current_conditions',
     'get_alerts',
     'get_historical_weather',
@@ -104,6 +108,13 @@ const TOOL_PRESETS: Record<string, ToolName[]> = {
  */
 const TOOL_ALIASES: Record<string, ToolName> = {
   'forecast': 'get_forecast',
+  'nomads': 'get_forecast_nomads',
+  'gfs': 'get_forecast_nomads',
+  'model': 'get_forecast_nomads',
+  'forecast_nomads': 'get_forecast_nomads',
+  'compare': 'get_model_comparison_forecast',
+  'comparison': 'get_model_comparison_forecast',
+  'models': 'get_model_comparison_forecast',
   'current': 'get_current_conditions',
   'conditions': 'get_current_conditions',
   'alerts': 'get_alerts',
@@ -243,6 +254,8 @@ function resolveToolName(name: string): ToolName | undefined {
 function isToolName(name: string): name is ToolName {
   const validTools: ToolName[] = [
     'get_forecast',
+    'get_forecast_nomads',
+    'get_model_comparison_forecast',
     'get_current_conditions',
     'get_alerts',
     'get_historical_weather',

--- a/src/errors/ApiError.ts
+++ b/src/errors/ApiError.ts
@@ -7,7 +7,7 @@
  */
 export class ApiError extends Error {
   public readonly statusCode: number;
-  public readonly service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim';
+  public readonly service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim' | 'NOMADS';
   public readonly userMessage: string;
   public readonly helpLinks: string[];
   public readonly isRetryable: boolean;
@@ -15,7 +15,7 @@ export class ApiError extends Error {
   constructor(
     message: string,
     statusCode: number,
-    service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim',
+    service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim' | 'NOMADS',
     userMessage: string,
     helpLinks: string[] = [],
     isRetryable: boolean = false
@@ -57,7 +57,7 @@ export class ApiError extends Error {
 export class RateLimitError extends ApiError {
   public readonly retryAfter?: number;
 
-  constructor(service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim', messageOrRetryAfter?: string | number, retryAfter?: number) {
+  constructor(service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim' | 'NOMADS', messageOrRetryAfter?: string | number, retryAfter?: number) {
     // Handle backwards compatibility: if second param is number, treat it as retryAfter
     let message: string | undefined;
     let retry: number | undefined;
@@ -96,7 +96,7 @@ export class RateLimitError extends ApiError {
  * Service unavailable error - API is down or timing out
  */
 export class ServiceUnavailableError extends ApiError {
-  constructor(service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim', messageOrError?: string | Error, originalError?: Error) {
+  constructor(service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim' | 'NOMADS', messageOrError?: string | Error, originalError?: Error) {
     // Handle backwards compatibility: if second param is Error, treat it as originalError
     let message: string | undefined;
     let error: Error | undefined;
@@ -140,7 +140,7 @@ export class InvalidLocationError extends ApiError {
   public readonly longitude?: number;
 
   constructor(
-    service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim',
+    service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim' | 'NOMADS',
     message: string,
     latitude?: number,
     longitude?: number
@@ -164,7 +164,7 @@ export class InvalidLocationError extends ApiError {
  * Data not found error - requested data doesn't exist
  */
 export class DataNotFoundError extends ApiError {
-  constructor(service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim', message: string) {
+  constructor(service: 'NOAA' | 'OpenMeteo' | 'NCEI' | 'RainViewer' | 'Nominatim' | 'NOMADS', message: string) {
     super(
       message,
       404,

--- a/src/handlers/forecastHandler.ts
+++ b/src/handlers/forecastHandler.ts
@@ -6,6 +6,7 @@
 import { DateTime } from 'luxon';
 import { NOAAService } from '../services/noaa.js';
 import { OpenMeteoService } from '../services/openmeteo.js';
+import { NOMADSService } from '../services/nomads.js';
 import { NCEIService } from '../services/ncei.js';
 import { LocationStore } from '../services/locationStore.js';
 import type { GridpointProperties, GridpointDataSeries } from '../types/noaa.js';
@@ -34,7 +35,7 @@ interface ForecastArgs {
   include_precipitation_probability?: boolean;
   include_severe_weather?: boolean;
   include_normals?: boolean;
-  source?: 'auto' | 'noaa' | 'openmeteo';
+  source?: 'auto' | 'noaa' | 'openmeteo' | 'nomads';
 }
 
 /**
@@ -165,6 +166,7 @@ export async function handleGetForecast(
   args: unknown,
   noaaService: NOAAService,
   openMeteoService: OpenMeteoService,
+  nomadsService: NOMADSService,
   locationStore: LocationStore,
   nceiService?: NCEIService
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
@@ -190,17 +192,7 @@ export async function handleGetForecast(
 
   // Get source preference or auto-detect
   const requestedSource = (args as ForecastArgs)?.source || 'auto';
-  let useNOAA: boolean;
-
-  if (requestedSource === 'auto') {
-    // Auto-detect based on location (US = NOAA, elsewhere = Open-Meteo)
-    useNOAA = isInUS(latitude, longitude);
-  } else {
-    useNOAA = requestedSource === 'noaa';
-  }
-
-  // Use NOAA for US locations or if explicitly requested
-  if (useNOAA) {
+  if (requestedSource === 'noaa') {
     return await formatNOAAForecast(
       noaaService,
       openMeteoService,
@@ -213,8 +205,9 @@ export async function handleGetForecast(
       include_severe_weather,
       include_normals
     );
-  } else {
-    // Use Open-Meteo for international locations
+  }
+
+  if (requestedSource === 'openmeteo') {
     return await formatOpenMeteoForecast(
       openMeteoService,
       nceiService,
@@ -226,6 +219,115 @@ export async function handleGetForecast(
       include_normals
     );
   }
+
+  if (requestedSource === 'nomads') {
+    return await formatNOMADSForecast(
+      nomadsService,
+      latitude,
+      longitude,
+      days
+    );
+  }
+
+  // Auto mode: prefer NOAA for US; for non-US daily forecasts try NOMADS first, then Open-Meteo fallback.
+  if (isInUS(latitude, longitude)) {
+    return await formatNOAAForecast(
+      noaaService,
+      openMeteoService,
+      nceiService,
+      latitude,
+      longitude,
+      days,
+      granularity,
+      include_precipitation_probability,
+      include_severe_weather,
+      include_normals
+    );
+  }
+
+  if (granularity === 'daily') {
+    try {
+      return await formatNOMADSForecast(
+        nomadsService,
+        latitude,
+        longitude,
+        days
+      );
+    } catch (error) {
+      logger.warn('NOMADS auto-selection failed, falling back to Open-Meteo', {
+        latitude,
+        longitude,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  return await formatOpenMeteoForecast(
+    openMeteoService,
+    nceiService,
+    latitude,
+    longitude,
+    days,
+    granularity,
+    include_precipitation_probability,
+    include_normals
+  );
+}
+
+async function formatNOMADSForecast(
+  nomadsService: NOMADSService,
+  latitude: number,
+  longitude: number,
+  days: number
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const forecast = await nomadsService.getForecast(latitude, longitude, days);
+  const numDays = Math.min(forecast.daily.time.length, days);
+
+  let output = '# Weather Forecast (Daily)\n\n';
+  output += `**Location:** ${latitude.toFixed(4)}, ${longitude.toFixed(4)}\n`;
+  output += `**Model:** ${forecast.model}\n`;
+  output += `**Model Run (UTC):** ${DateTime.fromISO(forecast.model_run).toUTC().toFormat('yyyy-LL-dd HH:mm')}Z\n`;
+  output += `**Timezone:** ${forecast.timezone}\n\n`;
+
+  for (let i = 0; i < numDays; i++) {
+    const dt = DateTime.fromISO(forecast.daily.time[i], { setZone: false }).setZone(forecast.timezone);
+    output += `## ${dt.toLocaleString({ weekday: 'long', month: 'long', day: 'numeric' })}\n`;
+
+    const high = forecast.daily.temperature_2m_max[i];
+    const low = forecast.daily.temperature_2m_min[i];
+    const precipChance = forecast.daily.precipitation_probability_max[i];
+    const precipSum = forecast.daily.precipitation_sum[i];
+    const windMax = forecast.daily.wind_speed_10m_max[i];
+    const humidity = forecast.daily.relative_humidity_2m_mean[i];
+
+    if (Number.isFinite(high) && Number.isFinite(low)) {
+      output += `**Temperature:** High ${Math.round(high)}°F / Low ${Math.round(low)}°F\n`;
+    }
+    output += `**Precipitation Chance:** ${Math.round(precipChance)}%\n`;
+    output += `**Precipitation:** ${precipSum.toFixed(2)} in\n`;
+
+    if (Number.isFinite(windMax)) {
+      output += `**Wind:** up to ${Math.round(windMax)} mph\n`;
+    }
+
+    if (Number.isFinite(humidity)) {
+      output += `**Humidity:** avg ${Math.round(humidity)}%\n`;
+    }
+
+    output += '\n';
+  }
+
+  output += '---\n';
+  output += '*Data source: NOMADS/NCEP GFS model run (global). Precipitation chance is derived from deterministic 6-hour model interval signals.*\n';
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output
+      }
+    ]
+  };
 }
 
 /**

--- a/src/handlers/modelComparisonHandler.ts
+++ b/src/handlers/modelComparisonHandler.ts
@@ -1,0 +1,113 @@
+import { DateTime } from 'luxon';
+import { LocationStore } from '../services/locationStore.js';
+import { ModelComparisonService } from '../services/modelComparison.js';
+import { resolveLocation } from '../utils/locationResolver.js';
+import { validateForecastDays } from '../utils/validation.js';
+import type { ComparisonModel } from '../types/modelComparison.js';
+
+interface ModelComparisonArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  days?: number;
+  models?: ComparisonModel[];
+}
+
+function parseModels(models?: unknown): ComparisonModel[] {
+  if (!Array.isArray(models)) {
+    return ['gfs', 'nam', 'ecmwf_proxy'];
+  }
+
+  const allowed = new Set<ComparisonModel>(['gfs', 'nam', 'ecmwf_proxy']);
+  const normalized = models
+    .map((item) => String(item).trim().toLowerCase())
+    .map((item) => (item === 'ecmwf' ? 'ecmwf_proxy' : item))
+    .filter((item): item is ComparisonModel => allowed.has(item as ComparisonModel));
+
+  return normalized.length > 0 ? Array.from(new Set(normalized)) : ['gfs', 'nam', 'ecmwf_proxy'];
+}
+
+function formatValue(value: number | undefined, digits = 0, suffix = ''): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'N/A';
+  }
+
+  return `${value.toFixed(digits)}${suffix}`;
+}
+
+export async function handleGetModelComparisonForecast(
+  args: unknown,
+  modelComparisonService: ModelComparisonService,
+  locationStore: LocationStore
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const { latitude, longitude } = resolveLocation(args as ModelComparisonArgs, locationStore);
+  const days = validateForecastDays(args);
+  const models = parseModels((args as ModelComparisonArgs)?.models);
+
+  const comparison = await modelComparisonService.compare(latitude, longitude, days, models);
+
+  let output = '# Multi-Model Forecast Comparison\n\n';
+  output += `**Location:** ${latitude.toFixed(4)}, ${longitude.toFixed(4)}\n`;
+  output += `**Timezone:** ${comparison.timezone}\n`;
+  output += `**Requested Window:** ${comparison.requestedDays} days\n\n`;
+
+  output += '## Model Availability\n';
+  for (const series of comparison.series) {
+    output += `- **${series.label}:** run ${DateTime.fromISO(series.modelRun).toUTC().toFormat('yyyy-LL-dd HH:mm')}Z, horizon ${series.horizonHours}h\n`;
+  }
+  output += '\n';
+
+  if (comparison.notes.length > 0) {
+    output += '## Notes\n';
+    for (const note of comparison.notes) {
+      output += `- ${note}\n`;
+    }
+    output += '\n';
+  }
+
+  for (const dayKey of comparison.days) {
+    const label = DateTime.fromISO(dayKey, { zone: comparison.timezone }).toLocaleString({
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    output += `## ${label}\n`;
+
+    for (const series of comparison.series) {
+      const values = series.daily[dayKey];
+
+      if (!values) {
+        if (series.model === 'nam') {
+          output += `- **${series.label}:** N/A (NAM deterministic horizon limit ~84h)\n`;
+        } else {
+          output += `- **${series.label}:** N/A\n`;
+        }
+        continue;
+      }
+
+      const tempHigh = formatValue(values.temperatureHighF, 0, '°F');
+      const tempLow = formatValue(values.temperatureLowF, 0, '°F');
+      const precipChance = formatValue(values.precipitationChancePct, 0, '%');
+      const precipTotal = formatValue(values.precipitationTotalIn, 2, ' in');
+      const wind = formatValue(values.windMaxMph, 0, ' mph');
+      const humidity = formatValue(values.humidityMeanPct, 0, '%');
+
+      output += `- **${series.label}:** High ${tempHigh} / Low ${tempLow}; Precip ${precipChance}; Total ${precipTotal}; Wind ${wind}; Humidity ${humidity}\n`;
+    }
+
+    output += '\n';
+  }
+
+  output += '---\n';
+  output += '*Comparison includes GFS and NAM model-run data from NOMADS. ECMWF line uses Open-Meteo proxy guidance for long-range context.*\n';
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output,
+      },
+    ],
+  };
+}

--- a/src/handlers/nomadsForecastHandler.ts
+++ b/src/handlers/nomadsForecastHandler.ts
@@ -1,0 +1,72 @@
+import { DateTime } from 'luxon';
+import { NOMADSService } from '../services/nomads.js';
+import { LocationStore } from '../services/locationStore.js';
+import { resolveLocation } from '../utils/locationResolver.js';
+import { validateForecastDays } from '../utils/validation.js';
+
+interface NomadsForecastArgs {
+  latitude?: number;
+  longitude?: number;
+  location_name?: string;
+  days?: number;
+}
+
+export async function handleGetNomadsForecast(
+  args: unknown,
+  nomadsService: NOMADSService,
+  locationStore: LocationStore
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const { latitude, longitude } = resolveLocation(args as NomadsForecastArgs, locationStore);
+  const days = validateForecastDays(args);
+
+  const forecast = await nomadsService.getForecast(latitude, longitude, days);
+
+  let output = '# Forecast (NOMADS/NCEP GFS Current Model Run)\n\n';
+  output += `**Location:** ${latitude.toFixed(4)}, ${longitude.toFixed(4)}\n`;
+  output += `**Model:** ${forecast.model}\n`;
+  output += `**Model Run (UTC):** ${DateTime.fromISO(forecast.model_run).toUTC().toFormat('yyyy-LL-dd HH:mm')}Z\n`;
+  output += `**Timezone:** ${forecast.timezone}\n`;
+  output += `**Forecast Step:** every ${forecast.forecast_step_hours} hours\n\n`;
+
+  for (let i = 0; i < forecast.daily.time.length; i++) {
+    const day = forecast.daily.time[i];
+    const dt = DateTime.fromISO(day, { zone: forecast.timezone });
+    output += `## ${dt.toLocaleString({ weekday: 'long', month: 'long', day: 'numeric' })}\n`;
+
+    const high = forecast.daily.temperature_2m_max[i];
+    const low = forecast.daily.temperature_2m_min[i];
+    const precipChance = forecast.daily.precipitation_probability_max[i];
+    const precipSum = forecast.daily.precipitation_sum[i];
+    const windMax = forecast.daily.wind_speed_10m_max[i];
+    const humidityMean = forecast.daily.relative_humidity_2m_mean[i];
+
+    if (Number.isFinite(high) && Number.isFinite(low)) {
+      output += `**Temperature:** High ${Math.round(high)}°F / Low ${Math.round(low)}°F\n`;
+    }
+
+    output += `**Precipitation Chance:** ${Math.round(precipChance)}%\n`;
+    output += `**Precipitation Total:** ${precipSum.toFixed(2)} in\n`;
+
+    if (Number.isFinite(windMax)) {
+      output += `**Wind:** up to ${Math.round(windMax)} mph\n`;
+    }
+
+    if (Number.isFinite(humidityMean)) {
+      output += `**Humidity:** avg ${Math.round(humidityMean)}%\n`;
+    }
+
+    output += '\n';
+  }
+
+  output += '---\n';
+  output += '*Data source: NOMADS/NCEP GFS (deterministic model run). Precipitation chance is derived from 6-hour forecast interval signals in the selected day.*\n';
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: output,
+      },
+    ],
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import { OpenMeteoService } from './services/openmeteo.js';
 import { NominatimService } from './services/nominatim.js';
 import { NCEIService } from './services/ncei.js';
 import { NIFCService } from './services/nifc.js';
+import { NOMADSService } from './services/nomads.js';
+import { ModelComparisonService } from './services/modelComparison.js';
 import { GeocodingService } from './services/geocoding.js';
 import { LocationStore } from './services/locationStore.js';
 import { CacheConfig } from './config/cache.js';
@@ -43,6 +45,8 @@ import {
   handleGetSavedLocation,
   handleRemoveSavedLocation
 } from './handlers/savedLocationsHandler.js';
+import { handleGetNomadsForecast } from './handlers/nomadsForecastHandler.js';
+import { handleGetModelComparisonForecast } from './handlers/modelComparisonHandler.js';
 import { withAnalytics, analytics } from './analytics/index.js';
 
 /**
@@ -125,6 +129,20 @@ const locationStore = new LocationStore();
  * Falls back to Open-Meteo computed normals if not configured
  */
 const nceiService = new NCEIService();
+
+/**
+ * Initialize the NOMADS service for NCEP GFS model forecasts
+ * No API key required - uses public NOMADS filter endpoint
+ */
+const nomadsService = new NOMADSService({
+  userAgent: `weather-mcp/${SERVER_VERSION} (https://github.com/weather-mcp/weather-mcp)`
+});
+
+/**
+ * Initialize model comparison orchestration service
+ * Combines GFS, NAM, and ECMWF proxy guidance in one response
+ */
+const modelComparisonService = new ModelComparisonService(nomadsService, openMeteoService);
 
 /**
  * Initialize the NIFC service for wildfire data
@@ -210,9 +228,85 @@ const TOOL_DEFINITIONS = {
         },
         source: {
           type: 'string' as const,
-          description: 'Data source: "auto" (default, selects NOAA for US or Open-Meteo for international), "noaa" (US only), or "openmeteo" (global)',
-          enum: ['auto', 'noaa', 'openmeteo'],
+          description: 'Data source: "auto" (default), "noaa" (US only), "openmeteo" (global), or "nomads" (NCEP GFS model run, global)',
+          enum: ['auto', 'noaa', 'openmeteo', 'nomads'],
           default: 'auto'
+        }
+      },
+      required: []
+    }
+  },
+
+  get_forecast_nomads: {
+    name: 'get_forecast_nomads' as const,
+    description: 'Get a forecast from the latest NOMADS/NCEP GFS model run. Returns daily high/low temperatures, derived precipitation chance, precipitation totals, and extra wind/humidity context. Use this when users ask for model-run based output specifically from NCEP/NOMADS.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        latitude: {
+          type: 'number' as const,
+          description: 'Latitude of the location (-90 to 90). Not required if location_name is provided.',
+          minimum: -90,
+          maximum: 90
+        },
+        longitude: {
+          type: 'number' as const,
+          description: 'Longitude of the location (-180 to 180). Not required if location_name is provided.',
+          minimum: -180,
+          maximum: 180
+        },
+        location_name: {
+          type: 'string' as const,
+          description: 'Name of a saved location (e.g., "home", "cabin"). Use this instead of latitude/longitude.'
+        },
+        days: {
+          type: 'number' as const,
+          description: 'Number of days to include in forecast (1-10, default: 7)',
+          minimum: 1,
+          maximum: 10,
+          default: 7
+        }
+      },
+      required: []
+    }
+  },
+
+  get_model_comparison_forecast: {
+    name: 'get_model_comparison_forecast' as const,
+    description: 'Compare forecasts across multiple model sources in one response. Supports GFS (NOMADS), NAM (NOMADS, ~84h deterministic horizon), and ECMWF proxy guidance via Open-Meteo. For 7+ day requests, NAM values are shown through its horizon and then marked as N/A.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        latitude: {
+          type: 'number' as const,
+          description: 'Latitude of the location (-90 to 90). Not required if location_name is provided.',
+          minimum: -90,
+          maximum: 90
+        },
+        longitude: {
+          type: 'number' as const,
+          description: 'Longitude of the location (-180 to 180). Not required if location_name is provided.',
+          minimum: -180,
+          maximum: 180
+        },
+        location_name: {
+          type: 'string' as const,
+          description: 'Name of a saved location (e.g., "home", "cabin"). Use this instead of latitude/longitude.'
+        },
+        days: {
+          type: 'number' as const,
+          description: 'Number of forecast days to compare (1-10, default: 7). NAM deterministic data is limited to about 84 hours.',
+          minimum: 1,
+          maximum: 10,
+          default: 7
+        },
+        models: {
+          type: 'array' as const,
+          description: 'Models to include. Defaults to ["gfs", "nam", "ecmwf_proxy"]. You may also pass "ecmwf" and it will map to "ecmwf_proxy".',
+          items: {
+            type: 'string' as const,
+            enum: ['gfs', 'nam', 'ecmwf_proxy', 'ecmwf']
+          }
         }
       },
       required: []
@@ -672,7 +766,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     switch (name) {
       case 'get_forecast':
         return await withAnalytics('get_forecast', async () =>
-          handleGetForecast(args, noaaService, openMeteoService, locationStore, nceiService)
+          handleGetForecast(args, noaaService, openMeteoService, nomadsService, locationStore, nceiService)
+        );
+
+      case 'get_forecast_nomads':
+        return await withAnalytics('get_forecast_nomads', async () =>
+          handleGetNomadsForecast(args, nomadsService, locationStore)
+        );
+
+      case 'get_model_comparison_forecast':
+        return await withAnalytics('get_model_comparison_forecast', async () =>
+          handleGetModelComparisonForecast(args, modelComparisonService, locationStore)
         );
 
       case 'get_current_conditions':

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ import {
 import { handleGetNomadsForecast } from './handlers/nomadsForecastHandler.js';
 import { handleGetModelComparisonForecast } from './handlers/modelComparisonHandler.js';
 import { withAnalytics, analytics } from './analytics/index.js';
+import { randomUUID } from 'crypto';
+import { logRequestLifecycle } from './utils/requestLogger.js';
 
 /**
  * Server information
@@ -756,6 +758,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
  */
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
+  const requestId = randomUUID();
+  const requestStartMs = Date.now();
+
+  logRequestLifecycle({
+    timestamp: new Date().toISOString(),
+    requestId,
+    tool: name,
+    status: 'start'
+  });
+
+  const completeSuccess = <T>(result: T): T => {
+    logRequestLifecycle({
+      timestamp: new Date().toISOString(),
+      requestId,
+      tool: name,
+      status: 'success',
+      durationMs: Date.now() - requestStartMs
+    });
+
+    return result;
+  };
 
   try {
     // Check if tool is enabled
@@ -765,57 +788,57 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (name) {
       case 'get_forecast':
-        return await withAnalytics('get_forecast', async () =>
+        return completeSuccess(await withAnalytics('get_forecast', async () =>
           handleGetForecast(args, noaaService, openMeteoService, nomadsService, locationStore, nceiService)
-        );
+        ));
 
       case 'get_forecast_nomads':
-        return await withAnalytics('get_forecast_nomads', async () =>
+        return completeSuccess(await withAnalytics('get_forecast_nomads', async () =>
           handleGetNomadsForecast(args, nomadsService, locationStore)
-        );
+        ));
 
       case 'get_model_comparison_forecast':
-        return await withAnalytics('get_model_comparison_forecast', async () =>
+        return completeSuccess(await withAnalytics('get_model_comparison_forecast', async () =>
           handleGetModelComparisonForecast(args, modelComparisonService, locationStore)
-        );
+        ));
 
       case 'get_current_conditions':
-        return await withAnalytics('get_current_conditions', async () =>
+        return completeSuccess(await withAnalytics('get_current_conditions', async () =>
           handleGetCurrentConditions(args, noaaService, openMeteoService, nceiService)
-        );
+        ));
 
       case 'get_alerts':
-        return await withAnalytics('get_alerts', async () =>
+        return completeSuccess(await withAnalytics('get_alerts', async () =>
           handleGetAlerts(args, noaaService)
-        );
+        ));
 
       case 'get_historical_weather':
-        return await withAnalytics('get_historical_weather', async () =>
+        return completeSuccess(await withAnalytics('get_historical_weather', async () =>
           handleGetHistoricalWeather(args, noaaService, openMeteoService)
-        );
+        ));
 
       case 'check_service_status':
-        return await withAnalytics('check_service_status', async () =>
+        return completeSuccess(await withAnalytics('check_service_status', async () =>
           handleCheckServiceStatus(noaaService, openMeteoService, SERVER_VERSION)
-        );
+        ));
 
       case 'search_location':
-        return await withAnalytics('search_location', async () =>
+        return completeSuccess(await withAnalytics('search_location', async () =>
           handleSearchLocation(args, geocodingService)
-        );
+        ));
 
       case 'get_air_quality':
-        return await withAnalytics('get_air_quality', async () =>
+        return completeSuccess(await withAnalytics('get_air_quality', async () =>
           handleGetAirQuality(args, openMeteoService)
-        );
+        ));
 
       case 'get_marine_conditions':
-        return await withAnalytics('get_marine_conditions', async () =>
+        return completeSuccess(await withAnalytics('get_marine_conditions', async () =>
           handleGetMarineConditions(args, noaaService, openMeteoService)
-        );
+        ));
 
       case 'get_weather_imagery':
-        return await withAnalytics('get_weather_imagery', async () => {
+        return completeSuccess(await withAnalytics('get_weather_imagery', async () => {
           const result = await getWeatherImagery(args as any);
           const formatted = formatWeatherImageryResponse(result);
           return {
@@ -826,10 +849,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               }
             ]
           };
-        });
+        }));
 
       case 'get_lightning_activity':
-        return await withAnalytics('get_lightning_activity', async () => {
+        return completeSuccess(await withAnalytics('get_lightning_activity', async () => {
           const result = await getLightningActivity(args as any);
           const formatted = formatLightningActivityResponse(result);
           return {
@@ -840,42 +863,50 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               }
             ]
           };
-        });
+        }));
 
       case 'get_river_conditions':
-        return await withAnalytics('get_river_conditions', async () =>
+        return completeSuccess(await withAnalytics('get_river_conditions', async () =>
           handleGetRiverConditions(args, noaaService)
-        );
+        ));
 
       case 'get_wildfire_info':
-        return await withAnalytics('get_wildfire_info', async () =>
+        return completeSuccess(await withAnalytics('get_wildfire_info', async () =>
           handleGetWildfireInfo(args, nifcService)
-        );
+        ));
 
       case 'save_location':
-        return await withAnalytics('save_location', async () =>
+        return completeSuccess(await withAnalytics('save_location', async () =>
           handleSaveLocation(args, locationStore, nominatimService)
-        );
+        ));
 
       case 'list_saved_locations':
-        return await withAnalytics('list_saved_locations', async () =>
+        return completeSuccess(await withAnalytics('list_saved_locations', async () =>
           handleListSavedLocations(locationStore)
-        );
+        ));
 
       case 'get_saved_location':
-        return await withAnalytics('get_saved_location', async () =>
+        return completeSuccess(await withAnalytics('get_saved_location', async () =>
           handleGetSavedLocation(args, locationStore)
-        );
+        ));
 
       case 'remove_saved_location':
-        return await withAnalytics('remove_saved_location', async () =>
+        return completeSuccess(await withAnalytics('remove_saved_location', async () =>
           handleRemoveSavedLocation(args, locationStore)
-        );
+        ));
 
       default:
         throw new Error(`Unknown tool: ${name}`);
     }
   } catch (error) {
+    logRequestLifecycle({
+      timestamp: new Date().toISOString(),
+      requestId,
+      tool: name,
+      status: 'error',
+      durationMs: Date.now() - requestStartMs
+    });
+
     // Redact sensitive fields from args before logging
     const redactedArgs = args ? redactSensitiveFields(args) : undefined;
 

--- a/src/services/modelComparison.ts
+++ b/src/services/modelComparison.ts
@@ -1,0 +1,175 @@
+import { DateTime } from 'luxon';
+import { NOMADSService } from './nomads.js';
+import { OpenMeteoService } from './openmeteo.js';
+import type {
+  ComparisonModel,
+  ComparisonModelSeries,
+  ComparisonDayValues,
+  ModelComparisonResult,
+} from '../types/modelComparison.js';
+
+export class ModelComparisonService {
+  constructor(
+    private readonly nomadsService: NOMADSService,
+    private readonly openMeteoService: OpenMeteoService
+  ) {}
+
+  async compare(
+    latitude: number,
+    longitude: number,
+    days: number,
+    models: ComparisonModel[]
+  ): Promise<ModelComparisonResult> {
+    const requestedDays = Math.max(1, Math.min(days, 10));
+
+    const requestedModels = models.length > 0
+      ? Array.from(new Set(models))
+      : ['gfs', 'nam', 'ecmwf_proxy'];
+
+    const notes: string[] = [];
+    const series: ComparisonModelSeries[] = [];
+
+    const modelFetches = requestedModels.map(async (model) => {
+      try {
+        switch (model) {
+          case 'gfs':
+            return await this.fetchGfsSeries(latitude, longitude, requestedDays);
+          case 'nam':
+            return await this.fetchNamSeries(latitude, longitude, requestedDays);
+          case 'ecmwf_proxy':
+            return await this.fetchEcmwfProxySeries(latitude, longitude, requestedDays);
+          default:
+            return null;
+        }
+      } catch (error) {
+        notes.push(`${model.toUpperCase()} unavailable: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        return null;
+      }
+    });
+
+    const fetchedSeries = await Promise.all(modelFetches);
+    for (const item of fetchedSeries) {
+      if (item) {
+        series.push(item);
+      }
+    }
+
+    const timezone = series[0]?.timezone || 'UTC';
+    const dayKeys = this.buildDayKeys(timezone, requestedDays);
+
+    const namSeries = series.find((item) => item.model === 'nam');
+    if (namSeries) {
+      notes.push('NAM deterministic horizon is limited to approximately 84 hours; later days are shown as N/A.');
+    }
+
+    const ecmwfSeries = series.find((item) => item.model === 'ecmwf_proxy');
+    if (ecmwfSeries) {
+      notes.push('ECMWF values are proxy guidance via Open-Meteo and do not include raw deterministic ECMWF run metadata.');
+    }
+
+    return {
+      latitude,
+      longitude,
+      timezone,
+      requestedDays,
+      days: dayKeys,
+      series,
+      notes,
+    };
+  }
+
+  private async fetchGfsSeries(latitude: number, longitude: number, days: number): Promise<ComparisonModelSeries> {
+    const forecast = await this.nomadsService.getForecast(latitude, longitude, days);
+
+    return {
+      model: 'gfs',
+      label: 'GFS (NOMADS)',
+      modelRun: forecast.model_run,
+      horizonHours: 240,
+      timezone: forecast.timezone,
+      daily: this.convertNomadsDailyToMap(forecast.daily),
+    };
+  }
+
+  private async fetchNamSeries(latitude: number, longitude: number, days: number): Promise<ComparisonModelSeries> {
+    const forecast = await this.nomadsService.getNamForecast(latitude, longitude, days);
+
+    return {
+      model: 'nam',
+      label: 'NAM (NOMADS)',
+      modelRun: forecast.model_run,
+      horizonHours: 84,
+      timezone: forecast.timezone,
+      daily: this.convertNomadsDailyToMap(forecast.daily),
+      note: 'Limited deterministic horizon (~84h).',
+    };
+  }
+
+  private async fetchEcmwfProxySeries(latitude: number, longitude: number, days: number): Promise<ComparisonModelSeries> {
+    const forecast = await this.openMeteoService.getForecast(latitude, longitude, days, false);
+
+    const daily: Record<string, ComparisonDayValues> = {};
+    const entries = forecast.daily?.time || [];
+
+    for (let i = 0; i < entries.length; i++) {
+      const day = entries[i];
+      daily[day] = {
+        temperatureHighF: forecast.daily?.temperature_2m_max?.[i],
+        temperatureLowF: forecast.daily?.temperature_2m_min?.[i],
+        precipitationChancePct: forecast.daily?.precipitation_probability_max?.[i],
+        precipitationTotalIn: forecast.daily?.precipitation_sum?.[i],
+        windMaxMph: forecast.daily?.wind_speed_10m_max?.[i],
+      };
+    }
+
+    return {
+      model: 'ecmwf_proxy',
+      label: 'ECMWF Proxy (Open-Meteo)',
+      modelRun: DateTime.utc().toISO() || new Date().toISOString(),
+      horizonHours: days * 24,
+      timezone: forecast.timezone,
+      daily,
+      note: 'Proxy guidance, not raw deterministic ECMWF run metadata.',
+    };
+  }
+
+  private convertNomadsDailyToMap(daily: {
+    time: string[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_probability_max: number[];
+    precipitation_sum: number[];
+    wind_speed_10m_max: number[];
+    relative_humidity_2m_mean: number[];
+  }): Record<string, ComparisonDayValues> {
+    const mapped: Record<string, ComparisonDayValues> = {};
+
+    for (let i = 0; i < daily.time.length; i++) {
+      const key = daily.time[i];
+      mapped[key] = {
+        temperatureHighF: Number.isFinite(daily.temperature_2m_max[i]) ? daily.temperature_2m_max[i] : undefined,
+        temperatureLowF: Number.isFinite(daily.temperature_2m_min[i]) ? daily.temperature_2m_min[i] : undefined,
+        precipitationChancePct: Number.isFinite(daily.precipitation_probability_max[i]) ? daily.precipitation_probability_max[i] : undefined,
+        precipitationTotalIn: Number.isFinite(daily.precipitation_sum[i]) ? daily.precipitation_sum[i] : undefined,
+        windMaxMph: Number.isFinite(daily.wind_speed_10m_max[i]) ? daily.wind_speed_10m_max[i] : undefined,
+        humidityMeanPct: Number.isFinite(daily.relative_humidity_2m_mean[i]) ? daily.relative_humidity_2m_mean[i] : undefined,
+      };
+    }
+
+    return mapped;
+  }
+
+  private buildDayKeys(timezone: string, days: number): string[] {
+    const start = DateTime.now().setZone(timezone).startOf('day');
+    const keys: string[] = [];
+
+    for (let i = 0; i < days; i++) {
+      const key = start.plus({ days: i }).toISODate();
+      if (key) {
+        keys.push(key);
+      }
+    }
+
+    return keys;
+  }
+}

--- a/src/services/nomads.ts
+++ b/src/services/nomads.ts
@@ -1,0 +1,459 @@
+import axios, { AxiosError, AxiosInstance } from 'axios';
+import { DateTime } from 'luxon';
+import { parseMessagesFromBuffer } from '@mattnucc/gribberish';
+import { Cache } from '../utils/cache.js';
+import { CacheConfig } from '../config/cache.js';
+import { validateLatitude, validateLongitude } from '../utils/validation.js';
+import { guessTimezoneFromCoords } from '../utils/timezone.js';
+import {
+  ApiError,
+  DataNotFoundError,
+  InvalidLocationError,
+  RateLimitError,
+  ServiceUnavailableError,
+} from '../errors/ApiError.js';
+import type { NomadsForecastResponse } from '../types/nomads.js';
+
+interface NomadsServiceConfig {
+  timeout?: number;
+  maxRetries?: number;
+  userAgent?: string;
+}
+
+interface GribMessage {
+  key: string;
+  varAbbrev?: string;
+  varName?: string;
+  units?: string;
+  data: number[];
+  gridShape?: {
+    rows: number;
+    cols: number;
+  };
+  latlng?: {
+    latitude: number[];
+    longitude: number[];
+  };
+  referenceDate?: Date;
+  forecastDate?: Date;
+}
+
+interface TimeStepData {
+  timestamp: Date;
+  temperatureF?: number;
+  humidityPct?: number;
+  windMph?: number;
+  precipitationIn?: number;
+}
+
+interface ModelFetchConfig {
+  cachePrefix: string;
+  modelLabel: string;
+  endpointUrl: string;
+  horizonHours: number;
+  stepHours: number;
+  availableCycles: string[];
+  candidateLookbackDays: number;
+  fileNameBuilder: (cycle: string, forecastHour: number) => string;
+  directoryBuilder: (date: string, cycle: string) => string;
+}
+
+const NOMADS_URL = 'https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_1p00.pl';
+const NAM_URL = 'https://nomads.ncep.noaa.gov/cgi-bin/filter_nam.pl';
+const HOURS_PER_STEP = 6;
+const NAM_HOURS_PER_STEP = 3;
+const MPS_TO_MPH = 2.2369362921;
+const MM_TO_IN = 0.0393701;
+
+export class NOMADSService {
+  private readonly client: AxiosInstance;
+  private readonly maxRetries: number;
+  private readonly cache: Cache;
+
+  constructor(config: NomadsServiceConfig = {}) {
+    const {
+      timeout = CacheConfig.apiTimeoutMs,
+      maxRetries = 3,
+      userAgent = 'weather-mcp/nomads-gfs',
+    } = config;
+
+    this.maxRetries = maxRetries;
+    this.cache = new Cache(CacheConfig.maxSize);
+    this.client = axios.create({
+      timeout,
+      headers: {
+        'User-Agent': userAgent,
+      },
+      responseType: 'arraybuffer',
+    });
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  async getForecast(latitude: number, longitude: number, days: number): Promise<NomadsForecastResponse> {
+    return this.getModelForecast(latitude, longitude, days, {
+      cachePrefix: 'nomads-gfs-forecast',
+      modelLabel: 'NCEP GFS 1.0 deg',
+      endpointUrl: NOMADS_URL,
+      horizonHours: 240,
+      stepHours: HOURS_PER_STEP,
+      availableCycles: ['18', '12', '06', '00'],
+      candidateLookbackDays: 2,
+      fileNameBuilder: (cycle: string, forecastHour: number) =>
+        `gfs.t${cycle}z.pgrb2.1p00.f${forecastHour.toString().padStart(3, '0')}`,
+      directoryBuilder: (date: string, cycle: string) => `/gfs.${date}/${cycle}/atmos`,
+    });
+  }
+
+  async getNamForecast(latitude: number, longitude: number, days: number): Promise<NomadsForecastResponse> {
+    return this.getModelForecast(latitude, longitude, days, {
+      cachePrefix: 'nomads-nam-forecast',
+      modelLabel: 'NCEP NAM (84h deterministic)',
+      endpointUrl: NAM_URL,
+      horizonHours: 84,
+      stepHours: NAM_HOURS_PER_STEP,
+      availableCycles: ['18', '12', '06', '00'],
+      candidateLookbackDays: 2,
+      fileNameBuilder: (cycle: string, forecastHour: number) =>
+        `nam.t${cycle}z.awphys${forecastHour.toString().padStart(2, '0')}.tm00.grib2`,
+      directoryBuilder: (date: string) => `/nam.${date}`,
+    });
+  }
+
+  private async getModelForecast(
+    latitude: number,
+    longitude: number,
+    days: number,
+    model: ModelFetchConfig
+  ): Promise<NomadsForecastResponse> {
+    validateLatitude(latitude);
+    validateLongitude(longitude);
+
+    const maxDaysForModel = Math.max(1, Math.ceil(model.horizonHours / 24));
+    const clampedDays = Math.max(1, Math.min(days, maxDaysForModel));
+    const cacheKey = Cache.generateKey(model.cachePrefix, latitude.toFixed(2), longitude.toFixed(2), clampedDays);
+
+    if (CacheConfig.enabled) {
+      const cached = this.cache.get(cacheKey);
+      if (cached) {
+        return cached as NomadsForecastResponse;
+      }
+    }
+
+    const run = await this.findLatestAvailableRun(latitude, longitude, model);
+    const maxForecastHour = Math.min(clampedDays * 24, model.horizonHours);
+    const points: TimeStepData[] = [];
+
+    for (let hour = 0; hour <= maxForecastHour; hour += model.stepHours) {
+      const messages = await this.fetchForecastMessages(run.date, run.cycle, hour, latitude, longitude, model);
+      const point = this.extractPointData(messages, latitude, longitude, run.referenceDate, hour);
+      points.push(point);
+    }
+
+    const timezone = guessTimezoneFromCoords(latitude, longitude);
+    const daily = this.aggregateDaily(points, timezone, clampedDays);
+
+    const response: NomadsForecastResponse = {
+      latitude,
+      longitude,
+      timezone,
+      model: model.modelLabel,
+      model_run: run.referenceDate.toISOString(),
+      forecast_step_hours: model.stepHours,
+      daily,
+    };
+
+    if (CacheConfig.enabled) {
+      this.cache.set(cacheKey, response, CacheConfig.ttl.forecast);
+    }
+
+    return response;
+  }
+
+  private async findLatestAvailableRun(
+    latitude: number,
+    longitude: number,
+    model: ModelFetchConfig
+  ): Promise<{ date: string; cycle: string; referenceDate: Date }> {
+    const now = DateTime.utc();
+    const candidateDates = Array.from({ length: model.candidateLookbackDays + 1 }, (_, idx) =>
+      now.minus({ days: idx })
+    );
+
+    for (const candidateDate of candidateDates) {
+      const dateStr = candidateDate.toFormat('yyyyLLdd');
+
+      for (const cycle of model.availableCycles) {
+        const probeHour = model.stepHours;
+
+        try {
+          const messages = await this.fetchForecastMessages(dateStr, cycle, probeHour, latitude, longitude, model);
+
+          if (messages.length > 0) {
+            const referenceDate = DateTime.fromFormat(`${dateStr}${cycle}`, 'yyyyLLddHH', { zone: 'utc' }).toJSDate();
+            return { date: dateStr, cycle, referenceDate };
+          }
+        } catch (error) {
+          // Continue probing older runs.
+        }
+      }
+    }
+
+    throw new ServiceUnavailableError(
+      'NOMADS',
+      `${model.modelLabel} runs were not reachable. Please try again shortly.`
+    );
+  }
+
+  private async fetchForecastMessages(
+    date: string,
+    cycle: string,
+    forecastHour: number,
+    latitude: number,
+    longitude: number,
+    model: ModelFetchConfig
+  ): Promise<GribMessage[]> {
+    const file = model.fileNameBuilder(cycle, forecastHour);
+
+    const params = {
+      file,
+      dir: model.directoryBuilder(date, cycle),
+      lev_2_m_above_ground: 'on',
+      lev_10_m_above_ground: 'on',
+      lev_surface: 'on',
+      var_TMP: 'on',
+      var_RH: 'on',
+      var_APCP: 'on',
+      var_UGRD: 'on',
+      var_VGRD: 'on',
+      subregion: '',
+      leftlon: (longitude - 2).toFixed(2),
+      rightlon: (longitude + 2).toFixed(2),
+      toplat: Math.min(90, latitude + 2).toFixed(2),
+      bottomlat: Math.max(-90, latitude - 2).toFixed(2),
+    };
+
+    const raw = await this.requestWithRetry(model.endpointUrl, params);
+
+    if (!raw || raw.length < 5 || raw.subarray(0, 4).toString('utf8') !== 'GRIB') {
+      throw new DataNotFoundError('NOMADS', `NOMADS data file unavailable for ${file}`);
+    }
+
+    return parseMessagesFromBuffer(raw) as unknown as GribMessage[];
+  }
+
+  private async requestWithRetry(endpointUrl: string, params: Record<string, string>, retries = 0): Promise<Buffer> {
+    try {
+      const response = await this.client.get<ArrayBuffer>(endpointUrl, { params });
+      return Buffer.from(response.data);
+    } catch (error) {
+      const axiosError = error as AxiosError;
+
+      if (axiosError.response?.status === 429) {
+        throw new RateLimitError('NOMADS', 'NOMADS rate limit reached. Retry in a moment.');
+      }
+
+      if (axiosError.response?.status === 404 || axiosError.response?.status === 403) {
+        throw new DataNotFoundError('NOMADS', 'Requested NOMADS model file was not found.');
+      }
+
+      if (retries < this.maxRetries) {
+        const delayMs = Math.round((2 ** retries) * 500 + Math.random() * 250);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        return this.requestWithRetry(endpointUrl, params, retries + 1);
+      }
+
+      if (axiosError.code === 'ECONNABORTED' || axiosError.code === 'ENOTFOUND') {
+        throw new ServiceUnavailableError('NOMADS', 'NOMADS endpoint timeout or DNS failure.');
+      }
+
+      throw new ApiError(
+        `NOMADS request failed: ${(error as Error).message}`,
+        500,
+        'NOMADS',
+        'NOMADS request failed. Please retry.',
+        [],
+        true
+      );
+    }
+  }
+
+  private extractPointData(
+    messages: GribMessage[],
+    latitude: number,
+    longitude: number,
+    referenceDate: Date,
+    forecastHour: number
+  ): TimeStepData {
+    if (messages.length === 0) {
+      throw new InvalidLocationError('NOMADS', 'No NOMADS messages returned for point extraction.');
+    }
+
+    const surfaceTemp = messages.find((m) => m.varAbbrev === 'TMP' && m.key.includes('2 in above ground'));
+    const humidity = messages.find((m) => m.varAbbrev === 'RH' && m.key.includes('2 in above ground'));
+    const ugrd = messages.find((m) => m.varAbbrev === 'UGRD' && m.key.includes('10 in above ground'));
+    const vgrd = messages.find((m) => m.varAbbrev === 'VGRD' && m.key.includes('10 in above ground'));
+    const precipCandidates = messages.filter((m) => m.varAbbrev === 'APCP');
+
+    const timestamp = surfaceTemp?.forecastDate ?? new Date(referenceDate.getTime() + forecastHour * 3600 * 1000);
+
+    const precipitationMmValues = precipCandidates
+      .map((msg) => this.extractNearestValue(msg, latitude, longitude))
+      .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+
+    const intervalPrecipMm = precipitationMmValues.length > 0 ? Math.max(...precipitationMmValues) : 0;
+
+    const temperatureK = surfaceTemp ? this.extractNearestValue(surfaceTemp, latitude, longitude) : undefined;
+    const humidityPct = humidity ? this.extractNearestValue(humidity, latitude, longitude) : undefined;
+
+    const u = ugrd ? this.extractNearestValue(ugrd, latitude, longitude) : undefined;
+    const v = vgrd ? this.extractNearestValue(vgrd, latitude, longitude) : undefined;
+
+    const windMph = typeof u === 'number' && typeof v === 'number'
+      ? Math.sqrt((u * u) + (v * v)) * MPS_TO_MPH
+      : undefined;
+
+    return {
+      timestamp,
+      temperatureF: typeof temperatureK === 'number' ? ((temperatureK - 273.15) * 9) / 5 + 32 : undefined,
+      humidityPct,
+      windMph,
+      precipitationIn: intervalPrecipMm * MM_TO_IN,
+    };
+  }
+
+  private extractNearestValue(message: GribMessage, latitude: number, longitude: number): number | undefined {
+    const latitudes = message.latlng?.latitude;
+    const longitudes = message.latlng?.longitude;
+    const rows = message.gridShape?.rows;
+    const cols = message.gridShape?.cols;
+
+    if (!latitudes || !longitudes || !rows || !cols || rows < 1 || cols < 1) {
+      return undefined;
+    }
+
+    const targetLon = longitude < 0 ? longitude + 360 : longitude;
+    const nearestLatIndex = this.findNearestIndex(latitudes, latitude);
+    const nearestLonIndex = this.findNearestIndex(longitudes, targetLon);
+    const flatIndex = nearestLatIndex * cols + nearestLonIndex;
+
+    const value = message.data[flatIndex];
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+
+  private findNearestIndex(values: number[], target: number): number {
+    let bestIndex = 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    for (let i = 0; i < values.length; i++) {
+      const distance = Math.abs(values[i] - target);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestIndex = i;
+      }
+    }
+
+    return bestIndex;
+  }
+
+  private aggregateDaily(points: TimeStepData[], timezone: string, days: number): NomadsForecastResponse['daily'] {
+    const buckets = new Map<string, {
+      highs: number[];
+      lows: number[];
+      precipIn: number;
+      precipSteps: number;
+      totalSteps: number;
+      humidity: number[];
+      wind: number[];
+    }>();
+
+    for (const point of points) {
+      const dayKey = DateTime.fromJSDate(point.timestamp, { zone: 'utc' }).setZone(timezone).toISODate();
+      if (!dayKey) {
+        continue;
+      }
+
+      let bucket = buckets.get(dayKey);
+      if (!bucket) {
+        bucket = {
+          highs: [],
+          lows: [],
+          precipIn: 0,
+          precipSteps: 0,
+          totalSteps: 0,
+          humidity: [],
+          wind: [],
+        };
+        buckets.set(dayKey, bucket);
+      }
+
+      if (typeof point.temperatureF === 'number') {
+        bucket.highs.push(point.temperatureF);
+        bucket.lows.push(point.temperatureF);
+      }
+
+      if (typeof point.precipitationIn === 'number') {
+        bucket.precipIn += point.precipitationIn;
+        if (point.precipitationIn >= 0.01) {
+          bucket.precipSteps += 1;
+        }
+      }
+
+      if (typeof point.humidityPct === 'number') {
+        bucket.humidity.push(point.humidityPct);
+      }
+
+      if (typeof point.windMph === 'number') {
+        bucket.wind.push(point.windMph);
+      }
+
+      bucket.totalSteps += 1;
+    }
+
+    const allSortedDays = Array.from(buckets.keys()).sort();
+    const todayKey = DateTime.now().setZone(timezone).toISODate();
+    const futureDays = todayKey
+      ? allSortedDays.filter((day) => day >= todayKey)
+      : allSortedDays;
+    const sortedDays = (futureDays.length > 0 ? futureDays : allSortedDays).slice(0, days);
+
+    return {
+      time: sortedDays,
+      temperature_2m_max: sortedDays.map((day) => {
+        const values = buckets.get(day)?.highs ?? [];
+        return values.length > 0 ? Math.round(Math.max(...values)) : NaN;
+      }),
+      temperature_2m_min: sortedDays.map((day) => {
+        const values = buckets.get(day)?.lows ?? [];
+        return values.length > 0 ? Math.round(Math.min(...values)) : NaN;
+      }),
+      precipitation_probability_max: sortedDays.map((day) => {
+        const bucket = buckets.get(day);
+        if (!bucket || bucket.totalSteps === 0) {
+          return 0;
+        }
+
+        return Math.round((bucket.precipSteps / bucket.totalSteps) * 100);
+      }),
+      precipitation_sum: sortedDays.map((day) => {
+        const bucket = buckets.get(day);
+        return bucket ? Number(bucket.precipIn.toFixed(2)) : 0;
+      }),
+      wind_speed_10m_max: sortedDays.map((day) => {
+        const values = buckets.get(day)?.wind ?? [];
+        return values.length > 0 ? Math.round(Math.max(...values)) : NaN;
+      }),
+      relative_humidity_2m_mean: sortedDays.map((day) => {
+        const values = buckets.get(day)?.humidity ?? [];
+        if (values.length === 0) {
+          return NaN;
+        }
+
+        const avg = values.reduce((sum, value) => sum + value, 0) / values.length;
+        return Math.round(avg);
+      }),
+    };
+  }
+}

--- a/src/services/nomads.ts
+++ b/src/services/nomads.ts
@@ -5,6 +5,7 @@ import { Cache } from '../utils/cache.js';
 import { CacheConfig } from '../config/cache.js';
 import { validateLatitude, validateLongitude } from '../utils/validation.js';
 import { guessTimezoneFromCoords } from '../utils/timezone.js';
+import { findNearestGridIndex, GridShape, GridLatLng } from '../utils/gribGrid.js';
 import {
   ApiError,
   DataNotFoundError,
@@ -26,14 +27,8 @@ interface GribMessage {
   varName?: string;
   units?: string;
   data: number[];
-  gridShape?: {
-    rows: number;
-    cols: number;
-  };
-  latlng?: {
-    latitude: number[];
-    longitude: number[];
-  };
+  gridShape?: GridShape;
+  latlng?: GridLatLng;
   referenceDate?: Date;
   forecastDate?: Date;
 }
@@ -325,37 +320,14 @@ export class NOMADSService {
   }
 
   private extractNearestValue(message: GribMessage, latitude: number, longitude: number): number | undefined {
-    const latitudes = message.latlng?.latitude;
-    const longitudes = message.latlng?.longitude;
-    const rows = message.gridShape?.rows;
-    const cols = message.gridShape?.cols;
+    const flatIndex = findNearestGridIndex(message.latlng, message.gridShape, latitude, longitude);
 
-    if (!latitudes || !longitudes || !rows || !cols || rows < 1 || cols < 1) {
+    if (flatIndex === undefined) {
       return undefined;
     }
 
-    const targetLon = longitude < 0 ? longitude + 360 : longitude;
-    const nearestLatIndex = this.findNearestIndex(latitudes, latitude);
-    const nearestLonIndex = this.findNearestIndex(longitudes, targetLon);
-    const flatIndex = nearestLatIndex * cols + nearestLonIndex;
-
     const value = message.data[flatIndex];
     return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
-  }
-
-  private findNearestIndex(values: number[], target: number): number {
-    let bestIndex = 0;
-    let bestDistance = Number.POSITIVE_INFINITY;
-
-    for (let i = 0; i < values.length; i++) {
-      const distance = Math.abs(values[i] - target);
-      if (distance < bestDistance) {
-        bestDistance = distance;
-        bestIndex = i;
-      }
-    }
-
-    return bestIndex;
   }
 
   private aggregateDaily(points: TimeStepData[], timezone: string, days: number): NomadsForecastResponse['daily'] {

--- a/src/types/modelComparison.ts
+++ b/src/types/modelComparison.ts
@@ -1,0 +1,30 @@
+export type ComparisonModel = 'gfs' | 'nam' | 'ecmwf_proxy';
+
+export interface ComparisonDayValues {
+  temperatureHighF?: number;
+  temperatureLowF?: number;
+  precipitationChancePct?: number;
+  precipitationTotalIn?: number;
+  windMaxMph?: number;
+  humidityMeanPct?: number;
+}
+
+export interface ComparisonModelSeries {
+  model: ComparisonModel;
+  label: string;
+  modelRun: string;
+  horizonHours: number;
+  timezone: string;
+  daily: Record<string, ComparisonDayValues>;
+  note?: string;
+}
+
+export interface ModelComparisonResult {
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  requestedDays: number;
+  days: string[];
+  series: ComparisonModelSeries[];
+  notes: string[];
+}

--- a/src/types/nomads.ts
+++ b/src/types/nomads.ts
@@ -1,0 +1,19 @@
+export interface NomadsDailyForecast {
+  time: string[];
+  temperature_2m_max: number[];
+  temperature_2m_min: number[];
+  precipitation_probability_max: number[];
+  precipitation_sum: number[];
+  wind_speed_10m_max: number[];
+  relative_humidity_2m_mean: number[];
+}
+
+export interface NomadsForecastResponse {
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  model: string;
+  model_run: string;
+  forecast_step_hours: number;
+  daily: NomadsDailyForecast;
+}

--- a/src/utils/gribGrid.ts
+++ b/src/utils/gribGrid.ts
@@ -1,0 +1,122 @@
+/**
+ * Utilities for locating the nearest grid point in a GRIB2 message's spatial grid.
+ *
+ * NOMADS models use two fundamentally different grid layouts:
+ *
+ * - Separable / rectilinear grids (e.g. GFS's global 1-degree lat/lon grid): latitude
+ *   and longitude are independent axes. The `latitude` array has one entry per row and
+ *   the `longitude` array has one entry per column, so a point's flat index is
+ *   `row * cols + col`.
+ * - Curvilinear / projected grids (e.g. NAM's Lambert Conformal Conic grid): every grid
+ *   point has its own unique (lat, lon) pair. Both `latitude` and `longitude` are flat
+ *   arrays of length `rows * cols`, one entry per point. Row/column indices found by
+ *   searching latitude and longitude independently cannot be recombined with
+ *   `row * cols + col` — the two axes are not separable, and doing so produces a
+ *   meaningless (often out-of-bounds) index.
+ *
+ * `findNearestGridIndex` detects which layout a message uses from the array lengths and
+ * searches accordingly.
+ */
+
+import { calculateDistance } from './distance.js';
+
+export interface GridShape {
+  rows: number;
+  cols: number;
+}
+
+export interface GridLatLng {
+  latitude: number[];
+  longitude: number[];
+}
+
+/**
+ * Find the flat data-array index of the grid point nearest to the target coordinates.
+ * Returns undefined if the grid data is missing or malformed.
+ */
+export function findNearestGridIndex(
+  latlng: GridLatLng | undefined,
+  gridShape: GridShape | undefined,
+  targetLatitude: number,
+  targetLongitude: number
+): number | undefined {
+  const latitudes = latlng?.latitude;
+  const longitudes = latlng?.longitude;
+  const rows = gridShape?.rows;
+  const cols = gridShape?.cols;
+
+  if (!latitudes?.length || !longitudes?.length || !rows || !cols || rows < 1 || cols < 1) {
+    return undefined;
+  }
+
+  const normalizedLon = normalizeLongitude(targetLongitude, longitudes);
+  const isSeparableGrid = latitudes.length === rows && longitudes.length === cols;
+
+  if (isSeparableGrid) {
+    const latIndex = findNearest1DIndex(latitudes, targetLatitude);
+    const lonIndex = findNearest1DIndex(longitudes, normalizedLon);
+    return latIndex * cols + lonIndex;
+  }
+
+  if (latitudes.length !== longitudes.length || latitudes.length !== rows * cols) {
+    // Neither a clean separable grid nor a fully-populated per-point grid; bail out
+    // rather than guess at an index.
+    return undefined;
+  }
+
+  return findNearestPointIndex(latitudes, longitudes, targetLatitude, normalizedLon);
+}
+
+/**
+ * NOMADS grids mix longitude conventions: GFS's global grid runs 0-360, while NAM's
+ * regional subregion is returned in -180/180. Detect the message's convention from its
+ * own values and normalize the target to match, rather than assuming one or the other.
+ */
+function normalizeLongitude(longitude: number, referenceLongitudes: number[]): number {
+  const usesZeroTo360 = referenceLongitudes.some((lon) => lon > 180);
+
+  if (usesZeroTo360 && longitude < 0) {
+    return longitude + 360;
+  }
+
+  if (!usesZeroTo360 && longitude > 180) {
+    return longitude - 360;
+  }
+
+  return longitude;
+}
+
+function findNearest1DIndex(values: number[], target: number): number {
+  let bestIndex = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < values.length; i++) {
+    const distance = Math.abs(values[i] - target);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = i;
+    }
+  }
+
+  return bestIndex;
+}
+
+function findNearestPointIndex(
+  latitudes: number[],
+  longitudes: number[],
+  targetLatitude: number,
+  targetLongitude: number
+): number {
+  let bestIndex = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < latitudes.length; i++) {
+    const distance = calculateDistance(latitudes[i], longitudes[i], targetLatitude, targetLongitude);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestIndex = i;
+    }
+  }
+
+  return bestIndex;
+}

--- a/src/utils/requestLogger.ts
+++ b/src/utils/requestLogger.ts
@@ -1,0 +1,51 @@
+/**
+ * High-level MCP request lifecycle logger.
+ * Writes one plain-text line per event to ~/.weather-mcp/requests.log.
+ */
+
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { logger } from './logger.js';
+
+export type RequestLogStatus = 'start' | 'success' | 'error';
+
+interface RequestLogEvent {
+  timestamp: string;
+  requestId: string;
+  tool: string;
+  status: RequestLogStatus;
+  durationMs?: number;
+}
+
+const REQUEST_LOG_DIR = join(homedir(), '.weather-mcp');
+const REQUEST_LOG_PATH = join(REQUEST_LOG_DIR, 'requests.log');
+
+function ensureRequestLogDirectoryExists(): void {
+  if (existsSync(REQUEST_LOG_DIR)) {
+    return;
+  }
+
+  mkdirSync(REQUEST_LOG_DIR, { recursive: true });
+}
+
+function formatRequestLogLine(event: RequestLogEvent): string {
+  const duration = event.durationMs !== undefined ? String(event.durationMs) : 'NA';
+  return `${event.timestamp} request_id=${event.requestId} tool=${event.tool} status=${event.status} duration_ms=${duration}\n`;
+}
+
+/**
+ * Append a request lifecycle event to the plain text request log.
+ * Failures are non-fatal and only reported to stderr logger.
+ */
+export function logRequestLifecycle(event: RequestLogEvent): void {
+  try {
+    ensureRequestLogDirectoryExists();
+    appendFileSync(REQUEST_LOG_PATH, formatRequestLogLine(event), 'utf-8');
+  } catch (error) {
+    logger.warn('Failed to write request lifecycle log', {
+      path: REQUEST_LOG_PATH,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+}

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -123,11 +123,15 @@ export function guessTimezoneFromCoords(latitude: number, longitude: number): st
   // For production use, consider integrating a proper coordinate-to-timezone library
   // like tz-lookup or @photostructure/tz-lookup for accurate global coverage
 
-  // Map to common US timezones for North America based on longitude
+  // Map to common US timezones for North America based on longitude.
+  // The Central time zone is geographically wide (it reaches from the Great Lakes
+  // out to roughly the Kansas/Colorado border), so its longitude band is much wider
+  // than Eastern's. Boundaries below are tuned against known city coordinates
+  // (see timezone.test.ts) rather than an even four-way split of the continent.
   if (latitude >= 24 && latitude <= 50 && longitude >= -125 && longitude <= -66) {
-    if (longitude >= -75) return 'America/New_York';
-    if (longitude >= -87) return 'America/Chicago';
-    if (longitude >= -104) return 'America/Denver';
+    if (longitude >= -85) return 'America/New_York';
+    if (longitude >= -101) return 'America/Chicago';
+    if (longitude >= -115) return 'America/Denver';
     if (longitude >= -125) return 'America/Los_Angeles';
   }
 

--- a/tests/unit/gribGrid.test.ts
+++ b/tests/unit/gribGrid.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for GRIB grid nearest-point lookup
+ */
+
+import { describe, it, expect } from 'vitest';
+import { findNearestGridIndex } from '../../src/utils/gribGrid.js';
+
+describe('findNearestGridIndex', () => {
+  describe('separable / rectilinear grids (e.g. GFS)', () => {
+    // latitude has one entry per row, longitude has one entry per column —
+    // the two axes are independent, so row * cols + col is a valid flat index.
+    const gridShape = { rows: 4, cols: 3 };
+    const latlng = {
+      latitude: [38, 39, 40, 41],
+      longitude: [264, 265, 267], // 0-360 convention, like GFS's global grid
+    };
+    // Row-major: data[row * 3 + col]
+    const data = [0, 1, 2, 10, 11, 12, 20, 21, 22, 30, 31, 32];
+
+    it('finds the correct flat index for a target inside the grid', () => {
+      // Nearest latitude: 39 (row 1). Nearest longitude: -94.5 -> normalized to
+      // 265.5 -> nearest is 265 (col 1). Expected flat index: 1*3 + 1 = 4.
+      const index = findNearestGridIndex(latlng, gridShape, 39.2, -94.5);
+
+      expect(index).toBe(4);
+      expect(data[index as number]).toBe(11);
+    });
+
+    it('normalizes a negative target longitude to the grid\'s 0-360 convention', () => {
+      // Target longitude -96 -> normalized to 264 -> nearest is col 0.
+      const index = findNearestGridIndex(latlng, gridShape, 38.1, -96);
+
+      expect(index).toBe(0);
+      expect(data[index as number]).toBe(0);
+    });
+  });
+
+  describe('curvilinear / projected grids (e.g. NAM Lambert Conformal Conic)', () => {
+    // Every grid point has its own unique (lat, lon) pair; both arrays are flat
+    // and length rows * cols. Row/column indices found independently cannot be
+    // recombined with row * cols + col.
+    const gridShape = { rows: 3, cols: 2 };
+    const latlng = {
+      latitude: [40.0, 40.5, 41.0, 39.0, 39.5, 40.0],
+      longitude: [-95.0, -94.0, -93.0, -95.2, -94.2, -93.2],
+    };
+    const data = [0, 1, 2, 3, 14, 5];
+
+    it('finds the true nearest point instead of recombining per-axis indices', () => {
+      // True nearest point to (39.7, -94.3) is index 4 (39.5, -94.2).
+      //
+      // The old buggy implementation searched the flat latitude array and flat
+      // longitude array independently (each returning index 4 here, since both
+      // happen to be closest along their own axis too) and then computed
+      // 4 * cols(2) + 4 = 12 — an index past the end of a 6-entry data array,
+      // so it always read back `undefined`.
+      const index = findNearestGridIndex(latlng, gridShape, 39.7, -94.3);
+
+      expect(index).toBe(4);
+      expect(data[index as number]).toBe(14);
+
+      // Confirm the old formula really was out of bounds for this fixture.
+      const buggyFlatIndex = 4 * gridShape.cols + 4;
+      expect(buggyFlatIndex).toBeGreaterThanOrEqual(data.length);
+    });
+
+    it('handles a target longitude already in -180/180 convention without misnormalizing it', () => {
+      const index = findNearestGridIndex(latlng, gridShape, 41.0, -93.0);
+
+      expect(index).toBe(2);
+      expect(data[index as number]).toBe(2);
+    });
+  });
+
+  describe('malformed or missing grid data', () => {
+    it('returns undefined when latlng is missing', () => {
+      expect(findNearestGridIndex(undefined, { rows: 2, cols: 2 }, 40, -95)).toBeUndefined();
+    });
+
+    it('returns undefined when gridShape is missing', () => {
+      const latlng = { latitude: [40, 41], longitude: [-95, -94] };
+      expect(findNearestGridIndex(latlng, undefined, 40, -95)).toBeUndefined();
+    });
+
+    it('returns undefined when latitude/longitude arrays are empty', () => {
+      const latlng = { latitude: [], longitude: [] };
+      expect(findNearestGridIndex(latlng, { rows: 2, cols: 2 }, 40, -95)).toBeUndefined();
+    });
+
+    it('returns undefined when array lengths do not match rows*cols or a separable layout', () => {
+      // Neither rows-length/cols-length (separable) nor rows*cols/rows*cols (curvilinear).
+      const latlng = { latitude: [40, 41, 42], longitude: [-95, -94] };
+      expect(findNearestGridIndex(latlng, { rows: 2, cols: 2 }, 40, -95)).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/timezone.test.ts
+++ b/tests/unit/timezone.test.ts
@@ -187,21 +187,38 @@ describe('Timezone Utilities', () => {
       expect(result).toBe('America/New_York');
     });
 
-    it('should guess timezone from Central US coords', () => {
-      // Note: guessTimezoneFromCoords uses simple longitude boundaries
-      // Chicago at -87.6298 falls into Denver zone due to >= -104 check
+    it('should guess Chicago timezone from Central US coords', () => {
       const result = guessTimezoneFromCoords(41.8781, -87.6298); // Chicago coords
 
-      // Should return a valid US timezone
-      expect(result).toMatch(/America\/(New_York|Chicago|Denver|Los_Angeles)/);
+      expect(result).toBe('America/Chicago');
     });
 
-    it('should guess timezone from Mountain coords', () => {
-      // Denver at -104.9903 falls into Los Angeles zone due to >= -125 check
+    it('should guess Denver timezone from Mountain coords', () => {
       const result = guessTimezoneFromCoords(39.7392, -104.9903); // Denver coords
 
-      // Should return a valid US timezone
-      expect(result).toMatch(/America\/(Denver|Los_Angeles)/);
+      expect(result).toBe('America/Denver');
+    });
+
+    it('should guess Chicago timezone for wide Central-time landmass', () => {
+      // The Central time zone spans much further west than a naive even split of
+      // the continent would suggest — these are all genuinely Central time despite
+      // longitudes well past -100.
+      expect(guessTimezoneFromCoords(39.0997, -94.5786)).toBe('America/Chicago'); // Kansas City, MO
+      expect(guessTimezoneFromCoords(41.2565, -95.9345)).toBe('America/Chicago'); // Omaha, NE
+      expect(guessTimezoneFromCoords(35.4676, -97.5164)).toBe('America/Chicago'); // Oklahoma City, OK
+      expect(guessTimezoneFromCoords(32.7767, -96.7970)).toBe('America/Chicago'); // Dallas, TX
+    });
+
+    it('should guess Denver timezone for other Mountain-time cities', () => {
+      expect(guessTimezoneFromCoords(40.7608, -111.8910)).toBe('America/Denver'); // Salt Lake City, UT
+    });
+
+    it('should guess Los Angeles timezone for other Pacific-time cities', () => {
+      expect(guessTimezoneFromCoords(47.6062, -122.3321)).toBe('America/Los_Angeles'); // Seattle, WA
+    });
+
+    it('should guess New York timezone for other Eastern-time cities', () => {
+      expect(guessTimezoneFromCoords(33.7490, -84.3880)).toBe('America/New_York'); // Atlanta, GA
     });
 
     it('should guess Los Angeles timezone from West Coast coords', () => {
@@ -220,13 +237,14 @@ describe('Timezone Utilities', () => {
 
     it('should handle coordinates at timezone boundaries', () => {
       // The function uses simple longitude ranges:
-      // >= -75: New York, >= -87: Chicago, >= -104: Denver, >= -125: LA
-      const eastern = guessTimezoneFromCoords(40.0, -74.0); // East of -75
-      const central = guessTimezoneFromCoords(40.0, -86.0); // Between -75 and -87
+      // >= -85: New York, >= -101: Chicago, >= -115: Denver, >= -125: LA
+      const eastern = guessTimezoneFromCoords(40.0, -74.0); // East of -85
+      const central = guessTimezoneFromCoords(40.0, -95.0); // Between -85 and -101
+      const mountain = guessTimezoneFromCoords(40.0, -110.0); // Between -101 and -115
 
       expect(eastern).toBe('America/New_York');
-      // -86 is >= -87, so returns Chicago
       expect(central).toBe('America/Chicago');
+      expect(mountain).toBe('America/Denver');
     });
 
     it('should return UTC as ultimate fallback', () => {


### PR DESCRIPTION
## Summary

Two confirmed bugs, root-caused via direct GRIB probing against live NOMADS endpoints:

**NAM forecasts always returned null/0.** `extractNearestValue` assumed every NOMADS grid is separable (GFS's regular 1-degree lat/lon grid, where latitude/longitude are independent row/column axes) and combined per-axis nearest indices with `row * cols + col`. NAM uses a Lambert Conformal Conic projection — curvilinear, every point has its own unique (lat, lon) pair stored as parallel flat arrays of length `rows * cols` — so that formula produced out-of-bounds indices and every lookup silently returned `undefined`.

**Central US coordinates were mislabeled Mountain/Pacific time.** `guessTimezoneFromCoords`'s Central/Mountain longitude cutoff (-87°) was ~15 degrees too far east, mislabeling most of Missouri, Kansas, Nebraska, Oklahoma, Texas — and even Denver itself — as the wrong zone.

## Changes

- New `src/utils/gribGrid.ts`: pure, independently-tested utility that detects separable vs. curvilinear grids from array lengths and searches each correctly (true nearest-point search via `calculateDistance` for curvilinear grids). Also normalizes the 0-360 vs. -180/180 longitude convention per-message rather than assuming one globally.
- `nomads.ts` now delegates to the new utility; removed the old broken `extractNearestValue`/`findNearestIndex`.
- `timezone.ts`: retuned longitude boundaries against known city coordinates (Kansas City, Denver, Omaha, OKC, Dallas, Salt Lake City, Seattle, Atlanta, NYC).
- `timezone.test.ts`: several existing tests asserted the *buggy* behavior with loose regex matches and comments acknowledging the mis-bucketing — replaced with exact-match assertions and expanded city coverage.
- New `gribGrid.test.ts`: fixtures for both grid layouts, including a curvilinear case that demonstrates the old formula would have computed an out-of-bounds index.

## Verification

- Verified against live NOMADS data for 39.015, -94.1985 (Grain Valley, MO): NAM now returns real temperature/humidity/wind values and the reported timezone is `America/Chicago`.
- 1037/1042 unit tests pass. The remaining 5 are pre-existing `tool-config.test.ts` failures (stale hardcoded tool-preset counts) unrelated to this change — confirmed present on `main` before this commit via `git stash`.
- Clean `npm run build`, zero TypeScript errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)